### PR TITLE
Implementation of in-stream watermark messages for ROS/Ray

### DIFF
--- a/erdos/data_stream.py
+++ b/erdos/data_stream.py
@@ -13,6 +13,7 @@ class DataStream(object):
                  name="",
                  labels=None,
                  callbacks=None,
+                 completion_callbacks=None,
                  uid=None):
         self.name = name if name else "{0}_{1}".format(self.__class__.__name__,
                                                        hash(self))
@@ -31,6 +32,11 @@ class DataStream(object):
         else:
             self.callbacks = callbacks
 
+        if completion_callbacks is None:
+            self.completion_callbacks = set([])
+        else:
+            self.completion_callbacks = completion_callbacks
+
     def add_callback(self, on_msg_cb):
         """Registers a stream callback.
 
@@ -39,6 +45,15 @@ class DataStream(object):
                 receipt of a message.
         """
         self.callbacks.add(on_msg_cb)
+
+    def add_completion_callback(self, on_watermark_cb):
+        """ Registers a watermark callback.
+
+        Args:
+            on_watermark_cb (Message -> None): Callback to be invoked upon
+                the completion of a timestamp.
+        """
+        self.completion_callbacks.add(on_watermark_cb)
 
     def send(self, msg):
         """Send a message on the stream.

--- a/erdos/data_streams.py
+++ b/erdos/data_streams.py
@@ -66,3 +66,14 @@ class DataStreams(object):
         for stream in self._streams:
             stream.add_callback(callback_func)
         return self
+
+    def add_completion_callback(self, callback_func):
+        """ Registers the callback function to be called upon
+            completion of a timestamp.
+
+        Returns:
+            (DataStreams): selected data streams.
+        """
+        for stream in self._streams:
+            stream.add_completion_callback(callback_func)
+        return self

--- a/erdos/graph.py
+++ b/erdos/graph.py
@@ -333,10 +333,10 @@ class Graph(object):
     def _init_ray(self):
         import ray
         if FLAGS.ray_redis_address == '':
-            ray.init(redirect_output=True)
+            ray.init()
         else:
             ray.init(
-                redis_address=FLAGS.ray_redis_address, redirect_output=True)
+                redis_address=FLAGS.ray_redis_address)
             time.sleep(2)
 
     def _create_executors(self):

--- a/erdos/message.py
+++ b/erdos/message.py
@@ -6,12 +6,25 @@ class Message(object):
            timestamp (Timestamp): The timestamp of the message.
     """
 
-    def __init__(self, data, timestamp, stream_name='default', watermark = False):
+    def __init__(self, data, timestamp, stream_name='default'):
         self.data = data
         self.timestamp = timestamp
         self.stream_name = stream_name
-        self.watermark = watermark
 
     def __str__(self):
-        return '{{stream: {}, timestamp: {}, watermark: {}, data: {}}}'.format(
-            self.stream_name, self.timestamp, self.watermark, self.data)
+        return '{{stream: {}, timestamp: {}, data: {}}}'.format(
+            self.stream_name, self.timestamp, self.data)
+
+class WatermarkMessage(Message):
+    """Class used to wrap ERDOS watermark message.
+
+       Attributes:
+           timestamp (Timestamp): The timestamp for which this is a watermark.
+    """
+
+    def __init__(self, timestamp, stream_name='default'):
+        super(WatermarkMessage, self).__init__(None, timestamp, stream_name)
+
+    def __str__(self):
+        return '{{stream: {}, timestamp: {}, watermark: True}}'.format(
+            self.stream_name, self.timestamp)

