### PR TITLE
Expand control plane to senders and receivers and update libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,6 @@ bincode = "1.2.1"
 bytes = "0.5.4"
 byteorder = "1.0.0"
 clap = "2.33.0"
-# futures-preview = "=0.3.0-alpha.19"
-# futures-util-preview = "=0.3.0-alpha.19"
 futures = "0.3.1"
 futures-util = "0.3.1"
 pyo3 = { version = "0.8.2", features=["unsound-subclass"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,21 @@ keywords = ["data-flow", "robotics", "autonomos", "driving"]
 abomonation = "0.7.3"
 abomonation_derive = "0.5.0"
 async-trait = "0.1.18"
-bincode = "1.1.4"
-bytes = "0.4.12"
+bincode = "1.2.1"
+bytes = "0.5.4"
 byteorder = "1.0.0"
 clap = "2.33.0"
-futures-preview = "=0.3.0-alpha.19"
-futures-util-preview = "=0.3.0-alpha.19"
+# futures-preview = "=0.3.0-alpha.19"
+# futures-util-preview = "=0.3.0-alpha.19"
+futures = "0.3.1"
+futures-util = "0.3.1"
 pyo3 = { version = "0.8.2", features=["unsound-subclass"] }
 rand = "0.3"
 serde = { version = "1.0.99", features = ["derive"] }
 slog = "2.4.2"
 slog-term = "2.4.2"
-tokio = "=0.2.0-alpha.6"
+tokio = { version = "0.2.11", features = ["sync", "tcp", "io-util", "rt-core", "rt-threaded"] }
+tokio-util = { version = "0.2.0", features = ["codec"] }
 tokio-serde-bincode = "0.2"
 uuid = { version = "0.7", features = ["v4", "v5", "serde"] }
 

--- a/src/communication/control_message_codec.rs
+++ b/src/communication/control_message_codec.rs
@@ -1,8 +1,7 @@
 use byteorder::{ByteOrder, NetworkEndian, WriteBytesExt};
 use bytes::BytesMut;
 use std::fmt::Debug;
-use tokio::codec::Decoder;
-use tokio::codec::Encoder;
+use tokio_util::codec::{Encoder, Decoder};
 
 use crate::communication::{CodecError, ControlMessage};
 

--- a/src/communication/control_message_handler.rs
+++ b/src/communication/control_message_handler.rs
@@ -1,0 +1,194 @@
+use std::collections::HashMap;
+
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+
+use crate::node::NodeId;
+
+use super::{CommunicationError, ControlMessage};
+
+// TODO: update `channels_to_nodes` for fault tolerance in case nodes to go down.
+pub struct ControlMessageHandler {
+    /// Sender to clone so other tasks can send messages to `self.rx`.
+    tx: UnboundedSender<ControlMessage>,
+    /// Receiver for all `ControlMessage`s
+    rx: UnboundedReceiver<ControlMessage>,
+    channels_to_control_senders: HashMap<NodeId, UnboundedSender<ControlMessage>>,
+    channels_to_control_receivers: HashMap<NodeId, UnboundedSender<ControlMessage>>,
+    channels_to_data_senders: HashMap<NodeId, UnboundedSender<ControlMessage>>,
+    channels_to_data_receivers: HashMap<NodeId, UnboundedSender<ControlMessage>>,
+    channels_to_nodes: HashMap<NodeId, UnboundedSender<ControlMessage>>,
+}
+
+impl ControlMessageHandler {
+    pub fn new() -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        Self {
+            tx,
+            rx,
+            channels_to_control_senders: HashMap::new(),
+            channels_to_control_receivers: HashMap::new(),
+            channels_to_data_senders: HashMap::new(),
+            channels_to_data_receivers: HashMap::new(),
+            channels_to_nodes: HashMap::new(),
+        }
+    }
+
+    pub fn add_channel_to_control_sender(
+        &mut self,
+        node_id: NodeId,
+        tx: UnboundedSender<ControlMessage>,
+    ) {
+        self.channels_to_control_senders.insert(node_id, tx);
+    }
+
+    pub fn send_to_control_sender(
+        &mut self,
+        node_id: NodeId,
+        msg: ControlMessage,
+    ) -> Result<(), CommunicationError> {
+        match self.channels_to_control_senders.get_mut(&node_id) {
+            Some(tx) => tx.send(msg).map_err(CommunicationError::from),
+            None => Err(CommunicationError::Disconnected),
+        }
+    }
+
+    pub fn broadcast_to_control_senders(
+        &mut self,
+        msg: ControlMessage,
+    ) -> Result<(), CommunicationError> {
+        for tx in self.channels_to_control_senders.values_mut() {
+            tx.send(msg.clone()).map_err(CommunicationError::from)?;
+        }
+        Ok(())
+    }
+
+    pub fn add_channel_to_control_receiver(
+        &mut self,
+        node_id: NodeId,
+        tx: UnboundedSender<ControlMessage>,
+    ) {
+        self.channels_to_control_receivers.insert(node_id, tx);
+    }
+
+    pub fn send_to_control_receiver(
+        &mut self,
+        node_id: NodeId,
+        msg: ControlMessage,
+    ) -> Result<(), CommunicationError> {
+        match self.channels_to_control_receivers.get_mut(&node_id) {
+            Some(tx) => tx.send(msg).map_err(CommunicationError::from),
+            None => Err(CommunicationError::Disconnected),
+        }
+    }
+
+    pub fn broadcast_to_control_receivers(
+        &mut self,
+        msg: ControlMessage,
+    ) -> Result<(), CommunicationError> {
+        for tx in self.channels_to_control_receivers.values_mut() {
+            tx.send(msg.clone()).map_err(CommunicationError::from)?;
+        }
+        Ok(())
+    }
+
+    pub fn add_channel_to_data_sender(
+        &mut self,
+        node_id: NodeId,
+        tx: UnboundedSender<ControlMessage>,
+    ) {
+        self.channels_to_data_senders.insert(node_id, tx);
+    }
+
+    pub fn send_to_data_sender(
+        &mut self,
+        node_id: NodeId,
+        msg: ControlMessage,
+    ) -> Result<(), CommunicationError> {
+        match self.channels_to_data_senders.get_mut(&node_id) {
+            Some(tx) => tx.send(msg).map_err(CommunicationError::from),
+            None => Err(CommunicationError::Disconnected),
+        }
+    }
+
+    pub fn broadcast_to_data_senders(
+        &mut self,
+        msg: ControlMessage,
+    ) -> Result<(), CommunicationError> {
+        for tx in self.channels_to_data_senders.values_mut() {
+            tx.send(msg.clone()).map_err(CommunicationError::from)?;
+        }
+        Ok(())
+    }
+
+    pub fn add_channel_to_data_receiver(
+        &mut self,
+        node_id: NodeId,
+        tx: UnboundedSender<ControlMessage>,
+    ) {
+        self.channels_to_data_receivers.insert(node_id, tx);
+    }
+
+    pub fn send_to_data_receiver(
+        &mut self,
+        node_id: NodeId,
+        msg: ControlMessage,
+    ) -> Result<(), CommunicationError> {
+        match self.channels_to_data_receivers.get_mut(&node_id) {
+            Some(tx) => tx.send(msg).map_err(CommunicationError::from),
+            None => Err(CommunicationError::Disconnected),
+        }
+    }
+
+    pub fn broadcast_to_data_receivers(
+        &mut self,
+        msg: ControlMessage,
+    ) -> Result<(), CommunicationError> {
+        for tx in self.channels_to_data_receivers.values_mut() {
+            tx.send(msg.clone()).map_err(CommunicationError::from)?;
+        }
+        Ok(())
+    }
+
+    pub fn add_channel_to_node(&mut self, node_id: NodeId, tx: UnboundedSender<ControlMessage>) {
+        self.channels_to_nodes.insert(node_id, tx);
+    }
+
+    pub fn send_to_node(
+        &mut self,
+        node_id: NodeId,
+        msg: ControlMessage,
+    ) -> Result<(), CommunicationError> {
+        match self.channels_to_nodes.get_mut(&node_id) {
+            Some(tx) => tx.send(msg).map_err(CommunicationError::from),
+            None => Err(CommunicationError::Disconnected),
+        }
+    }
+
+    pub fn broadcast_to_nodes(&mut self, msg: ControlMessage) -> Result<(), CommunicationError> {
+        for tx in self.channels_to_nodes.values_mut() {
+            tx.send(msg.clone()).map_err(CommunicationError::from)?;
+        }
+        Ok(())
+    }
+
+    pub fn get_channel_to_handler(&self) -> UnboundedSender<ControlMessage> {
+        self.tx.clone()
+    }
+
+    pub fn broadcast(&mut self, msg: ControlMessage) -> Result<(), CommunicationError> {
+        let iter = self
+            .channels_to_control_senders
+            .values_mut()
+            .chain(self.channels_to_control_receivers.values_mut())
+            .chain(self.channels_to_data_senders.values_mut())
+            .chain(self.channels_to_data_receivers.values_mut());
+        for tx in iter {
+            tx.send(msg.clone()).map_err(CommunicationError::from)?;
+        }
+        Ok(())
+    }
+
+    pub async fn read(&mut self) -> Result<ControlMessage, CommunicationError> {
+        self.rx.recv().await.ok_or(CommunicationError::Disconnected)
+    }
+}

--- a/src/communication/endpoints.rs
+++ b/src/communication/endpoints.rs
@@ -35,9 +35,7 @@ impl<D: Clone + Send + Debug> SendEndpoint<D> {
             Self::InterThread(_) => Err(CommunicationError::DeserializeNotImplemented),
             Self::InterProcess(stream_id, sender) => {
                 let msg = SerializedMessage::new(data, *stream_id);
-                sender
-                    .try_send(msg)
-                    .map_err(CommunicationError::from)
+                sender.send(msg).map_err(CommunicationError::from)
             }
         }
     }

