### PR TITLE
Move streams and operator executor to Tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rand = "0.3"
 serde = { version = "1.0.99", features = ["derive"] }
 slog = "2.4.2"
 slog-term = "2.4.2"
-tokio = { version = "0.2.11", features = ["sync", "tcp", "io-util", "rt-core", "rt-threaded", "time", "macros"] }
+tokio = { version = "0.2.11", features = ["sync", "tcp", "io-util", "rt-core", "rt-threaded", "time", "macros", "stream"] }
 tokio-util = { version = "0.2.0", features = ["codec"] }
 tokio-serde-bincode = "0.2"
 uuid = { version = "0.7", features = ["v4", "v5", "serde"] }

--- a/experiments/throughput_driver.rs
+++ b/experiments/throughput_driver.rs
@@ -234,11 +234,7 @@ pub struct PullRecvOp {
 }
 
 impl PullRecvOp {
-    pub fn new(
-        _name: &str,
-        config: OperatorConfig<(usize, usize)>,
-        read_stream: ReadStream<Vec<u8>>,
-    ) -> Self {
+    pub fn new(config: OperatorConfig<(usize, usize)>, read_stream: ReadStream<Vec<u8>>) -> Self {
         let (num_total_messages, message_size) = config.arg;
         Self {
             num_total_messages,
@@ -348,8 +344,8 @@ fn main() {
         true,
         recv_node,
     );
-    connect_0_write!(RecvOperator, recv_config, s);
-    // connect_0_write!(PullRecvOp, recv_node, (num_messages, message_size), s);
+    // connect_0_write!(RecvOperator, recv_config, s);
+    connect_0_write!(PullRecvOp, recv_config, s);
 
     node.run();
 }

--- a/experiments/throughput_driver.rs
+++ b/experiments/throughput_driver.rs
@@ -344,8 +344,8 @@ fn main() {
         true,
         recv_node,
     );
-    // connect_0_write!(RecvOperator, recv_config, s);
-    connect_0_write!(PullRecvOp, recv_config, s);
+    connect_0_write!(RecvOperator, recv_config, s);
+    // connect_0_write!(PullRecvOp, recv_config, s);
 
     node.run();
 }

--- a/src/communication/errors.rs
+++ b/src/communication/errors.rs
@@ -93,11 +93,11 @@ pub enum TryRecvError {
     BincodeError(bincode::Error),
 }
 
-impl From<std::sync::mpsc::TryRecvError> for TryRecvError {
-    fn from(e: std::sync::mpsc::TryRecvError) -> Self {
+impl From<mpsc::error::TryRecvError> for TryRecvError {
+    fn from(e: mpsc::error::TryRecvError) -> Self {
         match e {
-            std::sync::mpsc::TryRecvError::Disconnected => TryRecvError::Disconnected,
-            std::sync::mpsc::TryRecvError::Empty => TryRecvError::Empty,
+            mpsc::error::TryRecvError::Closed => TryRecvError::Disconnected,
+            mpsc::error::TryRecvError::Empty => TryRecvError::Empty,
         }
     }
 }

--- a/src/communication/pusher.rs
+++ b/src/communication/pusher.rs
@@ -1,5 +1,6 @@
 use bytes::BytesMut;
 use serde::Deserialize;
+use std::fmt;
 use std::{any::Any, fmt::Debug};
 
 use crate::{
@@ -75,5 +76,11 @@ where
             }
         }
         Ok(())
+    }
+}
+
+impl fmt::Debug for Box<dyn PusherT> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Box<dyn PusheT> {{ }}")
     }
 }

