### PR TITLE
Implement shutdown for nodes

### DIFF
--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -100,6 +100,18 @@ fn test_inter_thread() {
 }
 
 #[test]
+fn test_shutdown() {
+    let config = utils::make_default_config();
+    let node = Node::new(config);
+
+    let s = connect_1_write!(SendOperator, OperatorConfig::new().name("SendOperator"));
+    connect_0_write!(RecvOperator, OperatorConfig::new().name("RecvOperator"), s);
+
+    let node_handle = node.run_async();
+    node_handle.shutdown().unwrap();
+}
+
+#[test]
 fn test_ingest() {
     let config = utils::make_default_config();
     let node = Node::new(config);


### PR DESCRIPTION
`Node::run_async` returns a `NodeHandle` which exposes `join` and `shutdown` methods. `join` blocks until the node finishes. `shutdown` sends a shutdown message to the node, and then blocks until shutdown is complete.