### PR TITLE
[Python] Add name and ID properties to erdos.Operator

### DIFF
--- a/python/erdos/__init__.py
+++ b/python/erdos/__init__.py
@@ -14,7 +14,12 @@ import erdos.utils
 _num_py_operators = 0
 
 
-def connect(op_type, read_streams, flow_watermarks=True, *args, **kwargs):
+def connect(op_type,
+            read_streams,
+            name=None,
+            flow_watermarks=True,
+            *args,
+            **kwargs):
     """Registers the operator and its connected streams on the dataflow graph.
 
     The operator is created as follows:
@@ -24,6 +29,7 @@ def connect(op_type, read_streams, flow_watermarks=True, *args, **kwargs):
         op_type (type): The operator class. Should inherit from
             `erdos.Operator`.
         read_streams: the streams from which the operator processes data.
+        name (str): The name of the operator.
         flow_watermarks (bool): whether to automatically pass on the low
             watermark.
         args: arguments passed to the operator.
@@ -33,6 +39,8 @@ def connect(op_type, read_streams, flow_watermarks=True, *args, **kwargs):
         write_streams (list of WriteStream): the streams on which the operator
             sends data.
     """
+    if not issubclass(op_type, Operator):
+        raise TypeError("{} must subclass erdos.Operator".format(op_type))
     # 1-index operators because node 0 is preserved for the current process,
     # and each node can only run 1 python operator.
     global _num_py_operators
@@ -53,7 +61,8 @@ def connect(op_type, read_streams, flow_watermarks=True, *args, **kwargs):
                 stream=stream))
 
     internal_streams = _internal.connect(op_type, py_read_streams, args,
-                                         kwargs, node_id, flow_watermarks)
+                                         kwargs, node_id, name,
+                                         flow_watermarks)
     return [ReadStream(_py_read_stream=s) for s in internal_streams]
 
 

--- a/python/erdos/operator.py
+++ b/python/erdos/operator.py
@@ -10,8 +10,20 @@ class Operator(object):
         matching the read streams and write streams in `connect()`.
 
         Invoked automatically during `erdos.run()`.
+
+        ERDOS operators never need to call super().__init__(*streams) because
+        setup is handled by the ERDOS backend code.
         """
-        self._trace_events = []
+        pass
+
+    def __new__(cls, *args, **kwargs):
+        """Set up variables before call to `__init__` on the python end.
+
+        More setup is done in the Rust backend at `src/python/mod.rs`.
+        """
+        instance = super(Operator, cls).__new__(cls, *args, **kwargs)
+        instance._trace_events = []
+        return instance
 
     @staticmethod
     def connect(*read_streams):
@@ -29,6 +41,16 @@ class Operator(object):
         Invoked automaticaly during `erdos.run()`.
         """
         pass
+
+    @property
+    def name(self):
+        """Returns the operator's name."""
+        return self._name
+
+    @property
+    def id(self):
+        """Returns the operator's ID."""
+        return self._id
 
     def save_trace_events(self, file_name):
         import json

--- a/python/examples/simple_pipeline.py
+++ b/python/examples/simple_pipeline.py
@@ -41,7 +41,7 @@ class CallbackOp(erdos.Operator):
         return []
 
 
-class PullOp:
+class PullOp(erdos.Operator):
     def __init__(self, read_stream):
         self.read_stream = read_stream
 
@@ -55,7 +55,7 @@ class PullOp:
             print("PullOp: received {data}".format(data=data))
 
 
-class TryPullOp:
+class TryPullOp(erdos.Operator):
     def __init__(self, read_stream):
         self.read_stream = read_stream
 


### PR DESCRIPTION
Adds name and ID properties to python operators. These can be accessed as `self.name` and `self.id`.

In addition, moves setup for `_trace_events` to the `__new__` function. This avoids forcing users to call the `erdos.Operator.__init__()`. We might change this in the future.

Note that the `uuid` package is available in python 3.5+.