### PR TITLE
Fix ROS integration documentation

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -1,4 +1,5 @@
 absl-py
+mock
 sphinx
 sphinx-click
 sphinx_rtd_theme

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -43,6 +43,13 @@ extensions = [
     'sphinx.ext.napoleon',
 ]
 
+# Enable autodoc without requiring installation of listed modules
+import mock
+
+mock_modules = ["ray", "rospy", "actionlib"]
+for mod_name in mock_modules:
+    sys.modules[mod_name] = mock.Mock()
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
- Fixes issue where autodoc for ROS integration required installation of `rospy`, `actionlib`, and `ray`
- Replaces `rospy`, `actionlib`, and `ray` with mock modules when generating documentation