--- a/erdos/message.py
+++ b/erdos/message.py
@@ -6,11 +6,12 @@ class Message(object):
            timestamp (Timestamp): The timestamp of the message.
     """
 
-    def __init__(self, data, timestamp, stream_name='default'):
+    def __init__(self, data, timestamp, stream_name='default', watermark = False):
         self.data = data
         self.timestamp = timestamp
         self.stream_name = stream_name
+        self.watermark = watermark
 
     def __str__(self):
-        return '{{stream: {}, timestamp: {}, data: {}}}'.format(
-            self.stream_name, self.timestamp, self.data)
+        return '{{stream: {}, timestamp: {}, watermark: {}, data: {}}}'.format(
+            self.stream_name, self.timestamp, self.watermark, self.data)

--- a/erdos/ray/ray_executor.py
+++ b/erdos/ray/ray_executor.py
@@ -26,11 +26,15 @@ class RayExecutor(Executor):
         # decorators will turn into "wrapper", so we extract the __name__ here
         for stream in self.op_handle.input_streams:
             stream.callbacks = set([f.__name__ for f in stream.callbacks])
+            stream.completion_callbacks = set(
+                             [f.__name__ for f in stream.completion_callbacks])
         for stream in self.op_handle.output_streams:
             stream.callbacks = set([f.__name__ for f in stream.callbacks])
+            stream.completion_callbacks = set(
+                             [f.__name__ for f in stream.completion_callbacks])
 
         # Create the Ray actor wrapping the ERDOS operator.
-        ray_op = RayOperator._submit([self.op_handle], {}, num_cpus, num_gpus,
+        ray_op = RayOperator._remote([self.op_handle], {}, num_cpus, num_gpus,
                                      resources)
         # Set the actor handle in the ray operator actor.
         ray.get(ray_op.set_handle.remote(ray_op))

--- a/erdos/ray/ray_input_data_stream.py
+++ b/erdos/ray/ray_input_data_stream.py
@@ -8,6 +8,7 @@ class RayInputDataStream(DataStream):
             name=data_stream.name,
             labels=data_stream.labels,
             callbacks=data_stream.callbacks,
+            completion_callbacks=data_stream.completion_callbacks,
             uid=data_stream.uid)
         self._actor_handle = actor_handle
 
@@ -15,3 +16,7 @@ class RayInputDataStream(DataStream):
         for on_msg_callback in self.callbacks:
             self._actor_handle.register_callback.remote(
                 self.uid, on_msg_callback)
+ 
+        for on_watermark_callback in self.completion_callbacks:
+            self._actor_handle.register_completion_callback.remote(
+                self.uid, on_watermark_callback)

--- a/erdos/ray/ray_output_data_stream.py
+++ b/erdos/ray/ray_output_data_stream.py
@@ -14,17 +14,24 @@ class RayOutputDataStream(DataStream):
         self._op = op
         self._dependant_op_handles = dependant_op_handles
         self._dependant_op_on_msg = None
+        self._dependant_op_on_completion = None
 
     def send(self, msg):
         """Send a message on the stream.
         Invokes sink actors' on_msg remote methods.
         """
-        self._op.log_event(time.time(), msg.timestamp,
-                           'send {}'.format(self.name))
         msg.stream_name = self.name
         msg.stream_uid = self.uid
-        for on_msg_func in self._dependant_op_on_msg:
-            on_msg_func.remote(msg)
+        if msg.watermark:
+            self._op.log_event(time.time(), msg.timestamp,
+                           'watermark send {}'.format(self.name))
+            for on_completion_func in self._dependant_op_on_completion:
+                on_completion_func.remote(msg)
+        else:
+            self._op.log_event(time.time(), msg.timestamp,
+                               'send {}'.format(self.name))
+            for on_msg_func in self._dependant_op_on_msg:
+                on_msg_func.remote(msg)
 
     def setup(self):
         """Setup dependant operator on_msg methods.
@@ -33,5 +40,9 @@ class RayOutputDataStream(DataStream):
         """
         self._dependant_op_on_msg = [
             getattr(actor_handle, "on_msg")
+            for actor_handle in self._dependant_op_handles
+        ]
+        self._dependant_op_on_completion = [
+            getattr(actor_handle, "on_completion_msg")
             for actor_handle in self._dependant_op_handles
         ]

--- a/erdos/ray/ray_output_data_stream.py
+++ b/erdos/ray/ray_output_data_stream.py
@@ -1,6 +1,7 @@
 import time
 
 from erdos.data_stream import DataStream
+from erdos.message import WatermarkMessage
 
 
 class RayOutputDataStream(DataStream):
@@ -22,7 +23,7 @@ class RayOutputDataStream(DataStream):
         """
         msg.stream_name = self.name
         msg.stream_uid = self.uid
-        if msg.watermark:
+        if isinstance(msg, WatermarkMessage):
             self._op.log_event(time.time(), msg.timestamp,
                            'watermark send {}'.format(self.name))
             for on_completion_func in self._dependant_op_on_completion:

