### PR TITLE
Bug fix in the low watermark computation.

### DIFF
--- a/src/dataflow/message.rs
+++ b/src/dataflow/message.rs
@@ -72,4 +72,10 @@ impl IntTimestamp {
     pub fn new(time: Vec<u64>) -> Self {
         Self { time }
     }
+
+    pub fn top(&self) -> Self {
+        Self {
+            time: vec![std::u64::MAX; self.time.len()],
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes a bug in the low watermark computation. Previously, the watermark callback would not be invoked in the following situations:
1. Operator receives on stream 1 a watermark for timestamp t.
2. Operator receives on stream 2 a watermark for timestamp t + 1.

This PR ensures that we first compute the previous low watermark across all streams, update the low watermark on the stream we've received a watermark, and computes the new low watermark across all streams. The watermark callback is invoked if the new low watermark is higher that the previous low watermark.