### PR TITLE
Verify that corresponding types in `new()` and `connect()` match

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,11 @@ macro_rules! register {
             config.id = OperatorId::new_deterministic();
             let config_copy = config.clone();
 
+            // No-op that throws compile-time error if types in `new` and `connect` don't match.
+            if false {
+                $crate::make_operator!($t, config.clone(), ($($rs),*), ($($ws),*));
+            }
+
             // Add operator to dataflow graph.
             let read_stream_ids = vec![$($rs.get_id()),*];
             let write_stream_ids = vec![$($ws.get_id()),*];


### PR DESCRIPTION
I couldn't find a better way to do this type checking at compile time -- the closest I got was [`std::compile_error`](https://doc.rust-lang.org/std/macro.compile_error.html), but I couldn't find a way to interface this with the type checking.