--- a/tests/watermarks_test.py
+++ b/tests/watermarks_test.py
@@ -1,0 +1,131 @@
+from collections import defaultdict
+from time import sleep
+
+from absl import app
+from absl import flags
+
+import erdos.graph
+from erdos.op import Op
+from erdos.utils import frequency
+from erdos.message import Message
+from erdos.data_stream import DataStream
+from erdos.timestamp import Timestamp
+
+INTEGER_FREQUENCY = 10 # The frequency at which to send the integers.
+
+class FirstOperator(Op):
+    """ Source operator that publishes increasing integers at a fixed frequency.
+    The operator also inserts a watermark after a fixed number of messages.
+    """
+
+    def __init__(self, name, batch_size):
+        """ Initializes the attributes to be used by the source operator."""
+        super(FirstOperator, self).__init__(name)
+        self.batch_size = batch_size
+        self.counter = 1
+        self.batch_number = 1
+
+    @staticmethod
+    def setup_streams(input_streams):
+        """ Outputs a single stream where the messages are sent. """
+        return [DataStream(data_type = int, name = "integer_out")]
+
+    @frequency(INTEGER_FREQUENCY)
+    def publish_numbers(self):
+        """ Sends an increasing count of numbers 
+            to the downstream operators. """
+        output_msg = Message(self.counter, 
+                             Timestamp(coordinates = [self.batch_number]))
+        self.get_output_stream("integer_out").send(output_msg)
+       
+        # Decide if the watermark needs to be sent.
+        if self.counter % self.batch_size == 0:
+            # The batch has completed. We need to send a watermark now.
+            watermark_msg = Message(self.batch_number, 
+                               Timestamp(coordinates = [self.batch_number]),
+                               watermark = True) 
+            self.batch_number += 1
+            self.get_output_stream("integer_out").send(watermark_msg)
+
+        # Update the counters.
+        self.counter += 1
+
+    def execute(self):
+        """ Execute the publish number loop. """
+        self.publish_numbers()
+        self.spin() 
+
+class SecondOperator(Op):
+    """ Second operator that listens in on the numbers and reports their
+    sum when the watermark is received. """
+    
+    def __init__(self, name):
+        """ Initializes the attributes to be used."""
+        super(SecondOperator, self).__init__(name)
+        self.windows = defaultdict(list)
+
+    @staticmethod
+    def setup_streams(input_streams):
+        """ Subscribes all the input streams to the save numbers callback. """
+        input_streams.add_callback(SecondOperator.save_numbers)
+        input_streams.add_completion_callback(SecondOperator.execute_sum)
+        return [DataStream(data_type = int, name = "sum_out")]
+
+    def save_numbers(self, message): 
+        """ Save all the numbers corresponding to a window. """
+        batch_number = message.timestamp.coordinates[0]
+        self.windows[batch_number].append(message.data)
+
+    def execute_sum(self, message):
+        """ Sum all the numbers in this window and send out the aggregate. """
+        batch_number = message.timestamp.coordinates[0]
+        window_data = self.windows.pop(batch_number, None) 
+        #print("Received a watermark for the timestamp: {}".format(batch_number))
+        #print("The sum of the window {} is {}".format(
+        #              window_data, sum(window_data))) 
+        output_msg = Message(sum(window_data),
+                      Timestamp(coordinates = [batch_number]))
+        self.get_output_stream("sum_out").send(output_msg)
+
+    def execute(self):
+        """ Execute the spin() loop to continue processing messages. """ 
+        self.spin()
+
+class ThirdOperator(Op):
+    """ Third operator that listens in on the sum and verifies correctness."""
+    
+    def __init__(self, name):
+        """Initializes the attributes to be used."""
+        super(ThirdOperator, self).__init__(name)
+
+    @staticmethod
+    def setup_streams(input_streams):
+        """ Subscribes all the input streams to the assert callback."""
+        input_streams.add_callback(ThirdOperator.assert_correctness)
+        return []
+ 
+    def assert_correctness(self, message):
+        """ Assert the correctness of the results."""
+        batch_number = message.timestamp.coordinates[0]
+        sum_data = sum(range((batch_number - 1) * 10 + 1, batch_number * 10 + 1)) 
+        print("Received sum: {} for the batch_number {}, expected {}".format(
+                      message.data, batch_number, sum_data))
+
+def main(argv):
+    # Set up the graph.
+    graph = erdos.graph.get_current_graph()
+
+    # Add the operators.
+    source_op = graph.add(FirstOperator, name = "gen_op", init_args = {'batch_size' : 10})
+    sum_op    = graph.add(SecondOperator, name = "sum_op")
+    assert_op = graph.add(ThirdOperator, name = "assert_op")
+
+    # Connect the operators.
+    graph.connect([source_op], [sum_op])
+    graph.connect([sum_op], [assert_op])
+
+    # Execute the graph.
+    graph.execute('ray')
+
+if __name__ == "__main__":
+    app.run(main)

