### PR TITLE
Fix setup.py to include python files in wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__
 /env
 *.pyc
 dist
+/build
 
 # Editor files
 .vscode

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,6 @@
 import os
 
-from setuptools import setup
+from setuptools import setup, find_packages
 from setuptools_rust import Binding, RustExtension
 
 package_dir = os.path.dirname(__file__)
@@ -18,6 +18,7 @@ setup(
                       features=["python"],
                       binding=Binding.PyO3)
     ],
+    packages=find_packages("python"),
     package_dir={"": package_dir},
     # rust extensions are not zip safe, just like C-extensions.
     zip_safe=False,


### PR DESCRIPTION
Without this fix, wheels do not contain .py files.