--- a/src/dataflow/graph/mod.rs
+++ b/src/dataflow/graph/mod.rs
@@ -1,7 +1,6 @@
-use std::sync::{
-    mpsc::{Receiver, Sender},
-    Arc, Mutex,
-};
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::{
     communication::ControlMessage, node::operator_executor::OperatorExecutor,
@@ -21,8 +20,8 @@ pub trait OperatorRunner:
     'static
     + (Fn(
         Arc<Mutex<ChannelManager>>,
-        Sender<ControlMessage>,
-        Receiver<ControlMessage>,
+        UnboundedSender<ControlMessage>,
+        UnboundedReceiver<ControlMessage>,
     ) -> OperatorExecutor)
     + Sync
     + Send
@@ -34,8 +33,8 @@ impl<
         T: 'static
             + (Fn(
                 Arc<Mutex<ChannelManager>>,
-                Sender<ControlMessage>,
-                Receiver<ControlMessage>,
+                UnboundedSender<ControlMessage>,
+                UnboundedReceiver<ControlMessage>,
             ) -> OperatorExecutor)
             + Sync
             + Send

--- a/src/dataflow/stream/ingest_stream.rs
+++ b/src/dataflow/stream/ingest_stream.rs
@@ -21,6 +21,7 @@ where
     id: StreamId,
     name: String,
     node_id: NodeId,
+    // Use a std mutex because the driver doesn't run on the tokio runtime.
     write_stream_option: Arc<Mutex<Option<WriteStream<D>>>>,
 }
 

--- a/src/dataflow/stream/internal_read_stream.rs
+++ b/src/dataflow/stream/internal_read_stream.rs
@@ -89,6 +89,10 @@ impl<D: Data> InternalReadStream<D> {
             .push(Rc::clone(&child) as Rc<RefCell<dyn EventMakerT<EventDataType = D>>>);
         child
     }
