### PR TITLE
Bug fix in run_async python interface.

### DIFF
--- a/python/erdos/__init__.py
+++ b/python/erdos/__init__.py
@@ -120,11 +120,11 @@ def run_async(driver, start_port=9000):
 
     data_addresses = [
         "127.0.0.1:{port}".format(port=start_port + i)
-        for i in range(_num_py_operators + 1)
+        for i in range(_num_py_operators)
     ]
     control_addresses = [
         "127.0.0.1:{port}".format(port=start_port + len(data_addresses) + i)
-        for i in range(_num_py_operators + 1)
+        for i in range(_num_py_operators)
     ]
 
     def runner(driver, node_id, data_addresses, control_addresses):
@@ -134,7 +134,7 @@ def run_async(driver, start_port=9000):
     processes = [
         mp.Process(target=runner,
                    args=(driver, i, data_addresses, control_addresses))
-        for i in range(1, _num_py_operators + 1)
+        for i in range(1, len(data_addresses))
     ]
 
     # Needed to shut down child processes

--- a/python/examples/ingest_extract.py
+++ b/python/examples/ingest_extract.py
@@ -21,10 +21,25 @@ class SquareOp(erdos.Operator):
         return [erdos.WriteStream()]
 
 
+class NoOperationOp(erdos.Operator):
+    def __init__(self, read_stream, write_stream):
+        read_stream.add_callback(self.callback, [write_stream])
+
+    @staticmethod
+    def connect(read_streams):
+        return [erdos.WriteStream()]
+
+    def callback(self, msg, write_stream):
+        write_stream.send(msg)
+
+
 def driver():
     ingest_stream = erdos.IngestStream()
     (square_stream, ) = erdos.connect(SquareOp, [ingest_stream])
-    extract_stream = erdos.ExtractStream(square_stream)
+    # Introduced an operator that proceesses the output of a stream
+    # created by the operator defined in the driver.
+    (new_square_stream, ) = erdos.connect(NoOperationOp, [square_stream])
+    extract_stream = erdos.ExtractStream(new_square_stream)
 
     return ingest_stream, extract_stream
 


### PR DESCRIPTION
The additional internal operator causes the ingest_extract integration test to fail with a panic.