--- a/tests/watermarks_test.py
+++ b/tests/watermarks_test.py
@@ -10,6 +10,7 @@ from erdos.utils import frequency
 from erdos.message import Message
 from erdos.data_stream import DataStream
 from erdos.timestamp import Timestamp
+from erdos.message import WatermarkMessage
 
 INTEGER_FREQUENCY = 10 # The frequency at which to send the integers.
 
@@ -32,18 +33,17 @@ class FirstOperator(Op):
 
     @frequency(INTEGER_FREQUENCY)
     def publish_numbers(self):
-        """ Sends an increasing count of numbers 
+        """ Sends an increasing count of numbers
             to the downstream operators. """
-        output_msg = Message(self.counter, 
+        output_msg = Message(self.counter,
                              Timestamp(coordinates = [self.batch_number]))
         self.get_output_stream("integer_out").send(output_msg)
-       
+
         # Decide if the watermark needs to be sent.
         if self.counter % self.batch_size == 0:
             # The batch has completed. We need to send a watermark now.
-            watermark_msg = Message(self.batch_number, 
-                               Timestamp(coordinates = [self.batch_number]),
-                               watermark = True) 
+            watermark_msg = WatermarkMessage(Timestamp(coordinates =
+                                                       [self.batch_number]))
             self.batch_number += 1
             self.get_output_stream("integer_out").send(watermark_msg)
 
@@ -53,12 +53,12 @@ class FirstOperator(Op):
     def execute(self):
         """ Execute the publish number loop. """
         self.publish_numbers()
-        self.spin() 
+        self.spin()
 
 class SecondOperator(Op):
     """ Second operator that listens in on the numbers and reports their
     sum when the watermark is received. """
-    
+
     def __init__(self, name):
         """ Initializes the attributes to be used."""
         super(SecondOperator, self).__init__(name)
@@ -71,7 +71,7 @@ class SecondOperator(Op):
         input_streams.add_completion_callback(SecondOperator.execute_sum)
         return [DataStream(data_type = int, name = "sum_out")]
 
-    def save_numbers(self, message): 
+    def save_numbers(self, message):
         """ Save all the numbers corresponding to a window. """
         batch_number = message.timestamp.coordinates[0]
         self.windows[batch_number].append(message.data)
@@ -79,21 +79,21 @@ class SecondOperator(Op):
     def execute_sum(self, message):
         """ Sum all the numbers in this window and send out the aggregate. """
         batch_number = message.timestamp.coordinates[0]
-        window_data = self.windows.pop(batch_number, None) 
+        window_data = self.windows.pop(batch_number, None)
         #print("Received a watermark for the timestamp: {}".format(batch_number))
         #print("The sum of the window {} is {}".format(
-        #              window_data, sum(window_data))) 
+        #              window_data, sum(window_data)))
         output_msg = Message(sum(window_data),
                       Timestamp(coordinates = [batch_number]))
         self.get_output_stream("sum_out").send(output_msg)
 
     def execute(self):
-        """ Execute the spin() loop to continue processing messages. """ 
+        """ Execute the spin() loop to continue processing messages. """
         self.spin()
 
 class ThirdOperator(Op):
     """ Third operator that listens in on the sum and verifies correctness."""
-    
+
     def __init__(self, name):
         """Initializes the attributes to be used."""
         super(ThirdOperator, self).__init__(name)
@@ -103,11 +103,11 @@ class ThirdOperator(Op):
         """ Subscribes all the input streams to the assert callback."""
         input_streams.add_callback(ThirdOperator.assert_correctness)
         return []
- 
+
     def assert_correctness(self, message):
         """ Assert the correctness of the results."""
         batch_number = message.timestamp.coordinates[0]
-        sum_data = sum(range((batch_number - 1) * 10 + 1, batch_number * 10 + 1)) 
+        sum_data = sum(range((batch_number - 1) * 10 + 1, batch_number * 10 + 1))
         print("Received sum: {} for the batch_number {}, expected {}".format(
                       message.data, batch_number, sum_data))
 


### PR DESCRIPTION
- Added a new message type for `WatermarkMessage` that inherits from the base `Message`.
- Added a new `add_completion_callback` API to register callbacks for watermark messages.
- Changed the Ray init methods to match with the latest release.
- Tested using `watermarks_test` for both ROS and Ray.