### PR TITLE
Remove ReadStreamT trait

### DIFF
--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -10,8 +10,7 @@ pub mod stream;
 pub use message::{Data, Message, Timestamp, TimestampedData};
 pub use operator::{OperatorConfig, OperatorT};
 pub use stream::{
-    EventMakerT, LoopStream, ReadStream, ReadStreamT, StatefulReadStream, WriteStream,
-    WriteStreamError,
+    EventMakerT, LoopStream, ReadStream, StatefulReadStream, WriteStream, WriteStreamError,
 };
 
 /// Trait that must be implemented by stream state structs.

--- a/src/dataflow/stream/internal_read_stream.rs
+++ b/src/dataflow/stream/internal_read_stream.rs
@@ -6,7 +6,7 @@ use crate::{
     node::operator_event::OperatorEvent,
 };
 
-use super::{EventMakerT, InternalStatefulReadStream, ReadStreamT, StreamId};
+use super::{EventMakerT, InternalStatefulReadStream, StreamId};
 
 // TODO: split between system read streams and user accessible read streams to avoid Rc<RefCell<...>> in operator
 pub struct InternalReadStream<D: Data> {
@@ -93,26 +93,12 @@ impl<D: Data> InternalReadStream<D> {
     pub fn take_endpoint(&mut self) -> Option<RecvEndpoint<Message<D>>> {
         self.recv_endpoint.take()
     }
-}
-
-impl<D: Data> Default for InternalReadStream<D> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<D: Data> ReadStreamT for InternalReadStream<D> {
-    type DataType = D;
-
-    fn get_id(&self) -> StreamId {
-        self.id
-    }
 
     /// Tries to read a message from a channel.
     ///
     /// Returns an immutable reference, or `None` if no messages are
     /// available at the moment (i.e., non-blocking read).
-    fn try_read(&mut self) -> Option<Message<D>> {
+    pub fn try_read(&mut self) -> Option<Message<D>> {
         match self.recv_endpoint.take() {
             Some(mut recv) => {
                 let output = match recv.try_read() {
@@ -130,7 +116,7 @@ impl<D: Data> ReadStreamT for InternalReadStream<D> {
     /// Blocking read which polls the tokio channel.
     /// Returns `None` if the stream doesn't have a receive endpoint.
     // TODO: make async or find a way to run on tokio.
-    fn read(&mut self) -> Option<Message<D>> {
+    pub fn read(&mut self) -> Option<Message<D>> {
         match self.recv_endpoint.take() {
             Some(mut rx) => {
                 let mut result = None;
@@ -154,6 +140,12 @@ impl<D: Data> ReadStreamT for InternalReadStream<D> {
             }
             None => None,
         }
+    }
+}
+
+impl<D: Data> Default for InternalReadStream<D> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/dataflow/stream/mod.rs
+++ b/src/dataflow/stream/mod.rs
@@ -36,22 +36,6 @@ pub trait EventMakerT {
     fn make_events(&self, msg: Message<Self::EventDataType>) -> Vec<OperatorEvent>;
 }
 
-pub trait ReadStreamT: EventMakerT {
-    type DataType: Data;
-
-    /// Returns the id of the stream.
-    fn get_id(&self) -> StreamId;
-
-    /// Tries to read a message from a channel.
-    ///
-    /// Returns an immutable reference, or `None` if no messages are
-    /// available at the moment (i.e., non-blocking read).
-    fn try_read(&mut self) -> Option<Message<Self::DataType>>;
-
-    /// Blocking read. Returns `None` if the stream doesn't have a receive endpoint.
-    fn read(&mut self) -> Option<Message<Self::DataType>>;
-}
-
 pub trait WriteStreamT<D: Data> {
     /// Sends a messsage to a channel.
     fn send(&mut self, msg: Message<D>) -> Result<(), WriteStreamError>;

--- a/src/dataflow/stream/mod.rs
+++ b/src/dataflow/stream/mod.rs
@@ -53,7 +53,7 @@ mod tests {
     pub fn make_default_runtime() -> Runtime {
         Builder::new()
             .basic_scheduler()
-            .thread_name(format!("erdos-test"))
+            .thread_name("erdos-test")
             .enable_all()
             .build()
             .unwrap()

--- a/src/dataflow/stream/read_stream.rs
+++ b/src/dataflow/stream/read_stream.rs
@@ -5,8 +5,7 @@ use serde::Deserialize;
 use crate::dataflow::{Data, Message, State, Timestamp};
 
 use super::{
-    IngestStream, InternalReadStream, LoopStream, ReadStreamT, StatefulReadStream, StreamId,
-    WriteStream,
+    IngestStream, InternalReadStream, LoopStream, StatefulReadStream, StreamId, WriteStream,
 };
 
 #[derive(Clone, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ macro_rules! imports {
             communication::ControlMessage,
             dataflow::graph::default_graph,
             dataflow::stream::{InternalReadStream, WriteStreamT},
-            dataflow::{Message, OperatorConfig, ReadStream, ReadStreamT, WriteStream},
+            dataflow::{Message, ReadStream, WriteStream},
             node::operator_event::OperatorEvent,
             node::operator_executor::{OperatorExecutor, OperatorExecutorStream},
             scheduler::channel_manager::ChannelManager,


### PR DESCRIPTION
Removes the `ReadStreamT` trait since it is unused/unnecessary in its current state.