--- a/src/communication/errors.rs
+++ b/src/communication/errors.rs
@@ -38,12 +38,17 @@ impl<T> From<std::sync::mpsc::SendError<T>> for CommunicationError {
     }
 }
 
+impl<T> From<mpsc::error::SendError<T>> for CommunicationError {
+    fn from(_e: mpsc::error::SendError<T>) -> Self {
+        CommunicationError::Disconnected
+    }
+}
+
 impl<T> From<mpsc::error::TrySendError<T>> for CommunicationError {
     fn from(e: mpsc::error::TrySendError<T>) -> Self {
-        if e.is_closed() {
-            CommunicationError::Disconnected
-        } else {
-            CommunicationError::NoCapacity
+        match e {
+            mpsc::error::TrySendError::Closed(_) => CommunicationError::Disconnected,
+            mpsc::error::TrySendError::Full(_) => CommunicationError::NoCapacity,
         }
     }
 }
@@ -57,11 +62,11 @@ impl From<CodecError> for CommunicationError {
     }
 }
 
-impl<T> From<mpsc::error::UnboundedTrySendError<T>> for CommunicationError {
-    fn from(_e: mpsc::error::UnboundedTrySendError<T>) -> Self {
-        CommunicationError::Disconnected
-    }
-}
+// impl<T> From<mpsc::error::TrySendError<T>> for CommunicationError {
+//     fn from(_e: mpsc::error::TrySendError<T>) -> Self {
+//         CommunicationError::Disconnected
+//     }
+// }
 
 /// Error that is raised by the `MessageCodec` when messages cannot be encoded or decoded.
 #[derive(Debug)]

