### PR TITLE
Remove python driver function

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,24 +19,21 @@ Example Use
   # Construct the dataflow graph in the driver.
   # The dataflow graph consists of operators which process data,
   # and streams which broadcast messages to other operators.
-  def driver():
-      # Create a camera operator which generates a stream of RGB images.
-      camera_stream = erdos.connect(CameraOp)
-      # Create an object detection operator with the provided model.
-      # The object detection operator reads RGB images and sends bounding boxes.
-      bounding_box_stream = erdos.connect(ObjectDetectorOp, [camera_stream],
-                                          model="models/ssd_mobilenet_v1_coco")
-      # Create semantic segmentation operator with the provided model
-      segmentation_stream = erdos.connect(SegmentationOp, [camera_stream],
-                                          model="models/drn_d_22_cityscapes")
-      # Create an action operator to propose actions from provided features
-      action_op = erdos.connect(ActionOp, [bounding_box_stream, segmentation_stream])
-      # Create a robot operator to interface with the robot
-      erdos.connect(RobotOp)
-
-  if __name__ == "__main__":
-      # Execute the application
-      erdos.run(driver)
+  # Create a camera operator which generates a stream of RGB images.
+  camera_stream = erdos.connect(CameraOp)
+  # Create an object detection operator with the provided model.
+  # The object detection operator reads RGB images and sends bounding boxes.
+  bounding_box_stream = erdos.connect(ObjectDetectorOp, [camera_stream],
+                                      model="models/ssd_mobilenet_v1_coco")
+  # Create semantic segmentation operator with the provided model
+  segmentation_stream = erdos.connect(SegmentationOp, [camera_stream],
+                                      model="models/drn_d_22_cityscapes")
+  # Create an action operator to propose actions from provided features
+  action_op = erdos.connect(ActionOp, [bounding_box_stream, segmentation_stream])
+  # Create a robot operator to interface with the robot
+  erdos.connect(RobotOp)
+  # Execute the application
+  erdos.run()
 
 
 .. toctree::

--- a/python/examples/ingest_extract.py
+++ b/python/examples/ingest_extract.py
@@ -21,16 +21,12 @@ class SquareOp(erdos.Operator):
         return [erdos.WriteStream()]
 
 
-def driver():
+def main():
     ingest_stream = erdos.IngestStream()
     (square_stream, ) = erdos.connect(SquareOp, [ingest_stream])
     extract_stream = erdos.ExtractStream(square_stream)
 
-    return ingest_stream, extract_stream
-
-
-if __name__ == "__main__":
-    ingest_stream, extract_stream = erdos.run_async(driver)
+    erdos.run_async()
 
     count = 0
     while True:
@@ -44,3 +40,7 @@ if __name__ == "__main__":
 
         count += 1
         time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/join_streams.py
+++ b/python/examples/join_streams.py
@@ -64,8 +64,8 @@ class JoinOp(erdos.Operator):
         write_stream.send(joined_msg)
 
 
-def driver():
-    """Creates the dataflow graph."""
+def main():
+    """Creates and runs the dataflow graph."""
     (left_stream, ) = erdos.connect(SendOp, [],
                                     True,
                                     "FastSendOp",
@@ -76,6 +76,8 @@ def driver():
                                      frequency=1)
     erdos.connect(JoinOp, [left_stream, right_stream])
 
+    erdos.run()
+
 
 if __name__ == "__main__":
-    erdos.run(driver)
+    main()

--- a/python/examples/loop.py
+++ b/python/examples/loop.py
@@ -35,12 +35,14 @@ class LoopOp(erdos.Operator):
         self.write_stream.send(msg)
 
 
-def driver():
-    """Creates the dataflow graph."""
+def main():
+    """Creates and runs the dataflow graph."""
     loop_stream = erdos.LoopStream()
     (stream, ) = erdos.connect(LoopOp, [loop_stream])
     loop_stream.set(stream)
 
+    erdos.run()
+
 
 if __name__ == "__main__":
-    erdos.run(driver)
+    main()

--- a/python/examples/simple_pipeline.py
+++ b/python/examples/simple_pipeline.py
@@ -70,13 +70,15 @@ class TryPullOp:
             time.sleep(0.5)
 
 
-def driver():
-    """Creates the dataflow graph."""
+def main():
+    """Creates and runs the dataflow graph."""
     (count_stream, ) = erdos.connect(SendOp, [])
     erdos.connect(CallbackOp, [count_stream])
     erdos.connect(PullOp, [count_stream])
     erdos.connect(TryPullOp, [count_stream])
 
+    erdos.run()
+
 
 if __name__ == "__main__":
-    erdos.run(driver)
+    main()

--- a/python/examples/watermarks.py
+++ b/python/examples/watermarks.py
@@ -101,8 +101,8 @@ class PullWatermarkListener(erdos.Operator):
                     msg=msg))
 
 
-def driver():
-    """Creates the dataflow graph."""
+def main():
+    """Creates and runs the dataflow graph."""
     (count_stream, ) = erdos.connect(SendOp, [])
     (top_stream, ) = erdos.connect(TopOp, [])
     (batch_stream, ) = erdos.connect(BatchOp, [count_stream],
@@ -110,6 +110,8 @@ def driver():
     erdos.connect(CallbackWatermarkListener, [batch_stream, top_stream])
     erdos.connect(PullWatermarkListener, [batch_stream])
 
+    erdos.run()
+
 
 if __name__ == "__main__":
-    erdos.run(driver)
+    main()


### PR DESCRIPTION
API-breaking PR which removes the need to pass a driver function to `erdos.run()` and `erdos.run_async()`.

This PR simplifies the python API and removes a bug in which python nodes had superfluous copies of the dataflow graph.