### PR TITLE
Fix hanging tests

### DIFF
--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,10 +1,17 @@
 use erdos::Configuration;
 
+/// Returns a unique port for each test to avoid race conditions.
+fn get_unique_port() -> usize {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static PORT: AtomicUsize = AtomicUsize::new(9000);
+    PORT.fetch_add(1, Ordering::SeqCst)
+}
+
 pub fn make_default_config() -> Configuration {
-    let data_addresses = vec!["127.0.0.1:9000"
+    let data_addresses = vec![format!("127.0.0.1:{}", get_unique_port())
         .parse()
         .expect("Unable to parse socket address")];
-    let control_addresses = vec!["127.0.0.1:9001"
+    let control_addresses = vec![format!("127.0.0.1:{}", get_unique_port())
         .parse()
         .expect("Unable to parse socket address")];
     Configuration::new(0, data_addresses, control_addresses, 4, None)


### PR DESCRIPTION
Fixes #61. This PR assigns unique ports to each node used in a test.

Previously, `cargo test` would run tests in parallel in separate threads. Nodes requested the same ports which occasionally resulted in deadlock if one test acquired the control port and another acquired the data port.

Thanks to shepmaster whose [solution in this thread](https://users.rust-lang.org/t/unique-id-per-test/33882/4) was adapted into the fix.