### PR TITLE
Operators must implement Operator trait

### DIFF
--- a/experiments/throughput_driver.rs
+++ b/experiments/throughput_driver.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use erdos::dataflow::message::*;
-use erdos::dataflow::{stream::WriteStreamT, ReadStream, WriteStream};
+use erdos::dataflow::{stream::WriteStreamT, Operator, ReadStream, WriteStream};
 use erdos::node::Node;
 use erdos::*;
 
@@ -114,6 +114,8 @@ impl SendOperator {
         print!("\n\n");
     }
 }
+
+impl Operator for SendOperator {}
 
 #[derive(Clone)]
 pub struct RecvState {
@@ -227,6 +229,8 @@ impl RecvOperator {
     }
 }
 
+impl Operator for RecvOperator {}
+
 pub struct PullRecvOp {
     num_total_messages: usize,
     message_size: usize,
@@ -301,6 +305,8 @@ impl PullRecvOp {
         println!("\tmax: {} ms", max(&mut latencies));
     }
 }
+
+impl Operator for PullRecvOp {}
 
 fn main() {
     let args = erdos::new_app("ERDOS");

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -8,7 +8,7 @@ pub mod stream;
 
 // Re-export structs as if they were defined here.
 pub use message::{Data, Message, Timestamp, TimestampedData};
-pub use operator::{OperatorConfig, OperatorT};
+pub use operator::{Operator, OperatorConfig};
 pub use stream::{
     EventMakerT, LoopStream, ReadStream, StatefulReadStream, WriteStream, WriteStreamError,
 };

--- a/src/dataflow/operator.rs
+++ b/src/dataflow/operator.rs
@@ -2,16 +2,10 @@ use crate::{node::NodeId, OperatorId};
 
 /// Trait that must be implemented by any operator.
 pub trait Operator {
-    /// Gets the id of the operator.
-    fn get_id(&self) -> OperatorId;
-
-    /// Gets the string name of the operator.
-    fn get_name(&self) -> String;
-
     /// Implement this method if you want to take control of the execution loop of an
     /// operator (e.g., pull messages from streams).
     /// Note: No callbacks are invoked before the completion of this method.
-    fn run(&self) {}
+    fn run(&mut self) {}
 
     /// Implement this method if you need to do clean-up before the operator completes.
     /// An operator completes after it has received the top watermark on all its read streams.

--- a/src/dataflow/operator.rs
+++ b/src/dataflow/operator.rs
@@ -1,7 +1,7 @@
 use crate::{node::NodeId, OperatorId};
 
 /// Trait that must be implemented by any operator.
-pub trait OperatorT {
+pub trait Operator {
     /// Gets the id of the operator.
     fn get_id(&self) -> OperatorId;
 

--- a/src/dataflow/operators/join_operator.rs
+++ b/src/dataflow/operators/join_operator.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::{
     add_watermark_callback,
-    dataflow::{Data, OperatorConfig, OperatorT, ReadStream, Timestamp, WriteStream},
+    dataflow::{Data, Operator, OperatorConfig, ReadStream, Timestamp, WriteStream},
     OperatorId,
 };
 
@@ -23,7 +23,7 @@ pub struct JoinOperator<D1: Data, D2: Data, D3: Data> {
     phantom: PhantomData<(D1, D2, D3)>,
 }
 
-impl<D1: Data, D2: Data, D3: Data> OperatorT for JoinOperator<D1, D2, D3> {
+impl<D1: Data, D2: Data, D3: Data> Operator for JoinOperator<D1, D2, D3> {
     fn get_id(&self) -> OperatorId {
         self.id
     }

--- a/src/dataflow/operators/join_operator.rs
+++ b/src/dataflow/operators/join_operator.rs
@@ -23,15 +23,7 @@ pub struct JoinOperator<D1: Data, D2: Data, D3: Data> {
     phantom: PhantomData<(D1, D2, D3)>,
 }
 
-impl<D1: Data, D2: Data, D3: Data> Operator for JoinOperator<D1, D2, D3> {
-    fn get_id(&self) -> OperatorId {
-        self.id
-    }
-
-    fn get_name(&self) -> String {
-        self.name.clone()
-    }
-}
+impl<D1: Data, D2: Data, D3: Data> Operator for JoinOperator<D1, D2, D3> {}
 
 impl<D1: Data, D2: Data, D3: Data> JoinOperator<D1, D2, D3> {
     #[allow(dead_code)]
@@ -76,6 +68,7 @@ impl<D1: Data, D2: Data, D3: Data> JoinOperator<D1, D2, D3> {
         state.msgs.push(msg);
     }
 
+    #[allow(dead_code)]
     fn join(
         _t: &Timestamp,
         left_state: &WindowState<D1>,

--- a/src/dataflow/operators/join_operator.rs
+++ b/src/dataflow/operators/join_operator.rs
@@ -17,6 +17,7 @@ impl<D> WindowState<D> {
     }
 }
 
+#[allow(dead_code)]
 pub struct JoinOperator<D1: Data, D2: Data, D3: Data> {
     name: String,
     id: OperatorId,
@@ -71,9 +72,9 @@ impl<D1: Data, D2: Data, D3: Data> JoinOperator<D1, D2, D3> {
     #[allow(dead_code)]
     fn join(
         _t: &Timestamp,
-        left_state: &WindowState<D1>,
-        right_state: &WindowState<D2>,
-        write_stream: &mut WriteStream<D3>,
+        _left_state: &WindowState<D1>,
+        _right_state: &WindowState<D2>,
+        _write_stream: &mut WriteStream<D3>,
     ) {
         // TODO(ionel): Access the selector functions.
     }

--- a/src/dataflow/operators/map_operator.rs
+++ b/src/dataflow/operators/map_operator.rs
@@ -10,15 +10,7 @@ pub struct MapOperator<D1: Data, D2: Data> {
     _output_stream: WriteStream<D2>,
 }
 
-impl<D1: Data, D2: Data> Operator for MapOperator<D1, D2> {
-    fn get_id(&self) -> OperatorId {
-        self.id
-    }
-
-    fn get_name(&self) -> String {
-        self.name.clone()
-    }
-}
+impl<D1: Data, D2: Data> Operator for MapOperator<D1, D2> {}
 
 impl<D1: Data, D2: Data> MapOperator<D1, D2> {
     #[allow(dead_code)]

--- a/src/dataflow/operators/map_operator.rs
+++ b/src/dataflow/operators/map_operator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    dataflow::{Data, OperatorConfig, OperatorT, ReadStream, Timestamp, WriteStream},
+    dataflow::{Data, Operator, OperatorConfig, ReadStream, Timestamp, WriteStream},
     OperatorId,
 };
 
@@ -10,7 +10,7 @@ pub struct MapOperator<D1: Data, D2: Data> {
     _output_stream: WriteStream<D2>,
 }
 
-impl<D1: Data, D2: Data> OperatorT for MapOperator<D1, D2> {
+impl<D1: Data, D2: Data> Operator for MapOperator<D1, D2> {
     fn get_id(&self) -> OperatorId {
         self.id
     }

--- a/src/dataflow/operators/map_operator.rs
+++ b/src/dataflow/operators/map_operator.rs
@@ -3,6 +3,7 @@ use crate::{
     OperatorId,
 };
 
+#[allow(dead_code)]
 pub struct MapOperator<D1: Data, D2: Data> {
     name: String,
     id: OperatorId,

--- a/src/dataflow/operators/source_operator.rs
+++ b/src/dataflow/operators/source_operator.rs
@@ -10,15 +10,7 @@ pub struct SourceOperator {
     write_stream: WriteStream<usize>,
 }
 
-impl Operator for SourceOperator {
-    fn get_id(&self) -> OperatorId {
-        self.id
-    }
-
-    fn get_name(&self) -> String {
-        self.name.clone()
-    }
-}
+impl Operator for SourceOperator {}
 
 impl SourceOperator {
     #[allow(dead_code)]

--- a/src/dataflow/operators/source_operator.rs
+++ b/src/dataflow/operators/source_operator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    dataflow::{OperatorConfig, OperatorT, WriteStream},
+    dataflow::{Operator, OperatorConfig, WriteStream},
     OperatorId,
 };
 
@@ -10,7 +10,7 @@ pub struct SourceOperator {
     write_stream: WriteStream<usize>,
 }
 
-impl OperatorT for SourceOperator {
+impl Operator for SourceOperator {
     fn get_id(&self) -> OperatorId {
         self.id
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ macro_rules! imports {
             communication::ControlMessage,
             dataflow::graph::default_graph,
             dataflow::stream::{InternalReadStream, WriteStreamT},
-            dataflow::{Message, ReadStream, WriteStream},
+            dataflow::{Message, Operator, ReadStream, WriteStream},
             node::operator_event::OperatorEvent,
             node::operator_executor::{OperatorExecutor, OperatorExecutorStream},
             scheduler::channel_manager::ChannelManager,
@@ -219,7 +219,8 @@ macro_rules! register {
 
         // No-op that throws compile-time error if types in `new` and `connect` don't match.
         if false {
-            $crate::make_operator!($t, config.clone(), ($($rs),*), ($($ws),*));
+            let mut op = $crate::make_operator!($t, config.clone(), ($($rs),*), ($($ws),*));
+            Operator::run(&mut op)
         }
 
         // Add operator to dataflow graph.

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -7,7 +7,7 @@ use erdos::{
     dataflow::{
         message::*,
         stream::{ExtractStream, IngestStream, WriteStreamT},
-        OperatorConfig, ReadStream, WriteStream,
+        Operator, OperatorConfig, ReadStream, WriteStream,
     },
     node::Node,
     *,
@@ -41,6 +41,8 @@ impl SendOperator {
     }
 }
 
+impl Operator for SendOperator {}
+
 pub struct RecvOperator {}
 
 impl RecvOperator {
@@ -57,6 +59,8 @@ impl RecvOperator {
         println!("RecvOperator: received {}", msg);
     }
 }
+
+impl Operator for RecvOperator {}
 
 pub struct SquareOperator {}
 
@@ -86,6 +90,8 @@ impl SquareOperator {
             .unwrap();
     }
 }
+
+impl Operator for SquareOperator {}
 
 #[test]
 fn test_inter_thread() {

--- a/tests/loop_test.rs
+++ b/tests/loop_test.rs
@@ -2,7 +2,8 @@ use std::thread;
 
 use erdos::{
     dataflow::{
-        message::*, stream::WriteStreamT, LoopStream, OperatorConfig, ReadStream, WriteStream,
+        message::*, stream::WriteStreamT, LoopStream, Operator, OperatorConfig, ReadStream,
+        WriteStream,
     },
     node::Node,
     *,
@@ -58,6 +59,8 @@ impl LoopOperator {
         }
     }
 }
+
+impl Operator for LoopOperator {}
 
 #[test]
 fn test_loop() {

--- a/tests/watermark_test.rs
+++ b/tests/watermark_test.rs
@@ -5,7 +5,7 @@ use erdos::{
         message::*,
         operators::MapOperator,
         stream::{ExtractStream, WriteStreamT},
-        OperatorConfig, ReadStream, WriteStream,
+        Operator, OperatorConfig, ReadStream, WriteStream,
     },
     node::Node,
     *,
@@ -37,6 +37,8 @@ impl SendOperator {
     }
 }
 
+impl Operator for SendOperator {}
+
 pub struct MultiStreamCallbackOperator {}
 
 impl MultiStreamCallbackOperator {
@@ -64,6 +66,8 @@ impl MultiStreamCallbackOperator {
 
     pub fn run(&self) {}
 }
+
+impl Operator for MultiStreamCallbackOperator {}
 
 /// Prints a message after receiving a watermark.
 pub struct RecvOperator {}
@@ -96,6 +100,8 @@ impl RecvOperator {
         }
     }
 }
+
+impl Operator for RecvOperator {}
 
 #[test]
 fn test_flow_watermarks() {


### PR DESCRIPTION
- Renames `OperatorT` trait to `Operator`.
- Removes `get_name` and `get_id` methods from `Operator` trait.
- Add compile-time check that operators implement `Operator`.