### PR TITLE
Fix race condition in system initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rand = "0.3"
 serde = { version = "1.0.99", features = ["derive"] }
 slog = "2.4.2"
 slog-term = "2.4.2"
-tokio = { version = "0.2.11", features = ["sync", "tcp", "io-util", "rt-core", "rt-threaded"] }
+tokio = { version = "0.2.11", features = ["sync", "tcp", "io-util", "rt-core", "rt-threaded", "time"] }
 tokio-util = { version = "0.2.0", features = ["codec"] }
 tokio-serde-bincode = "0.2"
 uuid = { version = "0.7", features = ["v4", "v5", "serde"] }

--- a/python/erdos/__init__.py
+++ b/python/erdos/__init__.py
@@ -32,9 +32,11 @@ def connect(op_type, read_streams, flow_watermarks=True, *args, **kwargs):
         write_streams (list of WriteStream): the streams on which the operator
             sends data.
     """
+    # 1-index operators because node 0 is preserved for the current process,
+    # and each node can only run 1 python operator.
     global _num_py_operators
-    node_id = _num_py_operators
     _num_py_operators += 1
+    node_id = _num_py_operators
 
     py_read_streams = []
     for stream in read_streams:
@@ -71,11 +73,11 @@ def run(driver, start_port=9000):
 
     data_addresses = [
         "127.0.0.1:{port}".format(port=start_port + i)
-        for i in range(_num_py_operators)
+        for i in range(_num_py_operators + 1)
     ]
     control_addresses = [
         "127.0.0.1:{port}".format(port=start_port + len(data_addresses) + i)
-        for i in range(_num_py_operators)
+        for i in range(_num_py_operators + 1)
     ]
 
     def runner(driver, node_id, data_addresses, control_addresses):
@@ -85,7 +87,7 @@ def run(driver, start_port=9000):
     processes = [
         mp.Process(target=runner,
                    args=(driver, i, data_addresses, control_addresses))
-        for i in range(_num_py_operators)
+        for i in range(1, _num_py_operators + 1)
     ]
 
     for p in processes:
@@ -98,6 +100,8 @@ def run(driver, start_port=9000):
         sys.exit(0)
 
     signal.signal(signal.SIGINT, sigint_handler)
+
+    _internal.run_async(0, data_addresses, control_addresses)
 
     for p in processes:
         p.join()
@@ -128,6 +132,9 @@ def run_async(driver, start_port=9000):
     ]
 
     def runner(driver, node_id, data_addresses, control_addresses):
+        if node_id == 3:
+            import time
+            time.sleep(0.3)
         driver()
         _internal.run(node_id, data_addresses, control_addresses)
 

--- a/python/erdos/__init__.py
+++ b/python/erdos/__init__.py
@@ -132,9 +132,6 @@ def run_async(driver, start_port=9000):
     ]
 
     def runner(driver, node_id, data_addresses, control_addresses):
-        if node_id == 3:
-            import time
-            time.sleep(0.3)
         driver()
         _internal.run(node_id, data_addresses, control_addresses)
 

--- a/src/communication/mod.rs
+++ b/src/communication/mod.rs
@@ -23,12 +23,12 @@ use futures::future;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::net::SocketAddr;
-use std::thread::sleep;
 use std::time::Duration;
 use tokio::{
     io::AsyncWriteExt,
     net::{TcpListener, TcpStream},
     prelude::*,
+    time::delay_for,
 };
 
 use crate::{dataflow::stream::StreamId, node::node::NodeId, OperatorId};
@@ -160,7 +160,7 @@ async fn connect_to_node(
                     "could not connect to {}; error {}; retrying in 100 ms", dst_addr, e
                 );
                 // Wait a bit until it tries to connect again.
-                sleep(Duration::from_millis(100));
+                delay_for(Duration::from_millis(100)).await;
             }
         }
     }


### PR DESCRIPTION
The race condition occurs on multi-node (3+) setups when one node initializes slightly faster than the others. Messages were assumed to arrive in a specific order; however, messages were reordered if a node initialized before the others which led to messages mistakenly being dropped.

Closes #63 