### PR TITLE
[FIX] Propogate watermarks through the graph.

### DIFF
--- a/erdos/ros/ros_input_data_stream.py
+++ b/erdos/ros/ros_input_data_stream.py
@@ -38,6 +38,10 @@ class ROSInputDataStream(DataStream):
         if isinstance(msg, WatermarkMessage):
             for on_watermark_callback in self.completion_callbacks:
                 on_watermark_callback(self.op, msg)
+
+            # Flow the watermark forward.
+            for output_stream in self.op.output_streams.values():
+                output_stream.send(msg)
         else:
             for on_msg_callback in self.callbacks:
                 on_msg_callback(self.op, msg)


### PR DESCRIPTION
Fix Notes:
- The earlier implementation of watermarks would assume that every operator in the graph would add callbacks for watermarks and flow them forward, which might not always be the case. This fix propagates watermarks to downstream operators even if the operator does not implement callbacks for watermarks.
- Caveat: Double watermarks will flow if the operator does implement a callback and decides to propagate watermarks. This might need to be fixed in a future version of the code.
- Needs to re-cast a `Message` into a `WatermarkMessage` since Ray (as of 0.6.4) does not propagate types of variables correctly. (ref. ray-project/ray#4463)