+
+    pub fn take_endpoint(&mut self) -> Option<RecvEndpoint<Message<D>>> {
+        self.recv_endpoint.take()
+    }
 }
 
 impl<D: Data> Default for InternalReadStream<D> {

--- a/src/dataflow/stream/internal_read_stream.rs
+++ b/src/dataflow/stream/internal_read_stream.rs
@@ -1,8 +1,5 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
-use futures::task::Poll;
-use std::future::Future;
-
 use crate::{
     communication::{RecvEndpoint, TryRecvError},
     dataflow::{Data, Message, State, Timestamp},

--- a/src/dataflow/stream/write_stream.rs
+++ b/src/dataflow/stream/write_stream.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use abomonation::Abomonation;
 use serde::Deserialize;
 
@@ -91,6 +93,16 @@ impl<D: Data> WriteStream<D> {
 impl<D: Data> Default for WriteStream<D> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<D: Data> fmt::Debug for WriteStream<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "WriteStream {{ id: {}, low_watermark: {:?} }}",
+            self.id, self.low_watermark
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ macro_rules! make_operator_runner {
             )*
             // After: $rs is an identifier pointing to a read stream's StreamId
             // $ws is an identifier pointing to a write stream's StreamId
-            move |channel_manager: Arc<Mutex<ChannelManager>>, control_sender: Sender<ControlMessage>, control_receiver: Receiver<ControlMessage>| {
+            move |channel_manager: Arc<Mutex<ChannelManager>>, control_sender: UnboundedSender<ControlMessage>, mut control_receiver: UnboundedReceiver<ControlMessage>| {
                 let mut op_ex_streams: Vec<Box<dyn Send + Stream<Item = Vec<OperatorEvent>>>> = Vec::new();
                 // Before: $rs is an identifier pointing to a read stream's StreamId
                 // $ws is an identifier pointing to a write stream's StreamId
@@ -156,7 +156,7 @@ macro_rules! make_operator_runner {
                 }
                 // Wait for control message to run
                 loop {
-                    if let Ok(ControlMessage::RunOperator(id)) = control_receiver.recv() {
+                    if let Ok(ControlMessage::RunOperator(id)) = control_receiver.try_recv() {
                         if id == config.id {
                             break;
                         }
@@ -181,16 +181,14 @@ macro_rules! imports {
         use std::{
             cell::RefCell,
             rc::Rc,
-            sync::{
-                mpsc::{self, Receiver, Sender},
-                Arc, Mutex,
-            },
+            sync::{Arc, Mutex},
             thread,
             time::Duration,
         };
         extern crate slog;
         extern crate tokio;
         use tokio::stream::Stream;
+        use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
         use $crate::{
             self,
             communication::ControlMessage,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,8 @@ macro_rules! make_operator_runner {
 #[macro_export]
 macro_rules! imports {
     () => {
+        extern crate slog;
+        extern crate tokio;
         use std::{
             cell::RefCell,
             rc::Rc,
@@ -185,10 +187,10 @@ macro_rules! imports {
             thread,
             time::Duration,
         };
-        extern crate slog;
-        extern crate tokio;
-        use tokio::stream::Stream;
-        use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+        use tokio::{
+            stream::Stream,
+            sync::mpsc::{UnboundedReceiver, UnboundedSender},
+        };
         use $crate::{
             self,
             communication::ControlMessage,

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -379,9 +379,3 @@ impl Node {
         }
     }
 }
-
-impl Drop for Node {
-    fn drop(&mut self) {
-        eprintln!("dropping Node");
-    }
-}

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -62,7 +62,6 @@ impl Node {
         // Build a runtime with n threads.
         let mut runtime = Builder::new()
             .threaded_scheduler()
-            .core_threads(self.config.num_worker_threads)
             .thread_name(format!("node-{}", self.id))
             .enable_all()
             .build()

--- a/src/node/operator_event.rs
+++ b/src/node/operator_event.rs
@@ -32,6 +32,8 @@ impl OperatorEvent {
     }
 }
 
+unsafe impl Send for OperatorEvent {}
+
 // Explicitly implement trait so that the Binary heap in which OperatorEvents are
 // stored becomes a min-heap instead of a max-heap.
 impl Eq for OperatorEvent {}

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -1,7 +1,11 @@
-use std::cell::RefCell;
-use std::collections::BinaryHeap;
-use std::rc::Rc;
-use std::sync::Arc;
+use std::{
+    cell::RefCell,
+    collections::BinaryHeap,
+    pin::Pin,
+    rc::Rc,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use tokio::{
     self,
@@ -9,12 +13,11 @@ use tokio::{
     sync::{watch, Mutex},
 };
 
-use crate::communication::RecvEndpoint;
-use crate::dataflow::{stream::InternalReadStream, Data, EventMakerT, Message, ReadStream};
-use crate::node::operator_event::OperatorEvent;
-
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use crate::{
+    communication::RecvEndpoint,
+    dataflow::{stream::InternalReadStream, Data, EventMakerT, Message, ReadStream},
+    node::operator_event::OperatorEvent,
+};
 
 pub struct OperatorExecutorStream<D: Data> {
     stream: Rc<RefCell<InternalReadStream<D>>>,

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::collections::BinaryHeap;
 use std::rc::Rc;
 
-use async_trait::async_trait;
 use tokio;
 use tokio::stream::Stream;
 use tokio::stream::StreamExt;
@@ -100,15 +99,12 @@ impl OperatorExecutor {
     }
 
     pub async fn execute(&mut self) {
-        match self.event_stream.take() {
-            Some(mut event_stream) => {
-                while let Some(events) = event_stream.next().await {
-                    for event in events {
-                        (event.callback)()
-                    }
+        if let Some(mut event_stream) = self.event_stream.take() {
+            while let Some(events) = event_stream.next().await {
+                for event in events {
+                    (event.callback)()
                 }
             }
-            None => (),
         }
     }
 }

--- a/src/scheduler/channel_manager.rs
+++ b/src/scheduler/channel_manager.rs
@@ -1,11 +1,7 @@
 use async_trait::async_trait;
 use serde::Deserialize;
-use std::{
-    any::Any,
-    collections::HashMap,
-    sync::{mpsc, Arc},
-};
-use tokio::sync::Mutex;
+use std::{any::Any, collections::HashMap, sync::Arc};
+use tokio::sync::{mpsc, Mutex};
 
 use crate::{
     communication::{Pusher, PusherT, RecvEndpoint, SendEndpoint},
@@ -101,7 +97,7 @@ where
     }
 
     fn add_inter_thread_channel(&mut self) {
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::unbounded_channel();
         self.add_send_endpoint(SendEndpoint::InterThread(tx));
         self.add_recv_endpoint(RecvEndpoint::InterThread(rx));
     }
@@ -128,7 +124,7 @@ where
             .entry(self.stream_id)
             .or_insert_with(|| Box::new(Pusher::<Message<D>>::new()));
         if let Some(pusher) = pusher.as_any().downcast_mut::<Pusher<Message<D>>>() {
-            let (tx, rx) = mpsc::channel();
+            let (tx, rx) = mpsc::unbounded_channel();
             pusher.add_endpoint(SendEndpoint::InterThread(tx));
             self.add_recv_endpoint(RecvEndpoint::InterThread(rx));
             Ok(())

--- a/src/scheduler/endpoints_manager.rs
+++ b/src/scheduler/endpoints_manager.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, sync::mpsc};
+use std::collections::HashMap;
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     communication::{PusherT, SerializedMessage},
@@ -14,7 +15,7 @@ pub struct ChannelsToReceivers {
     // We do not use a tokio::mpsc::UnboundedSender because that only provides a blocking API.
     // It does not allow us to just check if the channel has a new message. We need this API in
     // the receivers, which regularly check if there are new pushers available.
-    senders: Vec<mpsc::Sender<(StreamId, Box<dyn PusherT>)>>,
+    senders: Vec<UnboundedSender<(StreamId, Box<dyn PusherT>)>>,
 }
 
 impl ChannelsToReceivers {
@@ -25,7 +26,7 @@ impl ChannelsToReceivers {
     }
 
     /// Adds a `mpsc::Sender` to a new receiver thread.
-    pub fn add_sender(&mut self, sender: mpsc::Sender<(StreamId, Box<dyn PusherT>)>) {
+    pub fn add_sender(&mut self, sender: UnboundedSender<(StreamId, Box<dyn PusherT>)>) {
         self.senders.push(sender);
     }
 
@@ -43,7 +44,7 @@ impl ChannelsToReceivers {
 /// Wrapper used to store mappings between node ids and `mpsc::UnboundedSender` to sender threads.
 pub struct ChannelsToSenders {
     /// The ith sender corresponds to a TCP connection to the ith node.
-    senders: HashMap<NodeId, tokio::sync::mpsc::UnboundedSender<SerializedMessage>>,
+    senders: HashMap<NodeId, UnboundedSender<SerializedMessage>>,
 }
 
 impl ChannelsToSenders {

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -82,7 +82,9 @@ impl SquareOperator {
 
     pub fn msg_callback(t: Timestamp, data: usize, write_stream: &mut WriteStream<usize>) {
         println!("SquareOperator: received {}", data);
-        write_stream.send(Message::new_message(t, data * data));
+        write_stream
+            .send(Message::new_message(t, data * data))
+            .unwrap();
     }
 }
 


### PR DESCRIPTION
- Avoids busy looping for invoking callbacks by moving streams and operator executor to tokio.
- Replaces std channels with tokio channels to prevent blocking of OS threads (which may cause starvation/block the entire runtime).
- Calls to `ReadStream::read` now busy loop, but don't interfere with the runtime. To solve this issue, we may want to move operators to tokio in the future, make `run` async, and implement an async `ReadStream::read`.
- Fixes a bug in the single node case where `Node::run_async` may finish running while operators should still be running.

Performance of `python/examples/watermarks.py` before fixes (note 3 CPUs at 100%):
![cpu_no_tokio](https://user-images.githubusercontent.com/14067561/74675960-b2b76200-5169-11ea-9a23-3d10a06405f9.png)

Performance of `python/examples/watermarks.py` before fixes (note 1 CPU at 100% due to `PullWatermarkListener`):
![cpu_tokio](https://user-images.githubusercontent.com/14067561/74675984-c4990500-5169-11ea-88c0-fea50a12d9cd.png)
