### PR TITLE
[Python] Add OperatorConfig

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,15 +23,16 @@ Example Use
   camera_stream = erdos.connect(CameraOp)
   # Create an object detection operator with the provided model.
   # The object detection operator reads RGB images and sends bounding boxes.
-  bounding_box_stream = erdos.connect(ObjectDetectorOp, [camera_stream],
+  bounding_box_stream = erdos.connect(ObjectDetectorOp, erdos.OperatorConfig(), [camera_stream],
                                       model="models/ssd_mobilenet_v1_coco")
   # Create semantic segmentation operator with the provided model
-  segmentation_stream = erdos.connect(SegmentationOp, [camera_stream],
+  segmentation_stream = erdos.connect(SegmentationOp, [camera_stream], erdos.OperatorConfig(),
                                       model="models/drn_d_22_cityscapes")
   # Create an action operator to propose actions from provided features
-  action_op = erdos.connect(ActionOp, [bounding_box_stream, segmentation_stream])
+  action_stream = erdos.connect(ActionOp, erdos.OperatorConfig(),
+                            [bounding_box_stream, segmentation_stream])
   # Create a robot operator to interface with the robot
-  erdos.connect(RobotOp)
+  erdos.connect(RobotOp, erdos.OperatorConfig(), [action_stream])
   # Execute the application
   erdos.run()
 

--- a/doc/source/operators.rst
+++ b/doc/source/operators.rst
@@ -23,7 +23,10 @@ contain a control loop or call methods that run regularly.
 API
 ---
 .. autoclass:: erdos.Operator
-    :members: __init__, connect, run
+    :members: __init__, connect, run, id, config,
+
+.. autoclass:: erdos.OperatorConfig
+    :members: name, flow_watermarks, log_file_name, csv_log_file_name, profile_file_name
 
 Examples
 --------

--- a/python/erdos/__init__.py
+++ b/python/erdos/__init__.py
@@ -5,7 +5,7 @@ import sys
 import erdos.internal as _internal
 from erdos.streams import (ReadStream, WriteStream, LoopStream, IngestStream,
                            ExtractStream)
-from erdos.operator import Operator
+from erdos.operator import Operator, OperatorConfig
 from erdos.profile import Profile
 from erdos.message import Message, WatermarkMessage
 from erdos.timestamp import Timestamp
@@ -14,12 +14,7 @@ import erdos.utils
 _num_py_operators = 0
 
 
-def connect(op_type,
-            read_streams,
-            name=None,
-            flow_watermarks=True,
-            *args,
-            **kwargs):
+def connect(op_type, config, read_streams, *args, **kwargs):
     """Registers the operator and its connected streams on the dataflow graph.
 
     The operator is created as follows:
@@ -60,9 +55,8 @@ def connect(op_type,
             raise TypeError("Unable to convert {stream} to ReadStream".format(
                 stream=stream))
 
-    internal_streams = _internal.connect(op_type, py_read_streams, args,
-                                         kwargs, node_id, name,
-                                         flow_watermarks)
+    internal_streams = _internal.connect(op_type, config, py_read_streams,
+                                         args, kwargs, node_id)
     return [ReadStream(_py_read_stream=s) for s in internal_streams]
 
 

--- a/python/erdos/__init__.py
+++ b/python/erdos/__init__.py
@@ -23,10 +23,9 @@ def connect(op_type, config, read_streams, *args, **kwargs):
     Args:
         op_type (type): The operator class. Should inherit from
             `erdos.Operator`.
+        config (OperatorConfig): Configuration details required by the
+            operator.
         read_streams: the streams from which the operator processes data.
-        name (str): The name of the operator.
-        flow_watermarks (bool): whether to automatically pass on the low
-            watermark.
         args: arguments passed to the operator.
         kwargs: keyword arguments passed to the operator.
 

--- a/python/erdos/operator.py
+++ b/python/erdos/operator.py
@@ -43,14 +43,14 @@ class Operator(object):
         pass
 
     @property
-    def name(self):
-        """Returns the operator's name."""
-        return self._name
-
-    @property
     def id(self):
         """Returns the operator's ID."""
         return self._id
+
+    @property
+    def config(self):
+        """Returns the operator's config."""
+        return self._config
 
     def save_trace_events(self, file_name):
         import json
@@ -59,3 +59,38 @@ class Operator(object):
 
     def _add_trace_event(self, event):
         self._trace_events.append(event)
+
+
+class OperatorConfig(object):
+    """Configuration details required by ERDOS Operators."""
+    def __init__(self,
+                 name=None,
+                 flow_watermarks=True,
+                 log_file_name=None,
+                 csv_log_file_name=None,
+                 profile_file_name=None):
+        self._name = name
+        self._flow_watermarks = flow_watermarks
+        self._log_file_name = log_file_name
+        self._csv_log_file_name = csv_log_file_name
+        self._profile_file_name = profile_file_name
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def flow_watermarks(self):
+        return self._flow_watermarks
+
+    @property
+    def log_file_name(self):
+        return self._log_file_name
+
+    @property
+    def csv_log_file_name(self):
+        return self._csv_log_file_name
+
+    @property
+    def profile_file_name(self):
+        return self._profile_file_name

--- a/python/erdos/operator.py
+++ b/python/erdos/operator.py
@@ -62,7 +62,8 @@ class Operator(object):
 
 
 class OperatorConfig(object):
-    """Configuration details required by ERDOS Operators."""
+    """Configuration details required by ERDOS Operators.
+    """
     def __init__(self,
                  name=None,
                  flow_watermarks=True,
@@ -77,20 +78,25 @@ class OperatorConfig(object):
 
     @property
     def name(self):
+        """Name of the operator."""
         return self._name
 
     @property
     def flow_watermarks(self):
+        """Whether to automatically pass on the low watermark."""
         return self._flow_watermarks
 
     @property
     def log_file_name(self):
+        """File name used for logging."""
         return self._log_file_name
 
     @property
     def csv_log_file_name(self):
+        """File name used for logging to CSV."""
         return self._csv_log_file_name
 
     @property
     def profile_file_name(self):
+        """File named used for profiling an operator's performance."""
         return self._profile_file_name

--- a/python/erdos/utils.py
+++ b/python/erdos/utils.py
@@ -25,9 +25,7 @@ def setup_csv_logging(name, log_file=None):
         handler = logging.FileHandler(log_file)
     handler.setLevel(logging.DEBUG)
 
-    formatter = logging.Formatter(
-        fmt='%(message)s',
-        datefmt=None)
+    formatter = logging.Formatter(fmt='%(message)s', datefmt=None)
     handler.setFormatter(formatter)
     logger = logging.getLogger(name)
     logger.addHandler(handler)

--- a/python/examples/ingest_extract.py
+++ b/python/examples/ingest_extract.py
@@ -23,7 +23,8 @@ class SquareOp(erdos.Operator):
 
 def main():
     ingest_stream = erdos.IngestStream()
-    (square_stream, ) = erdos.connect(SquareOp, [ingest_stream])
+    (square_stream, ) = erdos.connect(SquareOp, erdos.OperatorConfig(),
+                                      [ingest_stream])
     extract_stream = erdos.ExtractStream(square_stream)
 
     erdos.run_async()

--- a/python/examples/loop.py
+++ b/python/examples/loop.py
@@ -38,7 +38,7 @@ class LoopOp(erdos.Operator):
 def main():
     """Creates and runs the dataflow graph."""
     loop_stream = erdos.LoopStream()
-    (stream, ) = erdos.connect(LoopOp, [loop_stream])
+    (stream, ) = erdos.connect(LoopOp, erdos.OperatorConfig(), [loop_stream])
     loop_stream.set(stream)
 
     erdos.run()

--- a/python/examples/simple_pipeline.py
+++ b/python/examples/simple_pipeline.py
@@ -72,10 +72,10 @@ class TryPullOp(erdos.Operator):
 
 def main():
     """Creates and runs the dataflow graph."""
-    (count_stream, ) = erdos.connect(SendOp, [])
-    erdos.connect(CallbackOp, [count_stream])
-    erdos.connect(PullOp, [count_stream])
-    erdos.connect(TryPullOp, [count_stream])
+    (count_stream, ) = erdos.connect(SendOp, erdos.OperatorConfig(), [])
+    erdos.connect(CallbackOp, erdos.OperatorConfig(), [count_stream])
+    erdos.connect(PullOp, erdos.OperatorConfig(), [count_stream])
+    erdos.connect(TryPullOp, erdos.OperatorConfig(), [count_stream])
 
     erdos.run()
 

--- a/python/examples/watermarks.py
+++ b/python/examples/watermarks.py
@@ -103,12 +103,14 @@ class PullWatermarkListener(erdos.Operator):
 
 def main():
     """Creates and runs the dataflow graph."""
-    (count_stream, ) = erdos.connect(SendOp, [])
-    (top_stream, ) = erdos.connect(TopOp, [])
-    (batch_stream, ) = erdos.connect(BatchOp, [count_stream],
-                                     flow_watermarks=True)
-    erdos.connect(CallbackWatermarkListener, [batch_stream, top_stream])
-    erdos.connect(PullWatermarkListener, [batch_stream])
+    (count_stream, ) = erdos.connect(SendOp, erdos.OperatorConfig(), [])
+    (top_stream, ) = erdos.connect(TopOp, erdos.OperatorConfig(), [])
+    (batch_stream, ) = erdos.connect(BatchOp, erdos.OperatorConfig(),
+                                     [count_stream])
+    erdos.connect(CallbackWatermarkListener, erdos.OperatorConfig(),
+                  [batch_stream, top_stream])
+    erdos.connect(PullWatermarkListener, erdos.OperatorConfig(),
+                  [batch_stream])
 
     erdos.run()
 


### PR DESCRIPTION
Adds an `OperatorConfig` class which must be passed into `erdos.connect`, matching the Rust API.

Also adds the `config` property to the `Operator` base class.