--- a/src/communication/errors.rs
+++ b/src/communication/errors.rs
@@ -62,12 +62,6 @@ impl From<CodecError> for CommunicationError {
     }
 }
 
-// impl<T> From<mpsc::error::TrySendError<T>> for CommunicationError {
-//     fn from(_e: mpsc::error::TrySendError<T>) -> Self {
-//         CommunicationError::Disconnected
-//     }
-// }
-
 /// Error that is raised by the `MessageCodec` when messages cannot be encoded or decoded.
 #[derive(Debug)]
 pub enum CodecError {

--- a/src/communication/message_codec.rs
+++ b/src/communication/message_codec.rs
@@ -1,8 +1,7 @@
 use byteorder::{ByteOrder, NetworkEndian, WriteBytesExt};
 use bytes::{BufMut, BytesMut};
 use std::fmt::Debug;
-use tokio::codec::Decoder;
-use tokio::codec::Encoder;
+use tokio_util::codec::{Encoder, Decoder};
 
 use crate::communication::{CodecError, MessageHeader, SerializedMessage};
 

--- a/src/communication/mod.rs
+++ b/src/communication/mod.rs
@@ -96,7 +96,10 @@ pub async fn create_tcp_streams(
                 node_id,
                 e
             );
-            Vec::new()
+            panic!(
+                "Node {}: creating TCP streams errored with {:?}",
+                node_id, e
+            )
         }
     }
 }

