### PR TITLE
Fix race condition during setup

### DIFF
--- a/experiments/throughput.rs
+++ b/experiments/throughput.rs
@@ -4,14 +4,21 @@ use clap::{App, Arg};
 
 use std::process::{Child, Command, Stdio};
 
-fn run_node(index: u32, addresses: String, messages: usize, message_size: usize) -> Child {
+fn run_node(
+    index: u32,
+    data_addresses: String,
+    control_addresses: String,
+    messages: usize,
+    message_size: usize,
+) -> Child {
     Command::new("cargo")
         .arg("run")
         .arg("--release")
         .arg("--bin=experiment-throughput-driver")
         .arg("--")
         .arg(format!("--index={}", index))
-        .arg(format!("--addresses={}", addresses))
+        .arg(format!("--data-addresses={}", data_addresses))
+        .arg(format!("--control-addresses={}", control_addresses))
         .arg(format!("--messages={}", messages))
         .arg(format!("--message-size={}", message_size))
         .stdout(Stdio::inherit())
@@ -30,10 +37,17 @@ fn main() {
                 .possible_values(&["inter-thread", "inter-process"]),
         )
         .arg(
-            Arg::with_name("addresses")
+            Arg::with_name("data-addresses")
                 .short("a")
-                .long("addresses")
+                .long("data-addresses")
                 .default_value("127.0.0.1:9000,127.0.0.1:9001")
+                .help("Comma separated list of socket addresses of all nodes"),
+        )
+        .arg(
+            Arg::with_name("control-addresses")
+                .short("c")
+                .long("control-addresses")
+                .default_value("127.0.0.1:9002,127.0.0.1:9003")
                 .help("Comma separated list of socket addresses of all nodes"),
         )
         .arg(
@@ -59,13 +73,23 @@ fn main() {
         .expect("Unable to parse mode");
     let is_inter_thread = mode == "inter-thread";
 
-    let addresses: String = match is_inter_thread {
-        true => String::from("127.0.0.1:9000"),
-        false => matches
-            .value_of("addresses")
+    let data_addresses: String = if is_inter_thread {
+        String::from("127.0.0.1:9000")
+    } else {
+        matches
+            .value_of("data-addresses")
             .unwrap()
             .parse()
-            .expect("Unable to parse addresses"),
+            .expect("Unable to parse addresses")
+    };
+    let control_addresses: String = if is_inter_thread {
+        String::from("127.0.0.1:9001")
+    } else {
+        matches
+            .value_of("control-addresses")
+            .unwrap()
+            .parse()
+            .expect("Unable to parse addresses")
     };
 
     let num_messages: usize = matches
@@ -79,9 +103,21 @@ fn main() {
         .parse()
         .expect("Unable to parse message size");
 
-    let mut node0 = run_node(0, addresses.clone(), num_messages, message_size);
+    let mut node0 = run_node(
+        0,
+        data_addresses.clone(),
+        control_addresses.clone(),
+        num_messages,
+        message_size,
+    );
     if !is_inter_thread {
-        run_node(1, addresses, num_messages, message_size);
+        run_node(
+            1,
+            data_addresses,
+            control_addresses,
+            num_messages,
+            message_size,
+        );
     }
 
     node0.wait().unwrap();

--- a/experiments/throughput_driver.rs
+++ b/experiments/throughput_driver.rs
@@ -326,7 +326,7 @@ fn main() {
         .get_matches();
 
     let node_config = Configuration::from_args(&matches);
-    let recv_node = node_config.addr_nodes.len() - 1;
+    let recv_node = node_config.data_addresses.len() - 1;
     let mut node = Node::new(node_config);
 
     let num_messages: usize = matches

--- a/python/erdos/__init__.py
+++ b/python/erdos/__init__.py
@@ -69,17 +69,22 @@ def run(driver, start_port=9000):
     """
     driver()  # run driver to set _num_py_operators
 
-    addresses = [
+    data_addresses = [
         "127.0.0.1:{port}".format(port=start_port + i)
         for i in range(_num_py_operators)
     ]
+    control_addresses = [
+        "127.0.0.1:{port}".format(port=start_port + len(data_addresses) + i)
+        for i in range(_num_py_operators)
+    ]
 
-    def runner(driver, node_id, addresses):
+    def runner(driver, node_id, data_addresses, control_addresses):
         driver()
-        _internal.run(node_id, addresses)
+        _internal.run(node_id, data_addresses, control_addresses)
 
     processes = [
-        mp.Process(target=runner, args=(driver, i, addresses))
+        mp.Process(target=runner,
+                   args=(driver, i, data_addresses, control_addresses))
         for i in range(_num_py_operators)
     ]
 

--- a/src/communication/endpoints.rs
+++ b/src/communication/endpoints.rs
@@ -37,7 +37,7 @@ impl<D: Clone + Send + Debug> SendEndpoint<D> {
                 let msg = SerializedMessage::new(data, *stream_id);
                 sender
                     .try_send(msg)
-                    .map_err(|e| CommunicationError::from(e))
+                    .map_err(CommunicationError::from)
             }
         }
     }
@@ -61,7 +61,7 @@ impl<D: Clone + Send + Debug> RecvEndpoint<D> {
     /// Non-blocking read of a new message. Returns `TryRecvError::Empty` if no message is available.
     pub fn try_read(&mut self) -> Result<D, TryRecvError> {
         match self {
-            Self::InterThread(receiver) => receiver.try_recv().map_err(|e| TryRecvError::from(e)),
+            Self::InterThread(receiver) => receiver.try_recv().map_err(TryRecvError::from),
         }
     }
 }

--- a/src/communication/mod.rs
+++ b/src/communication/mod.rs
@@ -63,6 +63,7 @@ impl SerializedMessage {
     }
 }
 
+// TODO: update `channels_to_senders` for fault tolerance in case nodes to go down.
 pub struct ControlMessageHandler {
     channels_to_senders: HashMap<NodeId, UnboundedSender<ControlMessage>>,
     rx: UnboundedReceiver<ControlMessage>,

--- a/src/communication/pusher.rs
+++ b/src/communication/pusher.rs
@@ -61,7 +61,7 @@ where
     }
 
     fn send(&mut self, mut buf: BytesMut) -> Result<(), CommunicationError> {
-        if self.endpoints.len() > 0 {
+        if !self.endpoints.is_empty() {
             match Serializable::decode(&mut buf)? {
                 DeserializedMessage::<D>::Owned(msg) => {
                     for i in 1..self.endpoints.len() {
@@ -94,14 +94,14 @@ impl ControlPusher {
 
     pub fn send(&mut self, node_id: NodeId, msg: ControlMessage) -> Result<(), CommunicationError> {
         match self.channels_to_senders.get_mut(&node_id) {
-            Some(channel) => channel.try_send(msg).map_err(CommunicationError::from),
+            Some(tx) => tx.try_send(msg).map_err(CommunicationError::from),
             None => Err(CommunicationError::Disconnected),
         }
     }
 
     pub fn broadcast(&mut self, msg: ControlMessage) -> Result<(), CommunicationError> {
-        for channel in self.channels_to_senders.values_mut() {
-            channel.try_send(msg.clone()).map_err(CommunicationError::from)?;
+        for tx in self.channels_to_senders.values_mut() {
+            tx.try_send(msg.clone()).map_err(CommunicationError::from)?;
         }
         Ok(())
     }

--- a/src/communication/pusher.rs
+++ b/src/communication/pusher.rs
@@ -1,13 +1,15 @@
 use bytes::BytesMut;
 use serde::Deserialize;
-use std::{any::Any, fmt::Debug};
+use std::{any::Any, collections::HashMap, fmt::Debug};
+use tokio::{prelude::*, sync::mpsc::UnboundedSender};
 
 use crate::{
     communication::{
         serializable::{DeserializedMessage, Serializable},
-        CommunicationError, SendEndpoint,
+        CommunicationError, ControlMessage, SendEndpoint,
     },
     dataflow::Data,
+    node::NodeId,
 };
 
 /// Trait used to wrap a bunch of SendEndpoints of different types.
@@ -73,6 +75,33 @@ where
                     }
                 }
             }
+        }
+        Ok(())
+    }
+}
+
+/// Internal structure to send control messages to other processes
+pub struct ControlPusher {
+    channels_to_senders: HashMap<NodeId, UnboundedSender<ControlMessage>>,
+}
+
+impl ControlPusher {
+    pub fn new(channels_to_senders: HashMap<NodeId, UnboundedSender<ControlMessage>>) -> Self {
+        Self {
+            channels_to_senders,
+        }
+    }
+
+    pub fn send(&mut self, node_id: NodeId, msg: ControlMessage) -> Result<(), CommunicationError> {
+        match self.channels_to_senders.get_mut(&node_id) {
+            Some(channel) => channel.try_send(msg).map_err(CommunicationError::from),
+            None => Err(CommunicationError::Disconnected),
+        }
+    }
+
+    pub fn broadcast(&mut self, msg: ControlMessage) -> Result<(), CommunicationError> {
+        for channel in self.channels_to_senders.values_mut() {
+            channel.try_send(msg.clone()).map_err(CommunicationError::from)?;
         }
         Ok(())
     }

--- a/src/communication/pusher.rs
+++ b/src/communication/pusher.rs
@@ -1,15 +1,13 @@
 use bytes::BytesMut;
 use serde::Deserialize;
-use std::{any::Any, collections::HashMap, fmt::Debug};
-use tokio::sync::mpsc::UnboundedSender;
+use std::{any::Any, fmt::Debug};
 
 use crate::{
     communication::{
         serializable::{DeserializedMessage, Serializable},
-        CommunicationError, ControlMessage, SendEndpoint,
+        CommunicationError, SendEndpoint,
     },
     dataflow::Data,
-    node::NodeId,
 };
 
 /// Trait used to wrap a bunch of SendEndpoints of different types.
@@ -75,33 +73,6 @@ where
                     }
                 }
             }
-        }
-        Ok(())
-    }
-}
-
-/// Internal structure to send control messages to other processes
-pub struct ControlPusher {
-    channels_to_senders: HashMap<NodeId, UnboundedSender<ControlMessage>>,
-}
-
-impl ControlPusher {
-    pub fn new(channels_to_senders: HashMap<NodeId, UnboundedSender<ControlMessage>>) -> Self {
-        Self {
-            channels_to_senders,
-        }
-    }
-
-    pub fn send(&mut self, node_id: NodeId, msg: ControlMessage) -> Result<(), CommunicationError> {
-        match self.channels_to_senders.get_mut(&node_id) {
-            Some(tx) => tx.try_send(msg).map_err(CommunicationError::from),
-            None => Err(CommunicationError::Disconnected),
-        }
-    }
-
-    pub fn broadcast(&mut self, msg: ControlMessage) -> Result<(), CommunicationError> {
-        for tx in self.channels_to_senders.values_mut() {
-            tx.try_send(msg.clone()).map_err(CommunicationError::from)?;
         }
         Ok(())
     }

--- a/src/communication/pusher.rs
+++ b/src/communication/pusher.rs
@@ -1,7 +1,7 @@
 use bytes::BytesMut;
 use serde::Deserialize;
 use std::{any::Any, collections::HashMap, fmt::Debug};
-use tokio::{prelude::*, sync::mpsc::UnboundedSender};
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     communication::{

--- a/src/communication/receivers.rs
+++ b/src/communication/receivers.rs
@@ -1,13 +1,19 @@
 use futures::{future, stream::SplitStream};
 use std::{
     collections::HashMap,
-    sync::{mpsc, Arc},
+    sync::{mpsc, Arc, mpsc::Sender},
 };
-use tokio::{codec::Framed, net::TcpStream, prelude::*, sync::Mutex};
+use tokio::{
+    codec::Framed,
+    net::TcpStream,
+    prelude::*,
+    sync::Mutex,
+};
 
 use crate::{
-    communication::PusherT,
-    communication::{CommunicationError, MessageCodec},
+    communication::{
+        CommunicationError, ControlMessage, ControlMessageCodec, MessageCodec, PusherT,
+    },
     dataflow::stream::StreamId,
     node::node::NodeId,
     scheduler::endpoints_manager::ChannelsToReceivers,
@@ -31,7 +37,7 @@ impl ERDOSReceiver {
         node_id: NodeId,
         stream: SplitStream<Framed<TcpStream, MessageCodec>>,
         channels_to_receivers: Arc<Mutex<ChannelsToReceivers>>,
-    ) -> ERDOSReceiver {
+    ) -> Self {
         // Create a channel for this stream.
         let (tx, rx) = mpsc::channel();
         // Add entry in the shared state vector.
@@ -54,10 +60,11 @@ impl ERDOSReceiver {
                     self.update_pushers();
                     // Send the message.
                     match self.stream_id_to_pusher.get_mut(&msg.header.stream_id) {
-                        Some(pusher) => match pusher.send(msg.data) {
-                            Err(e) => return Err(e),
-                            _ => (),
-                        },
+                        Some(pusher) => {
+                            if let Err(e) = pusher.send(msg.data) {
+                                return Err(e);
+                            }
+                        }
                         None => panic!(
                             "Receiver does not have any pushers. \
                              Race condition during data-flow reconfiguration."
@@ -82,6 +89,52 @@ impl ERDOSReceiver {
 /// The function receives a vector of framed TCP receiver halves.
 /// It launches a task that listens for new messages for each TCP connection.
 pub async fn run_receivers(mut receivers: Vec<ERDOSReceiver>) -> Result<(), CommunicationError> {
+    // Wait for all futures to finish. It will happen only when all streams are closed.
+    future::join_all(receivers.iter_mut().map(|receiver| receiver.run())).await;
+    Ok(())
+}
+
+/// Listens on a TCP stream, and pushes control messages it receives to the node.
+#[allow(dead_code)]
+pub struct ControlReceiver {
+    /// The id of the node the stream is receiving data from.
+    node_id: NodeId,
+    /// Framed TCP read stream.
+    stream: SplitStream<Framed<TcpStream, ControlMessageCodec>>,
+    /// Mapping between stream id to pushers.
+    channel_to_node: Sender<ControlMessage>,
+}
+
+impl ControlReceiver {
+    pub fn new(
+        node_id: NodeId,
+        stream: SplitStream<Framed<TcpStream, ControlMessageCodec>>,
+        channel_to_node: Sender<ControlMessage>,
+    ) -> Self {
+        Self {
+            node_id,
+            stream,
+            channel_to_node,
+        }
+    }
+
+    pub async fn run(&mut self) -> Result<(), CommunicationError> {
+        while let Some(res) = self.stream.next().await {
+            match res {
+                Ok(msg) => {
+                    self.channel_to_node.send(msg).map_err(CommunicationError::from)?;
+                }
+                Err(e) => return Err(CommunicationError::from(e)),
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Receives TCP messages, and pushes them to the ControlHandler
+/// The function receives a vector of framed TCP receiver halves.
+/// It launches a task that listens for new messages for each TCP connection.
+pub async fn run_control_receivers(mut receivers: Vec<ControlReceiver>) -> Result<(), CommunicationError> {
     // Wait for all futures to finish. It will happen only when all streams are closed.
     future::join_all(receivers.iter_mut().map(|receiver| receiver.run())).await;
     Ok(())

--- a/src/communication/receivers.rs
+++ b/src/communication/receivers.rs
@@ -119,6 +119,8 @@ impl ControlReceiver {
     }
 
     pub async fn run(&mut self) -> Result<(), CommunicationError> {
+        // TODO: update `self.channel_to_handler` for up-to-date mappings
+        // between channels and handlers (e.g. for fault-tolerance).
         while let Some(res) = self.stream.next().await {
             match res {
                 Ok(msg) => {

--- a/src/communication/receivers.rs
+++ b/src/communication/receivers.rs
@@ -21,7 +21,7 @@ use crate::{
 
 /// Listens on a TCP stream, and pushes messages it receives to operator executors.
 #[allow(dead_code)]
-pub struct ERDOSReceiver {
+pub struct DataReceiver {
     /// The id of the node the stream is receiving data from.
     node_id: NodeId,
     /// Framed TCP read stream.
@@ -32,7 +32,7 @@ pub struct ERDOSReceiver {
     stream_id_to_pusher: HashMap<StreamId, Box<dyn PusherT>>,
 }
 
-impl ERDOSReceiver {
+impl DataReceiver {
     pub async fn new(
         node_id: NodeId,
         stream: SplitStream<Framed<TcpStream, MessageCodec>>,
@@ -88,7 +88,7 @@ impl ERDOSReceiver {
 /// Receives TCP messages, and pushes them to operators endpoints.
 /// The function receives a vector of framed TCP receiver halves.
 /// It launches a task that listens for new messages for each TCP connection.
-pub async fn run_receivers(mut receivers: Vec<ERDOSReceiver>) -> Result<(), CommunicationError> {
+pub async fn run_receivers(mut receivers: Vec<DataReceiver>) -> Result<(), CommunicationError> {
     // Wait for all futures to finish. It will happen only when all streams are closed.
     future::join_all(receivers.iter_mut().map(|receiver| receiver.run())).await;
     Ok(())

--- a/src/communication/senders.rs
+++ b/src/communication/senders.rs
@@ -12,7 +12,7 @@ use crate::scheduler::endpoints_manager::ChannelsToSenders;
 
 #[allow(dead_code)]
 /// Listens on a `tokio::sync::mpsc` channel, and sends received messages on the network.
-pub struct ERDOSSender {
+pub struct DataSender {
     /// The id of the node the sink is sending data to.
     node_id: NodeId,
     /// Framed TCP write sink.
@@ -21,7 +21,7 @@ pub struct ERDOSSender {
     rx: UnboundedReceiver<SerializedMessage>,
 }
 
-impl ERDOSSender {
+impl DataSender {
     pub async fn new(
         node_id: NodeId,
         sink: SplitSink<Framed<TcpStream, MessageCodec>, SerializedMessage>,
@@ -52,7 +52,7 @@ impl ERDOSSender {
 /// The function launches a task for each TCP sink. Each task listens
 /// on a mpsc channel for new `SerializedMessages` messages, which it
 /// forwards on the TCP stream.
-pub async fn run_senders(mut senders: Vec<ERDOSSender>) -> Result<(), CommunicationError> {
+pub async fn run_senders(mut senders: Vec<DataSender>) -> Result<(), CommunicationError> {
     // Waits until all futures complete. This code will only be reached
     // when all the mpsc channels are closed.
     future::join_all(senders.iter_mut().map(|sender| sender.run())).await;

--- a/src/communication/senders.rs
+++ b/src/communication/senders.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, mpsc::UnboundedReceiver, Mutex};
 use tokio::{codec::Framed, net::TcpStream, prelude::*};
 
-use crate::communication::{CommunicationError, MessageCodec, SerializedMessage};
+use crate::communication::{
+    CommunicationError, ControlMessage, ControlMessageCodec, MessageCodec, SerializedMessage,
+};
 use crate::node::node::NodeId;
 use crate::scheduler::endpoints_manager::ChannelsToSenders;
 
@@ -35,15 +37,11 @@ impl ERDOSSender {
     pub async fn run(&mut self) -> Result<(), CommunicationError> {
         loop {
             match self.rx.recv().await {
-                Some(msg) => match self
-                    .sink
-                    .send(msg)
-                    .await
-                    .map_err(|e| CommunicationError::from(e))
-                {
-                    Err(e) => return Err(e),
-                    _ => (),
-                },
+                Some(msg) => {
+                    if let Err(e) = self.sink.send(msg).await.map_err(CommunicationError::from) {
+                        return Err(e);
+                    }
+                }
                 None => return Err(CommunicationError::Disconnected),
             }
         }
@@ -55,6 +53,51 @@ impl ERDOSSender {
 /// on a mpsc channel for new `SerializedMessages` messages, which it
 /// forwards on the TCP stream.
 pub async fn run_senders(mut senders: Vec<ERDOSSender>) -> Result<(), CommunicationError> {
+    // Waits until all futures complete. This code will only be reached
+    // when all the mpsc channels are closed.
+    future::join_all(senders.iter_mut().map(|sender| sender.run())).await;
+    Ok(())
+}
+
+#[allow(dead_code)]
+/// Listens for control messages on a `tokio::sync::mpsc` channel, and sends received messages on the network.
+pub struct ControlSender {
+    /// The id of the node the sink is sending data to.
+    node_id: NodeId,
+    /// Framed TCP write sink.
+    sink: SplitSink<Framed<TcpStream, ControlMessageCodec>, ControlMessage>,
+    /// Tokio channel receiver on which to receive data from worker threads.
+    rx: UnboundedReceiver<ControlMessage>,
+}
+
+impl ControlSender {
+    pub fn new(
+        node_id: NodeId,
+        sink: SplitSink<Framed<TcpStream, ControlMessageCodec>, ControlMessage>,
+        rx: UnboundedReceiver<ControlMessage>,
+    ) -> Self {
+        Self { node_id, sink, rx }
+    }
+
+    pub async fn run(&mut self) -> Result<(), CommunicationError> {
+        loop {
+            match self.rx.recv().await {
+                Some(msg) => {
+                    if let Err(e) = self.sink.send(msg).await.map_err(CommunicationError::from) {
+                        return Err(e);
+                    }
+                }
+                None => return Err(CommunicationError::Disconnected),
+            }
+        }
+    }
+}
+
+/// Sends messages received fomr the control handler other nodes.
+/// The function launches a task for each TCP sink. Each task listens
+/// on a mpsc channel for new `ControlMessage`s, which it
+/// forwards on the TCP stream.
+pub async fn run_control_senders(mut senders: Vec<ControlSender>) -> Result<(), CommunicationError> {
     // Waits until all futures complete. This code will only be reached
     // when all the mpsc channels are closed.
     future::join_all(senders.iter_mut().map(|sender| sender.run())).await;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -19,7 +19,12 @@ pub struct Configuration {
 
 impl Configuration {
     /// Creates a new node configuration.
-    pub fn new(node_index: NodeId, data_addresses: Vec<SocketAddr>, control_addresses: Vec<SocketAddr>, num_worker_threads: usize) -> Self {
+    pub fn new(
+        node_index: NodeId,
+        data_addresses: Vec<SocketAddr>,
+        control_addresses: Vec<SocketAddr>,
+        num_worker_threads: usize,
+    ) -> Self {
         Self {
             index: node_index,
             num_worker_threads,
@@ -47,6 +52,11 @@ impl Configuration {
         for addr in control_addrs.split(",") {
             control_addresses.push(addr.parse().expect("Unable to parse socket address"));
         }
+        assert_eq!(
+            data_addresses.len(),
+            control_addresses.len(),
+            "Each node must have 1 data address and 1 control address"
+        );
         let node_index = args
             .value_of("index")
             .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ macro_rules! make_operator_runner {
                 // Notify node that operator is done setting up
                 control_sender.send(ControlMessage::OperatorInitialized(config.id));
                 // Wait for control message to run
-                while true {
+                loop {
                     if let Ok(ControlMessage::RunOperator(id)) = control_receiver.recv() {
                         if id == config.id {
                             break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub mod scheduler;
 pub use crate::configuration::Configuration;
 
 /// Makes a callback which automatically flows watermarks to downstream operators.
-/// 
+///
 /// Note: this is intended as an internal macro invoked by `make_operator_runner!`
 #[macro_export]
 macro_rules! flow_watermarks {
@@ -80,7 +80,7 @@ macro_rules! flow_watermarks {
 }
 
 /// Makes a callback which automatically flows watermarks to downstream operators.
-/// 
+///
 /// Note: this is intended as an internal macro invoked by `make_operator_runner!`
 #[macro_export]
 macro_rules! make_operator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use crate::configuration::Configuration;
 
 /// Makes a callback which automatically flows watermarks to downstream operators.
 /// 
-/// This macro is invoked by `make_operator_runner!`
+/// Note: this is intended as an internal macro invoked by `make_operator_runner!`
 #[macro_export]
 macro_rules! flow_watermarks {
     (($($rs:ident),+), ($($ws:ident),+)) => {
@@ -81,7 +81,7 @@ macro_rules! flow_watermarks {
 
 /// Makes a callback which automatically flows watermarks to downstream operators.
 /// 
-/// This macro is invoked by `make_operator_runner!`
+/// Note: this is intended as an internal macro invoked by `make_operator_runner!`
 #[macro_export]
 macro_rules! make_operator {
     ($t:ty, $config:expr, ($($rs:ident),+), ($($ws:ident),*)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,11 +454,18 @@ pub fn new_app(name: &str) -> clap::App {
                 .help("Number of worker threads per process"),
         )
         .arg(
-            Arg::with_name("addresses")
-                .short("a")
-                .long("addresses")
+            Arg::with_name("data-addresses")
+                .short("d")
+                .long("data-addresses")
                 .default_value("127.0.0.1:9000")
-                .help("Comma separated list of socket addresses of all nodes"),
+                .help("Comma separated list of data socket addresses of all nodes"),
+        )
+        .arg(
+            Arg::with_name("control-addresses")
+                .short("c")
+                .long("control-addresses")
+                .default_value("127.0.0.1:9000")
+                .help("Comma separated list of control socket addresses of all nodes"),
         )
         .arg(
             Arg::with_name("index")

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -165,7 +165,13 @@ if flow_watermarks and len(read_streams) > 0 and len(write_streams) > 0:
                     e.print(py)
                 }
                 // Notify node that operator is done setting up
-                control_sender.send(ControlMessage::OperatorInitialized(op_id));
+                let logger = crate::get_terminal_logger();
+                if let Err(e) = control_sender.send(ControlMessage::OperatorInitialized(op_id)) {
+                    error!(
+                        logger,
+                        "Error sending OperatorInitialized message to control handler: {:?}", e
+                    );
+                }
                 // Wait for control message to run
                 loop {
                     if let Ok(ControlMessage::RunOperator(id)) = control_receiver.recv() {
@@ -179,7 +185,7 @@ if flow_watermarks and len(read_streams) > 0 and len(write_streams) > 0:
                     e.print(py)
                 }
 
-                OperatorExecutor::new(op_ex_streams, crate::get_terminal_logger())
+                OperatorExecutor::new(op_ex_streams, logger)
             };
 
         default_graph::add_operator(

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1,9 +1,13 @@
 use pyo3::prelude::*;
 use pyo3::types::*;
 
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    mpsc::{Receiver, Sender},
+    Arc, Mutex,
+};
 
 use crate::{
+    communication::ControlMessage,
     dataflow::{graph::default_graph, stream::InternalReadStream, ReadStream, WriteStream},
     node::{
         operator_executor::{OperatorExecutor, OperatorExecutorStream, OperatorExecutorStreamT},
@@ -65,81 +69,85 @@ fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
         let args_arc = Arc::new(args);
         let kwargs_arc = Arc::new(kwargs);
 
-        let operator_runner = move |channel_manager: Arc<Mutex<ChannelManager>>| {
-            // Create python streams from endpoints
-            let py_read_streams: Vec<PyReadStream> = read_stream_ids_clone
-                .clone()
-                .iter()
-                .map(|&id| {
-                    let recv_endpoint = channel_manager
-                        .lock()
-                        .unwrap()
-                        .take_recv_endpoint(id)
-                        .unwrap();
-                    PyReadStream::from(ReadStream::from(InternalReadStream::from_endpoint(
-                        recv_endpoint,
-                        id,
-                    )))
-                })
-                .collect();
-            let py_write_streams: Vec<PyWriteStream> = write_stream_ids_clone
-                .iter()
-                .map(|&id| {
-                    let send_endpoints = channel_manager
-                        .lock()
-                        .unwrap()
-                        .get_send_endpoints(id)
-                        .unwrap();
-                    PyWriteStream::from(WriteStream::from_endpoints(send_endpoints, id))
-                })
-                .collect();
+        let operator_runner =
+            move |channel_manager: Arc<Mutex<ChannelManager>>,
+                  control_sender: Sender<ControlMessage>,
+                  control_receiver: Receiver<ControlMessage>| {
+                // Create python streams from endpoints
+                let py_read_streams: Vec<PyReadStream> = read_stream_ids_clone
+                    .clone()
+                    .iter()
+                    .map(|&id| {
+                        let recv_endpoint = channel_manager
+                            .lock()
+                            .unwrap()
+                            .take_recv_endpoint(id)
+                            .unwrap();
+                        PyReadStream::from(ReadStream::from(InternalReadStream::from_endpoint(
+                            recv_endpoint,
+                            id,
+                        )))
+                    })
+                    .collect();
+                let py_write_streams: Vec<PyWriteStream> = write_stream_ids_clone
+                    .iter()
+                    .map(|&id| {
+                        let send_endpoints = channel_manager
+                            .lock()
+                            .unwrap()
+                            .get_send_endpoints(id)
+                            .unwrap();
+                        PyWriteStream::from(WriteStream::from_endpoints(send_endpoints, id))
+                    })
+                    .collect();
 
-            // Create operator executor streams from read streams
-            let mut op_ex_streams: Vec<Box<dyn OperatorExecutorStreamT>> = Vec::new();
-            for py_read_stream in py_read_streams.iter() {
-                op_ex_streams.push(Box::new(OperatorExecutorStream::from(
-                    &py_read_stream.read_stream,
-                )));
-            }
+                // Create operator executor streams from read streams
+                let mut op_ex_streams: Vec<Box<dyn OperatorExecutorStreamT>> = Vec::new();
+                for py_read_stream in py_read_streams.iter() {
+                    op_ex_streams.push(Box::new(OperatorExecutorStream::from(
+                        &py_read_stream.read_stream,
+                    )));
+                }
 
-            // Instantiate and run the operator in Python
-            let gil = Python::acquire_gil();
-            let py = gil.python();
-            let locals = PyDict::new(py);
-            let py_read_streams: Vec<PyRef<PyReadStream>> = py_read_streams
-                .into_iter()
-                .map(|rs| PyRef::new(py, rs).unwrap())
-                .collect();
-            let py_write_streams: Vec<PyRef<PyWriteStream>> = py_write_streams
-                .into_iter()
-                .map(|ws| PyRef::new(py, ws).unwrap())
-                .collect();
-            locals
-                .set_item("Operator", py_type_arc.clone_ref(py))
-                .err()
-                .map(|e| e.print(py));
-            locals
-                .set_item("py_read_streams", py_read_streams)
-                .err()
-                .map(|e| e.print(py));
-            locals
-                .set_item("py_write_streams", py_write_streams)
-                .err()
-                .map(|e| e.print(py));
-            locals
-                .set_item("flow_watermarks", flow_watermarks)
-                .err()
-                .map(|e| e.print(py));
-            locals
-                .set_item("args", args_arc.clone_ref(py))
-                .err()
-                .map(|e| e.print(py));
-            locals
-                .set_item("kwargs", kwargs_arc.clone_ref(py))
-                .err()
-                .map(|e| e.print(py));
-            let py_result = py.run(
-                r#"
+                // Instantiate and run the operator in Python
+                let gil = Python::acquire_gil();
+                let py = gil.python();
+                let locals = PyDict::new(py);
+                let py_read_streams: Vec<PyRef<PyReadStream>> = py_read_streams
+                    .into_iter()
+                    .map(|rs| PyRef::new(py, rs).unwrap())
+                    .collect();
+                let py_write_streams: Vec<PyRef<PyWriteStream>> = py_write_streams
+                    .into_iter()
+                    .map(|ws| PyRef::new(py, ws).unwrap())
+                    .collect();
+                locals
+                    .set_item("Operator", py_type_arc.clone_ref(py))
+                    .err()
+                    .map(|e| e.print(py));
+                locals
+                    .set_item("py_read_streams", py_read_streams)
+                    .err()
+                    .map(|e| e.print(py));
+                locals
+                    .set_item("py_write_streams", py_write_streams)
+                    .err()
+                    .map(|e| e.print(py));
+                locals
+                    .set_item("flow_watermarks", flow_watermarks)
+                    .err()
+                    .map(|e| e.print(py));
+                locals
+                    .set_item("args", args_arc.clone_ref(py))
+                    .err()
+                    .map(|e| e.print(py));
+                locals
+                    .set_item("kwargs", kwargs_arc.clone_ref(py))
+                    .err()
+                    .map(|e| e.print(py));
+                // Initialize operator
+                let py_result = py.run(
+                    r#"
 import erdos
 
 read_streams = [erdos.ReadStream(_py_read_stream=s) for s in py_read_streams]
@@ -149,19 +157,30 @@ operator = Operator(*read_streams, *write_streams, *args, **kwargs)
 
 if flow_watermarks and len(read_streams) > 0 and len(write_streams) > 0:
    erdos.add_watermark_callback(read_streams, write_streams, erdos._flow_watermark_callback)
-
-operator.run()
 "#,
-                None,
-                Some(&locals),
-            );
-            match py_result {
-                Ok(_) => (),
-                Err(e) => e.print(py),
-            };
+                    None,
+                    Some(&locals),
+                );
+                if let Err(e) = py_result {
+                    e.print(py)
+                }
+                // Notify node that operator is done setting up
+                control_sender.send(ControlMessage::OperatorInitialized(op_id));
+                // Wait for control message to run
+                loop {
+                    if let Ok(ControlMessage::RunOperator(id)) = control_receiver.recv() {
+                        if id == op_id {
+                            break;
+                        }
+                    }
+                }
+                let py_result = py.run("operator.run()", None, Some(&locals));
+                if let Err(e) = py_result {
+                    e.print(py)
+                }
 
-            OperatorExecutor::new(op_ex_streams, crate::get_terminal_logger())
-        };
+                OperatorExecutor::new(op_ex_streams, crate::get_terminal_logger())
+            };
 
         default_graph::add_operator(
             op_id,
@@ -184,13 +203,22 @@ operator.run()
     }
 
     #[pyfn(m, "run")]
-    fn run_py(py: Python, node_id: NodeId, addresses: Vec<String>) -> PyResult<()> {
+    fn run_py(
+        py: Python,
+        node_id: NodeId,
+        data_addresses: Vec<String>,
+        control_addresses: Vec<String>,
+    ) -> PyResult<()> {
         py.allow_threads(move || {
-            let addresses = addresses
+            let data_addresses = data_addresses
                 .into_iter()
                 .map(|s| s.parse().expect("Unable to parse socket address"))
                 .collect();
-            let config = Configuration::new(node_id, addresses, 7);
+            let control_addresses = control_addresses
+                .into_iter()
+                .map(|s| s.parse().expect("Unable to parse socket address"))
+                .collect();
+            let config = Configuration::new(node_id, data_addresses, control_addresses, 7);
             let mut node = Node::new(config);
             node.run();
         });
@@ -198,12 +226,21 @@ operator.run()
     }
 
     #[pyfn(m, "run_async")]
-    fn run_async_py(_py: Python, node_id: NodeId, addresses: Vec<String>) -> PyResult<()> {
-        let addresses = addresses
+    fn run_async_py(
+        _py: Python,
+        node_id: NodeId,
+        data_addresses: Vec<String>,
+        control_addresses: Vec<String>,
+    ) -> PyResult<()> {
+        let data_addresses = data_addresses
             .into_iter()
             .map(|s| s.parse().expect("Unable to parse socket address"))
             .collect();
-        let config = Configuration::new(node_id, addresses, 7);
+        let control_addresses = control_addresses
+            .into_iter()
+            .map(|s| s.parse().expect("Unable to parse socket address"))
+            .collect();
+        let config = Configuration::new(node_id, data_addresses, control_addresses, 7);
         let node = Node::new(config);
         node.run_async();
         Ok(())

--- a/src/scheduler/channel_manager.rs
+++ b/src/scheduler/channel_manager.rs
@@ -212,7 +212,7 @@ impl ChannelManager {
             }
         }
 
-        // Send pushers to the ERDOSReceiver which publishes received messages from TCP
+        // Send pushers to the DataReceiver which publishes received messages from TCP
         // on the proper transport channel.
         for (k, v) in receiver_pushers.into_iter() {
             channels_to_receivers.lock().await.send(k, v);

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -14,6 +14,8 @@ use erdos::{
     *,
 };
 
+mod utils;
+
 pub struct SendOperator {
     write_stream: WriteStream<usize>,
 }
@@ -86,10 +88,7 @@ impl SquareOperator {
 
 #[test]
 fn test_inter_thread() {
-    let addresses = vec!["127.0.0.1:9000"
-        .parse()
-        .expect("Unable to parse socket address")];
-    let config = Configuration::new(0, addresses, 4);
+    let config = utils::make_default_config();
     let node = Node::new(config);
 
     let config = OperatorConfig::new("SendOperator", (), true, 0);
@@ -102,10 +101,7 @@ fn test_inter_thread() {
 
 #[test]
 fn test_ingest() {
-    let addresses = vec!["127.0.0.1:9000"
-        .parse()
-        .expect("Unable to parse socket address")];
-    let config = Configuration::new(0, addresses, 4);
+    let config = utils::make_default_config();
     let node = Node::new(config);
 
     let mut ingest_stream = IngestStream::new(0);
@@ -129,11 +125,7 @@ fn test_ingest() {
 
 #[test]
 fn test_extract() {
-    let addresses = vec!["127.0.0.1:9000"
-        .parse()
-        .expect("Unable to parse socket address")];
-
-    let config = Configuration::new(0, addresses, 4);
+    let config = utils::make_default_config();
     let node = Node::new(config);
 
     let config = OperatorConfig::new("SendOperator", (), true, 0);
@@ -151,10 +143,7 @@ fn test_extract() {
 
 #[test]
 fn test_ingest_extract() {
-    let addresses = vec!["127.0.0.1:9000"
-        .parse()
-        .expect("Unable to parse socket address")];
-    let config = Configuration::new(0, addresses, 4);
+    let config = utils::make_default_config();
     let node = Node::new(config);
 
     let mut ingest_stream = IngestStream::new(0);

--- a/tests/loop_test.rs
+++ b/tests/loop_test.rs
@@ -9,6 +9,8 @@ use erdos::{
     *,
 };
 
+mod utils;
+
 pub struct LoopOperator {
     send_first_msg: bool,
     num_iterations: usize,
@@ -60,10 +62,7 @@ impl LoopOperator {
 
 #[test]
 fn test_loop() {
-    let addresses = vec!["127.0.0.1:9000"
-        .parse()
-        .expect("Unable to parse socket address")];
-    let config = Configuration::new(0, addresses, 4);
+    let config = utils::make_default_config();
     let node = Node::new(config);
 
     let loop_stream = LoopStream::new();

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,0 +1,11 @@
+use erdos::Configuration;
+
+pub fn make_default_config() -> Configuration {
+    let data_addresses = vec!["127.0.0.1:9000"
+    .parse()
+    .expect("Unable to parse socket address")];
+    let control_addresses = vec!["127.0.0.1:9001"
+    .parse()
+    .expect("Unable to parse socket address")];
+    Configuration::new(0, data_addresses, control_addresses, 4)
+}

--- a/tests/watermark_test.rs
+++ b/tests/watermark_test.rs
@@ -9,6 +9,8 @@ use erdos::{
     *,
 };
 
+mod utils;
+
 /// Sends 5 watermark messages.
 pub struct SendOperator {
     write_stream: WriteStream<usize>,
@@ -67,10 +69,7 @@ impl RecvOperator {
 
 #[test]
 fn test_flow_watermarks() {
-    let addresses = vec!["127.0.0.1:9000"
-        .parse()
-        .expect("Unable to parse socket address")];
-    let config = Configuration::new(0, addresses, 4);
+    let config = utils::make_default_config();
     let node = Node::new(config);
 
     let s1 = connect_1_write!(SendOperator, ());
@@ -84,10 +83,7 @@ fn test_flow_watermarks() {
 
 #[test]
 fn test_no_flow_watermarks() {
-    let addresses = vec!["127.0.0.1:9000"
-        .parse()
-        .expect("Unable to parse socket address")];
-    let config = Configuration::new(0, addresses, 4);
+    let config = utils::make_default_config();
     let node = Node::new(config);
 
     let s1 = connect_1_write!(SendOperator, ());


### PR DESCRIPTION
Fixes the race condition where operators may begin executing before all nodes are connected and all operators are ready to run.

The following protocol on the control plane fixes the race condition:
1. The node executor spawns a green thread for each operator.
2.  Each operator initializes by calling `Operator::new()` and sends the `OperatorInitialized` message to the node executor.
3. The node executor waits until it has received `OperatorInitialized` messages from all operators. It then broadcasts the `AllOperatorsInitializedOnNode` message to all other nodes.
4. The node waits until it has received `AllOperatorsInitializedOnNode` messages from all nodes. It then begins executing operators via `Operator::run()`.

In addition to the protocol and control plane, this PR
- Refactors macros for easier maintainability.
- Deprecates the `--addresses` argument.
- Introduces `--data-addresses` and `--control-addresses` arguments.
- Refactors some tests.