### PR TITLE
[Ray] Schedule operators on specific machines by setting resources

### DIFF
--- a/erdos/graph.py
+++ b/erdos/graph.py
@@ -50,7 +50,8 @@ class Graph(object):
         self.input_op = self.add(NoopOp, name='input_op')
         self.output_op = self.add(NoopOp, name='output_op')
 
-    def add(self, op_cls, name="", init_args=None, setup_args=None):
+    def add(self, op_cls, name="", init_args=None, setup_args=None,
+            resources=None):
         """Adds an operator to the execution graph.
 
         Args:
@@ -61,16 +62,18 @@ class Graph(object):
                 method.
             setup_args (dict): Arguments passed to the operator's
                 `setup_streams` method.
+            resources (dict): A dictionary of resources for placing the
+                operator when using Ray.
 
         Returns:
             (str): Unique operator identifier.
         """
         if issubclass(op_cls, Graph):
             handle = GraphHandle(name, op_cls, init_args, setup_args,
-                                 self.graph_name, self)
+                                 self.graph_name, self, resources=resources)
         else:
             handle = OpHandle(name, op_cls, init_args, setup_args,
-                              self.graph_name)
+                              self.graph_name, resources=resources)
         op_id = handle.get_uid()
         assert (op_id not in self.op_handles), \
             'Duplicate operator name {}. Ensure name uniqueness ' \

--- a/erdos/graph_handle.py
+++ b/erdos/graph_handle.py
@@ -7,7 +7,6 @@ class GraphHandle(object):
                  graph_name,
                  parent,
                  framework='ray',
-                 machine="",
                  resources=None):
         # Ensure op name uniqueness
         self.name = name if name else "{0}_{1}".format(
@@ -20,7 +19,6 @@ class GraphHandle(object):
         self.graph_name = graph_name
         self.parent = parent
         self.framework = framework
-        self.machine = machine
         self.resources = {} if resources is None else resources
         self.dependant_ops = []  # handle ids of dependant ops
         self.dependent_op_handles = {}

--- a/erdos/op_handle.py
+++ b/erdos/op_handle.py
@@ -6,7 +6,6 @@ class OpHandle(object):
                  setup_args,
                  graph_name,
                  framework='ray',
-                 machine="",
                  resources=None):
         # Ensure op name uniqueness
         self.name = name if name else "{0}_{1}".format(
@@ -20,7 +19,6 @@ class OpHandle(object):
         self.input_streams = []
         self.output_streams = []
         self.framework = framework
-        self.machine = machine
         self.resources = {} if resources is None else resources
         self.dependant_ops = []  # handle ids of dependant ops
         self.dependent_op_handles = {}

--- a/erdos/ray/ray_executor.py
+++ b/erdos/ray/ray_executor.py
@@ -16,10 +16,9 @@ class RayExecutor(Executor):
     def setup(self):
         resources = dict(
             self.op_handle.resources) if self.op_handle.resources else {}
-        if self.op_handle.machine:
-            resources[self.op_handle.machine] = 1
         num_cpus = self.op_handle.resources.pop("CPU", None)
         num_gpus = self.op_handle.resources.pop("GPU", None)
+        print(self.op_handle.resources)
 
         # TODO (Yika): hacky solution for using decorator on callbacks
         # When we wrap op in ray operator, __name__ of callbacks that have

--- a/erdos/ray/ray_executor.py
+++ b/erdos/ray/ray_executor.py
@@ -18,7 +18,6 @@ class RayExecutor(Executor):
             self.op_handle.resources) if self.op_handle.resources else {}
         num_cpus = self.op_handle.resources.pop("CPU", None)
         num_gpus = self.op_handle.resources.pop("GPU", None)
-        print(self.op_handle.resources)
 
         # TODO (Yika): hacky solution for using decorator on callbacks
         # When we wrap op in ray operator, __name__ of callbacks that have

--- a/tests/ray_cluster_test.py
+++ b/tests/ray_cluster_test.py
@@ -1,0 +1,86 @@
+from __future__ import print_function
+
+from absl import app
+from absl import flags
+
+from ray.tests.cluster_utils import Cluster
+
+import ray.worker
+
+import erdos.graph
+from erdos.op import Op
+from erdos.utils import frequency
+
+FLAGS = flags.FLAGS
+
+# Maps plasma store socket name -> node id
+node_directory = {}
+
+
+class MachineAOp(Op):
+    def __init__(self, name):
+        super(MachineAOp, self).__init__(name)
+
+    @staticmethod
+    def setup_streams(input_streams):
+        return []
+
+    @frequency(1)
+    def print_node(self):
+        plasma_store_socket_name = (
+            ray.worker.global_worker.plasma_client.store_socket_name)
+        node_name = node_directory[plasma_store_socket_name]
+        print("MachineAOp is located on node {}".format(node_name))
+
+    def execute(self):
+        self.print_node()
+        self.spin()
+
+
+class MachineBOp(Op):
+    def __init__(self, name):
+        super(MachineBOp, self).__init__(name)
+
+    @staticmethod
+    def setup_streams(input_streams):
+        return []
+
+    @frequency(1)
+    def print_node(self):
+        plasma_store_socket_name = (
+            ray.worker.global_worker.plasma_client.store_socket_name)
+        node_name = node_directory[plasma_store_socket_name]
+        print("MachineBOp is located on node {}".format(node_name))
+
+    def execute(self):
+        self.print_node()
+        self.spin()
+
+
+def main(argv):
+    # Set up graph
+    graph = erdos.graph.get_current_graph()
+
+    # Add operators
+    machine_a_op = graph.add(MachineAOp, name='machine_a_op')
+    machine_b_op = graph.add(MachineBOp, name='machine_b_op')
+
+    # Execute graph
+    graph.execute("ray")
+
+
+if __name__ == "__main__":
+    cluster = Cluster(initialize_head=True)
+    a = cluster.add_node(resources={"machine_a": 100})
+    b = cluster.add_node(resources={"machine_b": 100})
+
+    node_directory[a.plasma_store_socket_name] = "machine_a"
+    node_directory[b.plasma_store_socket_name] = "machine_b"
+
+    print("node a plasma_store_socket_name:\n\t{}".format(
+        a.plasma_store_socket_name))
+    print("node b plasma_store_socket_name:\n\t{}".format(
+        b.plasma_store_socket_name))
+
+    FLAGS.ray_redis_address = cluster.redis_address
+    app.run(main)


### PR DESCRIPTION
To schedule an operator on a machine:
1. Initialize the machine with a custom resource, e.g. `ray.start --resources="{'machine_a': 100}"
2. Require that machine's custom resource when initializing the operator, e.g. `erdos.add(MyOp, resources={"machine_a": 1})

I also removed dead code when we had a `machine` argument for scheduling since custom resources are more general and less maintenance for now.