--- a/src/communication/receivers.rs
+++ b/src/communication/receivers.rs
@@ -6,13 +6,17 @@ use std::{
 };
 use tokio::{
     net::TcpStream,
-    sync::{mpsc::UnboundedSender, Mutex},
+    sync::{
+        mpsc::{UnboundedReceiver, UnboundedSender},
+        Mutex,
+    },
 };
 use tokio_util::codec::Framed;
 
 use crate::{
     communication::{
-        CommunicationError, ControlMessage, ControlMessageCodec, MessageCodec, PusherT,
+        CommunicationError, ControlMessage, ControlMessageCodec, ControlMessageHandler,
+        MessageCodec, PusherT,
     },
     dataflow::stream::StreamId,
     node::node::NodeId,
@@ -30,6 +34,10 @@ pub struct DataReceiver {
     rx: mpsc::Receiver<(StreamId, Box<dyn PusherT>)>,
     /// Mapping between stream id to pushers.
     stream_id_to_pusher: HashMap<StreamId, Box<dyn PusherT>>,
+    /// Tokio channel sender to `ControlMessageHandler`.
+    control_tx: UnboundedSender<ControlMessage>,
+    /// Tokio channel receiver from `ControlMessageHandler`.
+    control_rx: UnboundedReceiver<ControlMessage>,
 }
 
 impl DataReceiver {
@@ -37,20 +45,30 @@ impl DataReceiver {
         node_id: NodeId,
         stream: SplitStream<Framed<TcpStream, MessageCodec>>,
         channels_to_receivers: Arc<Mutex<ChannelsToReceivers>>,
+        control_handler: &mut ControlMessageHandler,
     ) -> Self {
         // Create a channel for this stream.
         let (tx, rx) = mpsc::channel();
         // Add entry in the shared state vector.
         channels_to_receivers.lock().await.add_sender(tx);
+        // Set up control channel.
+        let (control_tx, control_rx) = tokio::sync::mpsc::unbounded_channel();
+        control_handler.add_channel_to_data_receiver(node_id, control_tx);
         Self {
             node_id,
             stream,
             rx,
             stream_id_to_pusher: HashMap::new(),
+            control_tx: control_handler.get_channel_to_handler(),
+            control_rx,
         }
     }
 
     pub async fn run(&mut self) -> Result<(), CommunicationError> {
+        // Notify `ControlMessageHandler` that receiver is initialized.
+        self.control_tx
+            .send(ControlMessage::DataReceiverInitialized(self.node_id))
+            .map_err(CommunicationError::from)?;
         while let Some(res) = self.stream.next().await {
             match res {
                 // Push the message to the listening operator executors.
@@ -101,30 +119,40 @@ pub struct ControlReceiver {
     node_id: NodeId,
     /// Framed TCP read stream.
     stream: SplitStream<Framed<TcpStream, ControlMessageCodec>>,
-    /// Mapping between stream id to pushers.
-    channel_to_handler: UnboundedSender<ControlMessage>,
+    /// Tokio channel sender to `ControlMessageHandler`.
+    control_tx: UnboundedSender<ControlMessage>,
+    /// Tokio channel receiver from `ControlMessageHandler`.
+    control_rx: UnboundedReceiver<ControlMessage>,
 }
 
 impl ControlReceiver {
     pub fn new(
         node_id: NodeId,
         stream: SplitStream<Framed<TcpStream, ControlMessageCodec>>,
-        channel_to_handler: UnboundedSender<ControlMessage>,
+        control_handler: &mut ControlMessageHandler,
     ) -> Self {
+        // Set up control channel.
+        let (tx, control_rx) = tokio::sync::mpsc::unbounded_channel();
+        control_handler.add_channel_to_control_receiver(node_id, tx);
         Self {
             node_id,
             stream,
-            channel_to_handler,
+            control_tx: control_handler.get_channel_to_handler(),
+            control_rx,
         }
     }
 
     pub async fn run(&mut self) -> Result<(), CommunicationError> {
-        // TODO: update `self.channel_to_handler` for up-to-date mappings
+        // TODO: update `self.channel_to_handler` for up-to-date mappings.
         // between channels and handlers (e.g. for fault-tolerance).
+        // Notify `ControlMessageHandler` that sender is initialized.
+        self.control_tx
+            .send(ControlMessage::ControlReceiverInitialized(self.node_id))
+            .map_err(CommunicationError::from)?;
         while let Some(res) = self.stream.next().await {
             match res {
                 Ok(msg) => {
-                    self.channel_to_handler
+                    self.control_tx
                         .send(msg)
                         .map_err(CommunicationError::from)?;
                 }

--- a/src/communication/receivers.rs
+++ b/src/communication/receivers.rs
@@ -1,14 +1,14 @@
 use futures::{future, stream::SplitStream};
+use futures_util::stream::StreamExt;
 use std::{
     collections::HashMap,
     sync::{mpsc, Arc},
 };
 use tokio::{
-    codec::Framed,
     net::TcpStream,
-    prelude::*,
     sync::{mpsc::UnboundedSender, Mutex},
 };
+use tokio_util::codec::Framed;
 
 use crate::{
     communication::{
@@ -125,7 +125,7 @@ impl ControlReceiver {
             match res {
                 Ok(msg) => {
                     self.channel_to_handler
-                        .try_send(msg)
+                        .send(msg)
                         .map_err(CommunicationError::from)?;
                 }
                 Err(e) => return Err(CommunicationError::from(e)),

--- a/src/communication/senders.rs
+++ b/src/communication/senders.rs
@@ -4,12 +4,16 @@ use std::sync::Arc;
 use tokio::{
     self,
     net::TcpStream,
-    sync::{mpsc, mpsc::UnboundedReceiver, Mutex},
+    sync::{
+        mpsc::{self, UnboundedReceiver, UnboundedSender},
+        Mutex,
+    },
 };
 use tokio_util::codec::Framed;
 
 use crate::communication::{
-    CommunicationError, ControlMessage, ControlMessageCodec, MessageCodec, SerializedMessage,
+    CommunicationError, ControlMessage, ControlMessageCodec, ControlMessageHandler, MessageCodec,
+    SerializedMessage,
 };
 use crate::node::node::NodeId;
 use crate::scheduler::endpoints_manager::ChannelsToSenders;
@@ -23,6 +27,10 @@ pub struct DataSender {
     sink: SplitSink<Framed<TcpStream, MessageCodec>, SerializedMessage>,
     /// Tokio channel receiver on which to receive data from worker threads.
     rx: UnboundedReceiver<SerializedMessage>,
+    /// Tokio channel sender to `ControlMessageHandler`.
+    control_tx: UnboundedSender<ControlMessage>,
+    /// Tokio channel receiver from `ControlMessageHandler`.
+    control_rx: UnboundedReceiver<ControlMessage>,
 }
 
 impl DataSender {
@@ -30,15 +38,30 @@ impl DataSender {
         node_id: NodeId,
         sink: SplitSink<Framed<TcpStream, MessageCodec>, SerializedMessage>,
         channels_to_senders: Arc<Mutex<ChannelsToSenders>>,
+        control_handler: &mut ControlMessageHandler,
     ) -> Self {
         // Create a channel for this stream.
         let (tx, rx) = mpsc::unbounded_channel();
         // Add entry in the shared state map.
         channels_to_senders.lock().await.add_sender(node_id, tx);
-        Self { node_id, sink, rx }
+        // Set up control channel.
+        let (control_tx, control_rx) = mpsc::unbounded_channel();
+        control_handler.add_channel_to_data_sender(node_id, control_tx);
+        Self {
+            node_id,
+            sink,
+            rx,
+            control_tx: control_handler.get_channel_to_handler(),
+            control_rx,
+        }
     }
 
     pub async fn run(&mut self) -> Result<(), CommunicationError> {
+        // Notify `ControlMessageHandler` that sender is initialized.
+        self.control_tx
+            .send(ControlMessage::DataSenderInitialized(self.node_id))
+            .map_err(CommunicationError::from)?;
+        // TODO: listen on control_rx
         loop {
             match self.rx.recv().await {
                 Some(msg) => {
@@ -72,18 +95,39 @@ pub struct ControlSender {
     sink: SplitSink<Framed<TcpStream, ControlMessageCodec>, ControlMessage>,
     /// Tokio channel receiver on which to receive data from worker threads.
     rx: UnboundedReceiver<ControlMessage>,
+    /// Tokio channel sender to `ControlMessageHandler`.
+    control_tx: UnboundedSender<ControlMessage>,
+    /// Channel receiver for control messages intended for this `ControlSender`.
+    control_rx: UnboundedReceiver<ControlMessage>,
 }
 
 impl ControlSender {
     pub fn new(
         node_id: NodeId,
         sink: SplitSink<Framed<TcpStream, ControlMessageCodec>, ControlMessage>,
-        rx: UnboundedReceiver<ControlMessage>,
+        control_handler: &mut ControlMessageHandler,
     ) -> Self {
-        Self { node_id, sink, rx }
+        // Set up channel to other node.
+        let (tx, rx) = mpsc::unbounded_channel();
+        control_handler.add_channel_to_node(node_id, tx);
+        // Set up control channel.
+        let (control_tx, control_rx) = mpsc::unbounded_channel();
+        control_handler.add_channel_to_control_sender(node_id, control_tx);
+        Self {
+            node_id,
+            sink,
+            rx,
+            control_tx: control_handler.get_channel_to_handler(),
+            control_rx,
+        }
     }
 
     pub async fn run(&mut self) -> Result<(), CommunicationError> {
+        // Notify `ControlMessageHandler` that sender is initialized.
+        self.control_tx
+            .send(ControlMessage::ControlSenderInitialized(self.node_id))
+            .map_err(CommunicationError::from)?;
+        // TODO: listen on control_rx
         loop {
             match self.rx.recv().await {
                 Some(msg) => {

--- a/src/communication/serializable.rs
+++ b/src/communication/serializable.rs
@@ -27,7 +27,9 @@ where
 {
     default fn encode(&self) -> Result<BytesMut, CommunicationError> {
         let serialized_msg = bincode::serialize(self).map_err(|e| CommunicationError::from(e))?;
-        let serialized_msg: BytesMut = BytesMut::from(serialized_msg);
+        // TODO: check whether this introduces extra copies
+        // On v0.5.4, BytesMut does not implement From<Vec<u8>>
+        let serialized_msg: BytesMut = BytesMut::from(&serialized_msg[..]);
         Ok(serialized_msg)
     }
 
@@ -50,7 +52,9 @@ where
             encode(self, &mut serialized_msg)
                 .map_err(|e| CommunicationError::AbomonationError(e))?;
         }
-        let serialized_msg: BytesMut = BytesMut::from(serialized_msg);
+        // TODO: check whether this introduces extra copies
+        // On v0.5.4, BytesMut does not implement From<Vec<u8>>
+        let serialized_msg: BytesMut = BytesMut::from(&serialized_msg[..]);
         Ok(serialized_msg)
     }
 

--- a/src/dataflow/message.rs
+++ b/src/dataflow/message.rs
@@ -26,6 +26,16 @@ impl<D: Data> Message<D> {
     }
 }
 
+impl<D: Data + PartialEq> PartialEq for Message<D> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::TimestampedData(d1), Self::TimestampedData(d2)) => d1 == d2,
+            (Self::Watermark(w1), Self::Watermark(w2)) => w1 == w2,
+            _ => false,
+        }
+    }
+}
+
 /// Data message which operators send along streams.
 #[derive(Debug, Clone, Serialize, Deserialize, Abomonation)]
 pub struct TimestampedData<D: Data> {
@@ -38,6 +48,12 @@ pub struct TimestampedData<D: Data> {
 impl<D: Data> TimestampedData<D> {
     pub fn new(timestamp: Timestamp, data: D) -> Self {
         Self { timestamp, data }
+    }
+}
+
+impl<D: Data + PartialEq> PartialEq for TimestampedData<D> {
+    fn eq(&self, other: &Self) -> bool {
+        self.timestamp == other.timestamp && self.data == other.data
     }
 }
 

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -45,12 +45,13 @@ impl Node {
     /// Creates a new node.
     pub fn new(config: Configuration) -> Self {
         let id = config.index;
+        let logger = config.logger.clone();
         Self {
             config,
             id,
             channels_to_receivers: Arc::new(Mutex::new(ChannelsToReceivers::new())),
             channels_to_senders: Arc::new(Mutex::new(ChannelsToSenders::new())),
-            control_handler: ControlMessageHandler::new(),
+            control_handler: ControlMessageHandler::new(logger),
             initialized: Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new())),
         }
     }

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -6,11 +6,7 @@ use std::{
     thread,
     time::Duration,
 };
-use tokio::{
-    net::TcpStream,
-    runtime::Builder,
-    sync::{mpsc, Mutex},
-};
+use tokio::{net::TcpStream, runtime::Builder, sync::Mutex};
 use tokio_util::codec::Framed;
 
 use crate::communication::{
@@ -39,6 +35,10 @@ pub struct Node {
     channels_to_receivers: Arc<Mutex<ChannelsToReceivers>>,
     /// Structure to be used to send messages to sender threads.
     channels_to_senders: Arc<Mutex<ChannelsToSenders>>,
+    /// Structure used to send and receive control messages.
+    control_handler: ControlMessageHandler,
+    /// Used to block `run_async` until setup is complete for the driver to continue running safely.
+    initialized: Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
 }
 
 impl Node {
@@ -50,6 +50,8 @@ impl Node {
             id,
             channels_to_receivers: Arc::new(Mutex::new(ChannelsToReceivers::new())),
             channels_to_senders: Arc::new(Mutex::new(ChannelsToSenders::new())),
+            control_handler: ControlMessageHandler::new(),
+            initialized: Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new())),
         }
     }
 
@@ -75,10 +77,26 @@ impl Node {
     pub fn run_async(mut self) {
         // Copy dataflow graph to the other thread
         let graph = default_graph::clone();
+        let initialized = self.initialized.clone();
         thread::spawn(move || {
             default_graph::set(graph);
             self.run();
         });
+        // Wait for ERDOS to start up.
+        let (lock, cvar) = &*initialized;
+        let mut started = lock.lock().unwrap();
+        while !*started {
+            started = cvar.wait(started).unwrap();
+        }
+    }
+
+    fn set_node_initialized(&mut self) {
+        let (lock, cvar) = &*self.initialized;
+        let mut started = lock.lock().unwrap();
+        *started = true;
+        cvar.notify_all();
+
+        debug!(self.config.logger, "Notfiying node initialized");
     }
 
     /// Splits a vector of TCPStreams into `DataSender`s and `DataReceiver`s.
@@ -94,30 +112,36 @@ impl Node {
             let (split_sink, split_stream) = framed.split();
             // Create an ERDOS receiver for the stream half.
             stream_halves.push(
-                DataReceiver::new(node_id, split_stream, self.channels_to_receivers.clone()).await,
+                DataReceiver::new(
+                    node_id,
+                    split_stream,
+                    self.channels_to_receivers.clone(),
+                    &mut self.control_handler,
+                )
+                .await,
             );
 
             // Create an ERDOS sender for the sink half.
-            sink_halves
-                .push(DataSender::new(node_id, split_sink, self.channels_to_senders.clone()).await);
+            sink_halves.push(
+                DataSender::new(
+                    node_id,
+                    split_sink,
+                    self.channels_to_senders.clone(),
+                    &mut self.control_handler,
+                )
+                .await,
+            );
         }
         (sink_halves, stream_halves)
     }
 
     /// Splits a vector of TCPStreams into `ControlMessageHandler`, `ControlSender`s and `ControlReceiver`s.
     async fn split_control_streams(
-        &self,
+        &mut self,
         streams: Vec<(NodeId, TcpStream)>,
-    ) -> (
-        ControlMessageHandler,
-        Vec<ControlSender>,
-        Vec<ControlReceiver>,
-    ) {
+    ) -> (Vec<ControlSender>, Vec<ControlReceiver>) {
         let mut control_receivers = Vec::new();
         let mut control_senders = Vec::new();
-        let (handler_tx, handler_rx) = mpsc::unbounded_channel();
-
-        let mut channels_to_senders = HashMap::new();
 
         for (node_id, stream) in streams {
             // Use the message codec to divide the TCP stream data into messages.
@@ -127,21 +151,62 @@ impl Node {
             control_receivers.push(ControlReceiver::new(
                 node_id,
                 split_stream,
-                handler_tx.clone(),
+                &mut self.control_handler,
             ));
             // Create an control sender for the sink half.
-            let (tx, rx) = mpsc::unbounded_channel();
-            control_senders.push(ControlSender::new(node_id, split_sink, rx));
-            channels_to_senders.insert(node_id, tx);
+            control_senders.push(ControlSender::new(
+                node_id,
+                split_sink,
+                &mut self.control_handler,
+            ));
         }
 
-        let control_handler = ControlMessageHandler::new(channels_to_senders, handler_rx);
+        (control_senders, control_receivers)
+    }
 
-        (control_handler, control_senders, control_receivers)
+    async fn wait_for_communication_layer_initialized(&mut self) -> Result<(), String> {
+        let num_nodes = self.config.data_addresses.len();
+
+        let mut control_senders_initialized = HashSet::new();
+        control_senders_initialized.insert(self.id);
+        let mut control_receivers_initialized = HashSet::new();
+        control_receivers_initialized.insert(self.id);
+        let mut data_senders_initialized = HashSet::new();
+        data_senders_initialized.insert(self.id);
+        let mut data_receivers_initialized = HashSet::new();
+        data_receivers_initialized.insert(self.id);
+
+        while control_senders_initialized.len() < num_nodes
+            || control_receivers_initialized.len() < num_nodes
+            || data_senders_initialized.len() < num_nodes
+            || data_receivers_initialized.len() < num_nodes
+        {
+            let msg = self
+                .control_handler
+                .read()
+                .await
+                .map_err(|e| format!("Error receiving control message: {:?}", e))?;
+            match msg {
+                ControlMessage::ControlSenderInitialized(node_id) => {
+                    control_senders_initialized.insert(node_id);
+                }
+                ControlMessage::ControlReceiverInitialized(node_id) => {
+                    control_receivers_initialized.insert(node_id);
+                }
+                ControlMessage::DataSenderInitialized(node_id) => {
+                    data_senders_initialized.insert(node_id);
+                }
+                ControlMessage::DataReceiverInitialized(node_id) => {
+                    data_receivers_initialized.insert(node_id);
+                }
+                _ => (),
+            };
+        }
+        Ok(())
     }
 
     async fn wait_for_local_operators_initialized(
-        &self,
+        &mut self,
         rx_from_operators: std::sync::mpsc::Receiver<ControlMessage>,
         num_local_operators: usize,
     ) {
@@ -153,24 +218,18 @@ impl Node {
         }
     }
 
-    async fn broadcast_local_operators_initialized(
-        &self,
-        control_handler: &mut ControlMessageHandler,
-    ) -> Result<(), String> {
-        control_handler
-            .broadcast(ControlMessage::AllOperatorsInitializedOnNode(self.id))
+    async fn broadcast_local_operators_initialized(&mut self) -> Result<(), String> {
+        self.control_handler
+            .broadcast_to_nodes(ControlMessage::AllOperatorsInitializedOnNode(self.id))
             .map_err(|e| format!("Error broadcasting control message: {:?}", e))
     }
 
-    async fn wait_for_all_operators_initialized(
-        &self,
-        control_handler: &mut ControlMessageHandler,
-    ) -> Result<(), String> {
+    async fn wait_for_all_operators_initialized(&mut self) -> Result<(), String> {
         let num_nodes = self.config.data_addresses.len();
         let mut initialized_nodes = HashSet::new();
         initialized_nodes.insert(self.id);
         while initialized_nodes.len() < num_nodes {
-            match control_handler.read().await {
+            match self.control_handler.read().await {
                 Ok(ControlMessage::AllOperatorsInitializedOnNode(node_id)) => {
                     initialized_nodes.insert(node_id);
                 }
@@ -183,10 +242,9 @@ impl Node {
         Ok(())
     }
 
-    async fn run_operators(
-        &mut self,
-        mut control_handler: ControlMessageHandler,
-    ) -> Result<(), String> {
+    async fn run_operators(&mut self) -> Result<(), String> {
+        self.wait_for_communication_layer_initialized().await?;
+
         let graph = scheduler::schedule(&default_graph::clone());
 
         let channel_manager = ChannelManager::new(
@@ -224,25 +282,25 @@ impl Node {
             });
         }
 
-        // Wait for all operators to finish setting up
+        // Wait for all operators to finish setting up.
         self.wait_for_local_operators_initialized(rx_from_operators, num_local_operators)
             .await;
-        // Broadcast all operators initialized on current node
-        self.broadcast_local_operators_initialized(&mut control_handler)
-            .await?;
-        // Wait for all other nodes to finish setting up
-        self.wait_for_all_operators_initialized(&mut control_handler)
-            .await?;
-        // Tell all operators to run
-        for (op_id, tx) in channels_to_operators {
-            tx.send(ControlMessage::RunOperator(op_id))
-                .map_err(|e| format!("Error telling operator to run: {}", e))?;
-        }
+        // Broadcast all operators initialized on current node.
+        self.broadcast_local_operators_initialized().await?;
+        // Wait for all other nodes to finish setting up.
+        self.wait_for_all_operators_initialized().await?;
         // Setup driver on the current node.
         if let Some(driver) = graph.get_driver(self.id) {
             for setup_hook in driver.setup_hooks {
                 (setup_hook)(Arc::clone(&channel_manager));
             }
+        }
+        // Tell driver to run.
+        self.set_node_initialized();
+        // Tell all operators to run.
+        for (op_id, tx) in channels_to_operators {
+            tx.send(ControlMessage::RunOperator(op_id))
+                .map_err(|e| format!("Error telling operator to run: {}", e))?;
         }
 
         Ok(())
@@ -262,7 +320,7 @@ impl Node {
             &self.config.logger,
         )
         .await;
-        let (control_handler, control_senders, control_receivers) =
+        let (control_senders, control_receivers) =
             self.split_control_streams(control_streams).await;
         let (senders, receivers) = self.split_data_streams(data_streams).await;
         // Execute threads that send data to other nodes.
@@ -272,7 +330,7 @@ impl Node {
         let control_recvs_fut = receivers::run_control_receivers(control_receivers);
         let recvs_fut = receivers::run_receivers(receivers);
         // Execute operators.
-        let ops_fut = self.run_operators(control_handler);
+        let ops_fut = self.run_operators();
         // These threads only complete when a failure happens.
         let (senders_res, receivers_res, control_senders_res, control_receiver_res, ops_res) =
             future::join5(

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -43,6 +43,7 @@ impl<D: Data> OperatorExecutorStream<D> {
     }
 }
 
+#[allow(dead_code)]
 pub struct OperatorExecutor {
     operator_streams: Vec<Box<dyn OperatorExecutorStreamT>>,
     // Priority queue that sorts events by priority and timestamp.

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -233,22 +233,24 @@ if flow_watermarks and len(read_streams) > 0 and len(write_streams) > 0:
 
     #[pyfn(m, "run_async")]
     fn run_async_py(
-        _py: Python,
+        py: Python,
         node_id: NodeId,
         data_addresses: Vec<String>,
         control_addresses: Vec<String>,
     ) -> PyResult<()> {
-        let data_addresses = data_addresses
-            .into_iter()
-            .map(|s| s.parse().expect("Unable to parse socket address"))
-            .collect();
-        let control_addresses = control_addresses
-            .into_iter()
-            .map(|s| s.parse().expect("Unable to parse socket address"))
-            .collect();
-        let config = Configuration::new(node_id, data_addresses, control_addresses, 7);
-        let node = Node::new(config);
-        node.run_async();
+        py.allow_threads(move || {
+            let data_addresses = data_addresses
+                .into_iter()
+                .map(|s| s.parse().expect("Unable to parse socket address"))
+                .collect();
+            let control_addresses = control_addresses
+                .into_iter()
+                .map(|s| s.parse().expect("Unable to parse socket address"))
+                .collect();
+            let config = Configuration::new(node_id, data_addresses, control_addresses, 7);
+            let node = Node::new(config);
+            node.run_async();
+        });
         Ok(())
     }
 

--- a/src/scheduler/channel_manager.rs
+++ b/src/scheduler/channel_manager.rs
@@ -184,10 +184,13 @@ impl ChannelManager {
                                     graph.get_operator(op_id).unwrap().node_id
                                 }
                             };
-                            stream_endpoint_t.add_inter_node_send_endpoint(
-                                other_node_id,
-                                Arc::clone(&channels_to_senders),
-                            ).await.unwrap();
+                            stream_endpoint_t
+                                .add_inter_node_send_endpoint(
+                                    other_node_id,
+                                    Arc::clone(&channels_to_senders),
+                                )
+                                .await
+                                .unwrap();
                         }
                         Channel::InterThread(_) => {
                             stream_endpoint_t.add_inter_thread_channel();

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -134,11 +134,16 @@ fn test_extract() {
 
     node.run_async();
 
-    for _ in 0..5 {
-        let result = extract_stream.read();
+    for count in 0..5 {
+        let msg = extract_stream.read();
+        assert_eq!(
+            msg,
+            Some(Message::new_message(
+                Timestamp::new(vec![count as u64]),
+                count as usize
+            ))
+        );
     }
-
-    thread::sleep(std::time::Duration::from_millis(1000));
 }
 
 #[test]


### PR DESCRIPTION
This PR expands the control plane via the `ControlMessageHandler` by adding channels to and from `ControlSenders`, `ControlReceivers` `DataSenders` and `DataReceivers`.

The PR uses these changes to block on sender/receiver setup before running the driver and operators. Doing this fixes #61, as well as the un-reported "could not clone channel to node" issue.

Also fixes Python bugs that appeared when running `erdos.run_async`. This bug previously affected Python ingest and extract streams.

Finally, upgrades several libraries (notably tokio and futures) to the latest stable versions.