### PR TITLE
Add operator destructors and allow closing streams

### DIFF
--- a/experiments/throughput_driver.rs
+++ b/experiments/throughput_driver.rs
@@ -252,7 +252,7 @@ impl PullRecvOp {
     pub fn run(&self) {
         println!("RecvOp: receiving warmup messages");
         for _ in 0..NUM_WARMUP_MESSAGES {
-            self.read_stream.read();
+            self.read_stream.read().unwrap();
         }
 
         let mut msg_times: Vec<(u64, SystemTime)> = Vec::with_capacity(self.num_total_messages);

--- a/python/erdos/__init__.py
+++ b/python/erdos/__init__.py
@@ -167,8 +167,8 @@ def add_watermark_callback(read_streams, write_streams, callback):
         callback (timestamp, list of WriteStream -> None): a low watermark
             callback.
     """
-    def internal_watermark_callback(coordinates):
-        timestamp = Timestamp(coordinates=coordinates)
+    def internal_watermark_callback(coordinates, is_top):
+        timestamp = Timestamp(coordinates=coordinates, is_top=is_top)
         callback(timestamp, *write_streams)
 
     py_read_streams = [s._py_read_stream for s in read_streams]

--- a/python/erdos/message.py
+++ b/python/erdos/message.py
@@ -25,18 +25,13 @@ class WatermarkMessage(Message):
        Attributes:
            timestamp (Timestamp): The timestamp for which this is a watermark.
     """
-    def __init__(self, timestamp):
+    def __init__(self, timestamp, is_top=False):
         super(WatermarkMessage, self).__init__(timestamp, None)
+        self._is_top = is_top
 
     def __str__(self):
         return "{{timestamp: {}, watermark: True}}".format(self.timestamp)
 
-
-class StreamClosedMessage(Message):
-    """Class used to indicate that a stream is closed.
-    """
-    def __init__(self):
-        super(StreamClosed, self).__init__(None, None)
-
-    def __str__(self):
-        return "StreamClosed".format(self.timestamp)
+    @property
+    def is_top(self):
+        return self._is_top

--- a/python/erdos/message.py
+++ b/python/erdos/message.py
@@ -16,7 +16,7 @@ class Message(object):
         self.data = data
 
     def __str__(self):
-        return '{{timestamp: {}, data: {}}}'.format(self.timestamp, self.data)
+        return "{{timestamp: {}, data: {}}}".format(self.timestamp, self.data)
 
 
 class WatermarkMessage(Message):
@@ -25,9 +25,18 @@ class WatermarkMessage(Message):
        Attributes:
            timestamp (Timestamp): The timestamp for which this is a watermark.
     """
-
     def __init__(self, timestamp):
         super(WatermarkMessage, self).__init__(timestamp, None)
 
     def __str__(self):
-        return '{{timestamp: {}, watermark: True}}'.format(self.timestamp)
+        return "{{timestamp: {}, watermark: True}}".format(self.timestamp)
+
+
+class StreamClosedMessage(Message):
+    """Class used to indicate that a stream is closed.
+    """
+    def __init__(self):
+        super(StreamClosed, self).__init__(None, None)
+
+    def __str__(self):
+        return "StreamClosed".format(self.timestamp)

--- a/python/erdos/message.py
+++ b/python/erdos/message.py
@@ -25,13 +25,12 @@ class WatermarkMessage(Message):
        Attributes:
            timestamp (Timestamp): The timestamp for which this is a watermark.
     """
-    def __init__(self, timestamp, is_top=False):
+    def __init__(self, timestamp):
         super(WatermarkMessage, self).__init__(timestamp, None)
-        self._is_top = is_top
 
     def __str__(self):
         return "{{timestamp: {}, watermark: True}}".format(self.timestamp)
 
     @property
     def is_top(self):
-        return self._is_top
+        return self.timestamp.is_top

--- a/python/erdos/operator.py
+++ b/python/erdos/operator.py
@@ -50,6 +50,14 @@ class Operator(object):
         """
         pass
 
+    def destroy(self):
+        """Destroys the operator.
+
+        Invoked automatically once all `ReadStreams` the operator reads from
+        are closed.
+        """
+        pass
+
     @property
     def id(self):
         """Returns the operator's ID."""

--- a/python/erdos/operator.py
+++ b/python/erdos/operator.py
@@ -54,7 +54,7 @@ class Operator(object):
         """Destroys the operator.
 
         Invoked automatically once all `ReadStreams` the operator reads from
-        are closed.
+        are closed and `run()` completes.
         """
         pass
 

--- a/python/erdos/streams.py
+++ b/python/erdos/streams.py
@@ -46,6 +46,10 @@ class ReadStream(object):
         self._py_read_stream = PyReadStream(
         ) if _py_read_stream is None else _py_read_stream
 
+    def is_closed(self):
+        """Whether a StreamClosed message has been received."""
+        self._py_read_stream.is_closed()
+
     def read(self):
         """Blocks until a message is read from the stream."""
         return _parse_message(self._py_read_stream.read())
@@ -110,6 +114,10 @@ class WriteStream(object):
         self._py_write_stream = PyWriteStream(
         ) if _py_write_stream is None else _py_write_stream
 
+    def is_closed(self):
+        """Whether a StreamClosed message has been sent."""
+        self._py_write_stream.is_closed()
+
     def send(self, msg):
         """Sends a message on the stream.
 
@@ -141,6 +149,13 @@ class IngestStream(object):
     def __init__(self):
         self._py_ingest_stream = PyIngestStream(0)
 
+    def is_closed(self):
+        """Whether the stream is closed.
+
+        Returns True if the a StreamClosed message was sent or the
+        IngestStream was unable to successfully set up.
+        """
+
     def send(self, msg):
         """Sends a message on the stream.
 
@@ -163,6 +178,14 @@ class ExtractStream(object):
     """
     def __init__(self, read_stream):
         self._py_extract_stream = PyExtractStream(read_stream._py_read_stream)
+
+    def is_closed(self):
+        """Whether the stream is closed.
+
+        Returns True if the a StreamClosed message was sent or the
+        ExtractStream was unable to successfully set up.
+        """
+        self._py_extract_stream.is_closed()
 
     def read(self):
         """Blocks until a message is read from the stream."""

--- a/python/erdos/streams.py
+++ b/python/erdos/streams.py
@@ -45,7 +45,7 @@ class ReadStream(object):
         ) if _py_read_stream is None else _py_read_stream
 
     def is_closed(self):
-        """Whether a StreamClosed message has been received."""
+        """Whether a top watermark message has been received."""
         return self._py_read_stream.is_closed()
 
     def read(self):
@@ -113,7 +113,7 @@ class WriteStream(object):
         ) if _py_write_stream is None else _py_write_stream
 
     def is_closed(self):
-        """Whether a StreamClosed message has been sent."""
+        """Whether a top watermark message has been sent."""
         return self._py_write_stream.is_closed()
 
     def send(self, msg):
@@ -150,7 +150,7 @@ class IngestStream(object):
     def is_closed(self):
         """Whether the stream is closed.
 
-        Returns True if the a StreamClosed message was sent or the
+        Returns True if the a top watermark message was sent or the
         IngestStream was unable to successfully set up.
         """
         return self._py_ingest_stream.is_closed()
@@ -181,7 +181,7 @@ class ExtractStream(object):
     def is_closed(self):
         """Whether the stream is closed.
 
-        Returns True if the a StreamClosed message was sent or the
+        Returns True if the a top watermark message was sent or the
         ExtractStream was unable to successfully set up.
         """
         return self._py_extract_stream.is_closed()

--- a/python/erdos/timestamp.py
+++ b/python/erdos/timestamp.py
@@ -5,9 +5,12 @@ class Timestamp(object):
        Attributes:
            timestamp (Timestamp): For the copy constructor.
            coordinates (list of int): An array of coordinates.
+           is_top (bool): Whether this is the highest possible timestamp.
     """
-
-    def __init__(self, timestamp=None, coordinates=None):
+    def __init__(self, timestamp=None, coordinates=None, is_top=False):
+        self._is_top = is_top
+        if is_top and coordinates is None:
+            coordinates = []
         if timestamp is None:
             assert coordinates is not None, "Timestamp has empty coordinates"
             self.coordinates = coordinates
@@ -21,6 +24,8 @@ class Timestamp(object):
         return self.__repr__()
 
     def __eq__(self, timestamp):
+        if self.is_top and timestamp.is_top:
+            return True
         if len(self.coordinates) != len(timestamp.coordinates):
             return False
         for coord, other_coord in zip(self.coordinates, timestamp.coordinates):
@@ -32,6 +37,10 @@ class Timestamp(object):
         return not self.__eq__(timestamp)
 
     def __lt__(self, timestamp):
+        if self.is_top:
+            return False
+        if not self.is_top and timestamp.is_top:
+            return True
         if len(self.coordinates) != len(timestamp.coordinates):
             raise Exception(
                 "Cannot compare timestamps of different size {} and {}".format(
@@ -44,6 +53,10 @@ class Timestamp(object):
         return False
 
     def __le__(self, timestamp):
+        if self.is_top:
+            return timestamp.is_top
+        if not self.is_top and timestamp.is_top:
+            return True
         if len(self.coordinates) != len(timestamp.coordinates):
             raise Exception(
                 "Cannot compare timestamps of different size {} and {}".format(
@@ -63,3 +76,7 @@ class Timestamp(object):
 
     def __hash__(self):
         return hash(tuple(self.coordinates))
+
+    @property
+    def is_top(self):
+        return self._is_top

--- a/python/examples/close_streams.py
+++ b/python/examples/close_streams.py
@@ -1,0 +1,36 @@
+import erdos
+
+
+class NoopOp(erdos.Operator):
+    def __init__(self, read_stream, write_stream):
+        pass
+
+    @staticmethod
+    def connect(read_streams):
+        return [erdos.WriteStream()]
+
+    def destroy(self):
+        print("Destroying NoopOp")
+
+
+def main():
+    ingest_stream = erdos.IngestStream()
+    (s, ) = erdos.connect(NoopOp, erdos.OperatorConfig(), [ingest_stream])
+    extract_stream = erdos.ExtractStream(s)
+
+    erdos.run_async()
+
+    timestamp = erdos.Timestamp(is_top=True)
+    send_msg = erdos.WatermarkMessage(timestamp)
+    print("IngestStream: sending {send_msg}".format(send_msg=send_msg))
+    ingest_stream.send(send_msg)
+    assert ingest_stream.is_closed()
+
+    recv_msg = extract_stream.read()
+    print("ExtractStream: received {recv_msg}".format(recv_msg=recv_msg))
+    assert recv_msg.is_top
+    assert extract_stream.is_closed()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/make_callback_builder.py
+++ b/scripts/make_callback_builder.py
@@ -250,8 +250,8 @@ def make_add_write_stream(num_rs, num_ws):
 make_receive_watermark_template = """
     fn receive_watermark(&mut self, stream_id: StreamId, t: Timestamp) -> Vec<OperatorEvent> {{
         let some_t = Some(t.clone());
-        let mut previous_low_watermark_opt = Some(t.top());
-        let mut current_low_watermark_opt = Some(t.top());
+        let mut previous_low_watermark_opt = Some(Timestamp::top());
+        let mut current_low_watermark_opt = Some(Timestamp::top());
 
         {previous_low_watermark}
         {set_watermark}

--- a/src/dataflow/message.rs
+++ b/src/dataflow/message.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::fmt::Debug;
 
 /// Trait for valid message data. The data must be clonable, sendable between threads and
@@ -12,7 +13,6 @@ impl<T> Data for T where for<'a> T: 'static + Clone + Send + Debug + Serialize +
 pub enum Message<D: Data> {
     TimestampedData(TimestampedData<D>),
     Watermark(Timestamp),
-    StreamClosed,
 }
 
 impl<D: Data> Message<D> {
@@ -26,9 +26,18 @@ impl<D: Data> Message<D> {
         Self::Watermark(timestamp)
     }
 
-    /// Creates a new `StreamClosed` message.
-    pub fn new_stream_closed() -> Message<D> {
-        Self::StreamClosed
+    /// Creates a new `Watermark` message containing `Timestamp::top()`
+    /// which closes the stream.
+    pub fn new_top_watermark() -> Message<D> {
+        Self::Watermark(Timestamp::top())
+    }
+
+    pub fn is_top_watermark(&self) -> bool {
+        if let Self::Watermark(t) = self {
+            t.is_top
+        } else {
+            false
+        }
     }
 }
 
@@ -37,7 +46,6 @@ impl<D: Data + PartialEq> PartialEq for Message<D> {
         match (self, other) {
             (Self::TimestampedData(d1), Self::TimestampedData(d2)) => d1 == d2,
             (Self::Watermark(w1), Self::Watermark(w2)) => w1 == w2,
-            (Self::StreamClosed, Self::StreamClosed) => true,
             _ => false,
         }
     }
@@ -68,23 +76,44 @@ impl<D: Data + PartialEq> PartialEq for TimestampedData<D> {
 pub type Timestamp = IntTimestamp;
 
 /// Information about when an operator released a message.
-#[derive(
-    Debug, Clone, Serialize, Deserialize, Abomonation, PartialOrd, PartialEq, Ord, Eq, Hash,
-)]
+#[derive(Debug, Clone, Serialize, Deserialize, Abomonation, PartialEq, Eq, Hash)]
 pub struct IntTimestamp {
     // TODO: Storing the dimensions in a vector is inefficient. Fix.
     /// Stores the timestamp values for each dimension.
     pub time: Vec<u64>,
+    /// Whether this is a top timestamp used to close streams.
+    pub is_top: bool,
 }
 
 impl IntTimestamp {
     pub fn new(time: Vec<u64>) -> Self {
-        Self { time }
+        Self {
+            time,
+            is_top: false,
+        }
     }
 
-    pub fn top(&self) -> Self {
+    pub fn top() -> Self {
         Self {
-            time: vec![std::u64::MAX; self.time.len()],
+            time: Vec::new(),
+            is_top: true,
         }
+    }
+}
+
+impl Ord for IntTimestamp {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self.is_top, other.is_top) {
+            (true, true) => Ordering::Equal,
+            (true, false) => Ordering::Greater,
+            (false, true) => Ordering::Less,
+            (false, false) => self.time.cmp(&other.time),
+        }
+    }
+}
+
+impl PartialOrd for IntTimestamp {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }

--- a/src/dataflow/message.rs
+++ b/src/dataflow/message.rs
@@ -12,6 +12,7 @@ impl<T> Data for T where for<'a> T: 'static + Clone + Send + Debug + Serialize +
 pub enum Message<D: Data> {
     TimestampedData(TimestampedData<D>),
     Watermark(Timestamp),
+    StreamClosed,
 }
 
 impl<D: Data> Message<D> {
@@ -24,6 +25,11 @@ impl<D: Data> Message<D> {
     pub fn new_watermark(timestamp: Timestamp) -> Message<D> {
         Self::Watermark(timestamp)
     }
+
+    /// Creates a new `StreamClosed` message.
+    pub fn new_stream_closed() -> Message<D> {
+        Self::StreamClosed
+    }
 }
 
 impl<D: Data + PartialEq> PartialEq for Message<D> {
@@ -31,6 +37,7 @@ impl<D: Data + PartialEq> PartialEq for Message<D> {
         match (self, other) {
             (Self::TimestampedData(d1), Self::TimestampedData(d2)) => d1 == d2,
             (Self::Watermark(w1), Self::Watermark(w2)) => w1 == w2,
+            (Self::StreamClosed, Self::StreamClosed) => true,
             _ => false,
         }
     }

--- a/src/dataflow/message.rs
+++ b/src/dataflow/message.rs
@@ -26,12 +26,6 @@ impl<D: Data> Message<D> {
         Self::Watermark(timestamp)
     }
 
-    /// Creates a new `Watermark` message containing `Timestamp::top()`
-    /// which closes the stream.
-    pub fn new_top_watermark() -> Message<D> {
-        Self::Watermark(Timestamp::top())
-    }
-
     pub fn is_top_watermark(&self) -> bool {
         if let Self::Watermark(t) = self {
             t.is_top

--- a/src/dataflow/message.rs
+++ b/src/dataflow/message.rs
@@ -39,6 +39,20 @@ impl<D: Data> Message<D> {
             false
         }
     }
+
+    pub fn data(&self) -> Option<&D> {
+        match self {
+            Self::TimestampedData(d) => Some(&d.data),
+            _ => None,
+        }
+    }
+
+    pub fn timestamp(&self) -> &Timestamp {
+        match self {
+            Self::TimestampedData(d) => &d.timestamp,
+            Self::Watermark(t) => &t,
+        }
+    }
 }
 
 impl<D: Data + PartialEq> PartialEq for Message<D> {
@@ -82,7 +96,7 @@ pub struct IntTimestamp {
     /// Stores the timestamp values for each dimension.
     pub time: Vec<u64>,
     /// Whether this is a top timestamp used to close streams.
-    pub is_top: bool,
+    is_top: bool,
 }
 
 impl IntTimestamp {
@@ -98,6 +112,10 @@ impl IntTimestamp {
             time: Vec::new(),
             is_top: true,
         }
+    }
+
+    pub fn is_top(&self) -> bool {
+        self.is_top
     }
 }
 

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -273,7 +273,7 @@ mod tests {
         rws.borrow_mut().add_watermark_callback(
             |_t: &Timestamp, state: &CounterState, output_stream: &mut WriteStream<usize>| {
                 let msg = TimestampedData {
-                    timestamp: Timestamp { time: vec![1] },
+                    timestamp: Timestamp::new(vec![1]),
                     data: state.count,
                 };
                 output_stream.send(Message::TimestampedData(msg)).unwrap()

--- a/src/dataflow/operator.rs
+++ b/src/dataflow/operator.rs
@@ -9,7 +9,12 @@ pub trait Operator {
 
     /// Implement this method if you need to do clean-up before the operator completes.
     /// An operator completes after it has received the top watermark on all its read streams.
-    fn destroy(&self) {}
+    fn destroy(&mut self) {}
+}
+
+pub trait OperatorConfigT {
+    fn name(&self) -> Option<String>;
+    fn id(&self) -> OperatorId;
 }
 
 #[derive(Clone)]
@@ -54,5 +59,15 @@ impl<T: Clone> OperatorConfig<T> {
     pub fn node(&mut self, node_id: NodeId) -> &mut Self {
         self.node_id = node_id;
         self
+    }
+}
+
+impl<T: Clone> OperatorConfigT for OperatorConfig<T> {
+    fn name(&self) -> Option<String> {
+        self.name.clone()
+    }
+
+    fn id(&self) -> OperatorId {
+        self.id
     }
 }

--- a/src/dataflow/operator.rs
+++ b/src/dataflow/operator.rs
@@ -8,7 +8,7 @@ pub trait Operator {
     fn run(&mut self) {}
 
     /// Implement this method if you need to do clean-up before the operator completes.
-    /// An operator completes after it has received StreamClosed on all its read streams.
+    /// An operator completes after it has received top watermark on all its read streams.
     fn destroy(&mut self) {}
 }
 

--- a/src/dataflow/operator.rs
+++ b/src/dataflow/operator.rs
@@ -8,7 +8,7 @@ pub trait Operator {
     fn run(&mut self) {}
 
     /// Implement this method if you need to do clean-up before the operator completes.
-    /// An operator completes after it has received the top watermark on all its read streams.
+    /// An operator completes after it has received StreamClosed on all its read streams.
     fn destroy(&mut self) {}
 }
 

--- a/src/dataflow/stream/errors.rs
+++ b/src/dataflow/stream/errors.rs
@@ -36,7 +36,7 @@ impl From<TryRecvError> for TryReadError {
 
 /// Error raised by the WriteStream layer.
 // TODO: rename this to SendError
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum WriteStreamError {
     /// Message serialization failed.
     SerializationError,

--- a/src/dataflow/stream/errors.rs
+++ b/src/dataflow/stream/errors.rs
@@ -9,6 +9,8 @@ pub enum WriteStreamError {
     IOError,
     /// Timestamp or watermark is smaller or equal to the low watermark.
     TimestampError,
+    /// Stream is closed and can no longer send messages.
+    StreamClosedError,
 }
 
 impl From<CommunicationError> for WriteStreamError {

--- a/src/dataflow/stream/errors.rs
+++ b/src/dataflow/stream/errors.rs
@@ -1,6 +1,41 @@
-use crate::communication::CommunicationError;
+use crate::communication::{CommunicationError, TryRecvError};
+
+/// Errors raised by reading from a `ReadStream`.
+#[derive(Debug, PartialEq)]
+pub enum ReadError {
+    /// Message deserialization failed.
+    SerializationError,
+    /// The channel or the TCP stream has been closed.
+    Disconnected,
+    /// Stream is closed and can longer sends messages.
+    Closed,
+}
+
+/// Errors raised by calling `try_read` from a `ReadStream`.
+#[derive(Debug, PartialEq)]
+pub enum TryReadError {
+    /// No message available in the buffer.
+    Empty,
+    /// The channel or the TCP stream has been closed.
+    Disconnected,
+    /// Message deserialization failed.
+    SerializationError,
+    /// Stream is closed and can longer sends messages.
+    Closed,
+}
+
+impl From<TryRecvError> for TryReadError {
+    fn from(e: TryRecvError) -> Self {
+        match e {
+            TryRecvError::Empty => Self::Empty,
+            TryRecvError::Disconnected => Self::Disconnected,
+            TryRecvError::BincodeError(_) => Self::SerializationError,
+        }
+    }
+}
 
 /// Error raised by the WriteStream layer.
+// TODO: rename this to SendError
 #[derive(Debug)]
 pub enum WriteStreamError {
     /// Message serialization failed.
@@ -10,7 +45,7 @@ pub enum WriteStreamError {
     /// Timestamp or watermark is smaller or equal to the low watermark.
     TimestampError,
     /// Stream is closed and can no longer send messages.
-    StreamClosedError,
+    Closed,
 }
 
 impl From<CommunicationError> for WriteStreamError {

--- a/src/dataflow/stream/extract_stream.rs
+++ b/src/dataflow/stream/extract_stream.rs
@@ -63,7 +63,7 @@ where
         self.node_id
     }
 
-    /// Returns true if a StreamClosed message was sent or the ExtractStream was unable to set up.
+    /// Returns true if a top watermark message was sent or the ExtractStream was unable to set up.
     pub fn is_closed(&self) -> bool {
         self.read_stream_option
             .as_ref()

--- a/src/dataflow/stream/extract_stream.rs
+++ b/src/dataflow/stream/extract_stream.rs
@@ -63,6 +63,14 @@ where
         self.node_id
     }
 
+    /// Returns true if a StreamClosed message was sent or the ExtractStream was unable to set up.
+    pub fn is_closed(&self) -> bool {
+        self.read_stream_option
+            .as_ref()
+            .map(ReadStream::is_closed)
+            .unwrap_or(true)
+    }
+
     /// Tries to read a message from a channel.
     ///
     /// Returns an immutable reference, or `None` if no messages are

--- a/src/dataflow/stream/ingest_stream.rs
+++ b/src/dataflow/stream/ingest_stream.rs
@@ -80,7 +80,7 @@ where
         self.node_id
     }
 
-    /// Returns true if a StreamClosed message was received or the IngestStream failed to set up.
+    /// Returns true if a top watermark message was received or the IngestStream failed to set up.
     pub fn is_closed(&self) -> bool {
         self.write_stream_option
             .lock()

--- a/src/dataflow/stream/ingest_stream.rs
+++ b/src/dataflow/stream/ingest_stream.rs
@@ -79,6 +79,16 @@ where
     pub fn get_node_id(&self) -> NodeId {
         self.node_id
     }
+
+    /// Returns true if a StreamClosed message was received or the IngestStream failed to set up.
+    pub fn is_closed(&self) -> bool {
+        self.write_stream_option
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(WriteStream::is_closed)
+            .unwrap_or(true)
+    }
 }
 
 impl<D> WriteStreamT<D> for IngestStream<D>

--- a/src/dataflow/stream/internal_read_stream.rs
+++ b/src/dataflow/stream/internal_read_stream.rs
@@ -199,6 +199,7 @@ impl<D: Data> EventMakerT for InternalReadStream<D> {
                     }))
                 }
             }
+            _ => (),
         }
         events
     }

--- a/src/dataflow/stream/internal_read_stream.rs
+++ b/src/dataflow/stream/internal_read_stream.rs
@@ -120,7 +120,11 @@ impl<D: Data> InternalReadStream<D> {
             .map_or(Err(TryReadError::Disconnected), |rx| {
                 rx.try_read().map_err(TryReadError::from)
             });
-        if let Ok(Message::StreamClosed) = result {
+        if result
+            .as_ref()
+            .map(Message::is_top_watermark)
+            .unwrap_or(false)
+        {
             self.closed = true;
             self.recv_endpoint = None;
         }
@@ -151,7 +155,11 @@ impl<D: Data> InternalReadStream<D> {
                     }
                 }
             });
-        if let Ok(Message::StreamClosed) = result {
+        if result
+            .as_ref()
+            .map(Message::is_top_watermark)
+            .unwrap_or(false)
+        {
             self.closed = true;
             self.recv_endpoint = None;
         }
@@ -215,7 +223,6 @@ impl<D: Data> EventMakerT for InternalReadStream<D> {
                     }))
                 }
             }
-            _ => (),
         }
         events
     }

--- a/src/dataflow/stream/internal_read_stream.rs
+++ b/src/dataflow/stream/internal_read_stream.rs
@@ -64,6 +64,10 @@ impl<D: Data> InternalReadStream<D> {
         &self.name[..]
     }
 
+    pub fn is_closed(&self) -> bool {
+        self.closed
+    }
+
     pub fn from_endpoint(recv_endpoint: RecvEndpoint<Message<D>>, id: StreamId) -> Self {
         Self {
             id: id,

--- a/src/dataflow/stream/internal_read_stream.rs
+++ b/src/dataflow/stream/internal_read_stream.rs
@@ -118,6 +118,7 @@ impl<D: Data> InternalReadStream<D> {
             });
         if let Ok(Message::StreamClosed) = result {
             self.closed = true;
+            self.recv_endpoint = None;
         }
         result
     }
@@ -148,6 +149,7 @@ impl<D: Data> InternalReadStream<D> {
             });
         if let Ok(Message::StreamClosed) = result {
             self.closed = true;
+            self.recv_endpoint = None;
         }
         result
     }

--- a/src/dataflow/stream/internal_stateful_read_stream.rs
+++ b/src/dataflow/stream/internal_stateful_read_stream.rs
@@ -121,6 +121,7 @@ impl<D: Data, S: State> EventMakerT for InternalStatefulReadStream<D, S> {
                     }))
                 }
             }
+            Message::StreamClosed => (),
         }
         events
     }

--- a/src/dataflow/stream/internal_stateful_read_stream.rs
+++ b/src/dataflow/stream/internal_stateful_read_stream.rs
@@ -121,7 +121,6 @@ impl<D: Data, S: State> EventMakerT for InternalStatefulReadStream<D, S> {
                     }))
                 }
             }
-            Message::StreamClosed => (),
         }
         events
     }

--- a/src/dataflow/stream/mod.rs
+++ b/src/dataflow/stream/mod.rs
@@ -3,8 +3,7 @@ use crate::{
     node::operator_event::OperatorEvent,
 };
 
-mod errors;
-
+pub mod errors;
 pub mod extract_stream;
 pub mod ingest_stream;
 pub mod internal_read_stream;

--- a/src/dataflow/stream/read_stream.rs
+++ b/src/dataflow/stream/read_stream.rs
@@ -49,6 +49,10 @@ impl<D: Data> ReadStream<D> {
         self.internal_stream.borrow().get_name().to_string()
     }
 
+    pub fn is_closed(&self) -> bool {
+        self.internal_stream.borrow().is_closed()
+    }
+
     /// Tries to read a message from a channel.
     ///
     /// Returns an immutable reference, or `None` if no messages are

--- a/src/dataflow/stream/read_stream.rs
+++ b/src/dataflow/stream/read_stream.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use crate::dataflow::{Data, Message, State, Timestamp};
 
 use super::{
+    errors::{ReadError, TryReadError},
     IngestStream, InternalReadStream, LoopStream, StatefulReadStream, StreamId, WriteStream,
 };
 
@@ -52,12 +53,12 @@ impl<D: Data> ReadStream<D> {
     ///
     /// Returns an immutable reference, or `None` if no messages are
     /// available at the moment (i.e., non-blocking read).
-    pub fn try_read(&self) -> Option<Message<D>> {
+    pub fn try_read(&self) -> Result<Message<D>, TryReadError> {
         self.internal_stream.borrow_mut().try_read()
     }
 
     /// Blocking read. Returns `None` if the stream doesn't have a receive endpoint.
-    pub fn read(&self) -> Option<Message<D>> {
+    pub fn read(&self) -> Result<Message<D>, ReadError> {
         self.internal_stream.borrow_mut().read()
     }
 }

--- a/src/dataflow/stream/write_stream.rs
+++ b/src/dataflow/stream/write_stream.rs
@@ -118,9 +118,6 @@ impl<'a, D: Data + Deserialize<'a>> WriteStreamT<D> for WriteStream<D> {
         }
         if let Message::StreamClosed = msg {
             self.stream_closed = true;
-            // Drop SendEndpoints.
-            self.inter_thread_endpoints = Vec::with_capacity(0);
-            self.inter_process_endpoints = Vec::with_capacity(0);
         }
         self.update_watermark(&msg)?;
         if !self.inter_process_endpoints.is_empty() {
@@ -147,6 +144,12 @@ impl<'a, D: Data + Deserialize<'a>> WriteStreamT<D> for WriteStream<D> {
                 .send(msg)
                 .map_err(WriteStreamError::from)?;
         }
+
+        // Drop SendEndpoints.
+        if self.stream_closed {
+            self.inter_thread_endpoints = Vec::with_capacity(0);
+            self.inter_process_endpoints = Vec::with_capacity(0);
+        }
         Ok(())
     }
 }
@@ -159,9 +162,6 @@ impl<'a, D: Data + Deserialize<'a> + Abomonation> WriteStreamT<D> for WriteStrea
         }
         if let Message::StreamClosed = msg {
             self.stream_closed = true;
-            // Drop SendEndpoints.
-            self.inter_thread_endpoints = Vec::with_capacity(0);
-            self.inter_process_endpoints = Vec::with_capacity(0);
         }
         self.update_watermark(&msg)?;
         if !self.inter_process_endpoints.is_empty() {
@@ -187,6 +187,11 @@ impl<'a, D: Data + Deserialize<'a> + Abomonation> WriteStreamT<D> for WriteStrea
                 .map_err(WriteStreamError::from)?;
         }
 
+        // Drop SendEndpoints.
+        if self.stream_closed {
+            self.inter_thread_endpoints = Vec::with_capacity(0);
+            self.inter_process_endpoints = Vec::with_capacity(0);
+        }
         Ok(())
     }
 }

--- a/src/dataflow/stream/write_stream.rs
+++ b/src/dataflow/stream/write_stream.rs
@@ -114,12 +114,11 @@ impl<'a, D: Data + Deserialize<'a>> WriteStreamT<D> for WriteStream<D> {
     /// Specialized implementation for when the Data does not implement `Abomonation`.
     default fn send(&mut self, msg: Message<D>) -> Result<(), WriteStreamError> {
         if self.stream_closed {
-            return Err(WriteStreamError::StreamClosedError);
+            return Err(WriteStreamError::Closed);
         }
-        match msg {
-            Message::StreamClosed => self.stream_closed = true,
-            _ => (),
-        };
+        if let Message::StreamClosed = msg {
+            self.stream_closed = true;
+        }
         self.update_watermark(&msg)?;
         if !self.inter_process_endpoints.is_empty() {
             // Serialize the message because we have endpoints in different processes.
@@ -153,12 +152,11 @@ impl<'a, D: Data + Deserialize<'a> + Abomonation> WriteStreamT<D> for WriteStrea
     /// Specialized implementation for when the Data implements `Abomonation`.
     fn send(&mut self, msg: Message<D>) -> Result<(), WriteStreamError> {
         if self.stream_closed {
-            return Err(WriteStreamError::StreamClosedError);
+            return Err(WriteStreamError::Closed);
         }
-        match msg {
-            Message::StreamClosed => self.stream_closed = true,
-            _ => (),
-        };
+        if let Message::StreamClosed = msg {
+            self.stream_closed = true;
+        }
         self.update_watermark(&msg)?;
         if !self.inter_process_endpoints.is_empty() {
             let serialized_msg = msg.encode().map_err(WriteStreamError::from)?;

--- a/src/dataflow/stream/write_stream.rs
+++ b/src/dataflow/stream/write_stream.rs
@@ -118,6 +118,9 @@ impl<'a, D: Data + Deserialize<'a>> WriteStreamT<D> for WriteStream<D> {
         }
         if let Message::StreamClosed = msg {
             self.stream_closed = true;
+            // Drop SendEndpoints.
+            self.inter_thread_endpoints = Vec::with_capacity(0);
+            self.inter_process_endpoints = Vec::with_capacity(0);
         }
         self.update_watermark(&msg)?;
         if !self.inter_process_endpoints.is_empty() {
@@ -156,6 +159,9 @@ impl<'a, D: Data + Deserialize<'a> + Abomonation> WriteStreamT<D> for WriteStrea
         }
         if let Message::StreamClosed = msg {
             self.stream_closed = true;
+            // Drop SendEndpoints.
+            self.inter_thread_endpoints = Vec::with_capacity(0);
+            self.inter_process_endpoints = Vec::with_capacity(0);
         }
         self.update_watermark(&msg)?;
         if !self.inter_process_endpoints.is_empty() {

--- a/src/dataflow/stream/write_stream.rs
+++ b/src/dataflow/stream/write_stream.rs
@@ -92,7 +92,6 @@ impl<D: Data> WriteStream<D> {
                 }
                 self.low_watermark = msg_watermark.clone();
             }
-            Message::StreamClosed => (),
         }
         Ok(())
     }
@@ -120,7 +119,7 @@ impl<'a, D: Data + Deserialize<'a>> WriteStreamT<D> for WriteStream<D> {
         if self.stream_closed {
             return Err(WriteStreamError::Closed);
         }
-        if let Message::StreamClosed = msg {
+        if msg.is_top_watermark() {
             self.stream_closed = true;
         }
         self.update_watermark(&msg)?;
@@ -164,7 +163,7 @@ impl<'a, D: Data + Deserialize<'a> + Abomonation> WriteStreamT<D> for WriteStrea
         if self.stream_closed {
             return Err(WriteStreamError::Closed);
         }
-        if let Message::StreamClosed = msg {
+        if msg.is_top_watermark() {
             self.stream_closed = true;
         }
         self.update_watermark(&msg)?;

--- a/src/dataflow/stream/write_stream.rs
+++ b/src/dataflow/stream/write_stream.rs
@@ -68,6 +68,10 @@ impl<D: Data> WriteStream<D> {
         &self.name[..]
     }
 
+    pub fn is_closed(&self) -> bool {
+        self.stream_closed
+    }
+
     fn add_endpoint(&mut self, endpoint: SendEndpoint<Message<D>>) {
         match endpoint {
             SendEndpoint::InterThread(_) => self.inter_thread_endpoints.push(endpoint),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ macro_rules! make_operator_runner {
         // After: $rs is an identifier pointing to a read stream's StreamId
         // $ws is an identifier pointing to a write stream's StreamId
         move |channel_manager: Arc<Mutex<ChannelManager>>, control_sender: UnboundedSender<ControlMessage>, mut control_receiver: UnboundedReceiver<ControlMessage>| {
-            let mut op_ex_streams: Vec<Box<dyn Send + Stream<Item = Vec<OperatorEvent>>>> = Vec::new();
+            let mut op_ex_streams: Vec<Box<dyn OperatorExecutorStreamT>> = Vec::new();
             // Before: $rs is an identifier pointing to a read stream's StreamId
             // $ws is an identifier pointing to a write stream's StreamId
             $(
@@ -186,18 +186,16 @@ macro_rules! imports {
             thread,
             time::Duration,
         };
-        use tokio::{
-            stream::Stream,
-            sync::mpsc::{UnboundedReceiver, UnboundedSender},
-        };
+        use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
         use $crate::{
             self,
             communication::ControlMessage,
             dataflow::graph::default_graph,
             dataflow::stream::{InternalReadStream, WriteStreamT},
             dataflow::{Message, Operator, ReadStream, WriteStream},
-            node::operator_event::OperatorEvent,
-            node::operator_executor::{OperatorExecutor, OperatorExecutorStream},
+            node::operator_executor::{
+                OperatorExecutor, OperatorExecutorStream, OperatorExecutorStreamT,
+            },
             scheduler::channel_manager::ChannelManager,
             OperatorId,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ macro_rules! make_operator_runner {
             // TODO: execute the operator in parallel?
             // Currently, callbacks are NOT invoked while operator.execute() runs.
             op.run();
-            let mut op_executor = OperatorExecutor::new(op_ex_streams, logger);
+            let mut op_executor = OperatorExecutor::new(op, config, op_ex_streams, logger);
             op_executor
         }
     }};

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -23,7 +23,7 @@ use crate::{
     node::operator_event::OperatorEvent,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 enum EventRunnerMessage {
     AddedEvents,
     DestroyOperator,
@@ -169,9 +169,12 @@ impl OperatorExecutor {
         mut notifier_rx: watch::Receiver<EventRunnerMessage>,
     ) {
         // Wait for notification for events added.
-        while let Some(EventRunnerMessage::AddedEvents) = notifier_rx.recv().await {
+        while let Some(control_msg) = notifier_rx.recv().await {
             while let Some(event) = { event_queue.lock().await.pop() } {
                 (event.callback)();
+            }
+            if EventRunnerMessage::DestroyOperator == control_msg {
+                break;
             }
         }
     }

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -77,7 +77,7 @@ impl<D: Data> Stream for OperatorExecutorStream<D> {
         match mut_self.recv_endpoint.as_mut() {
             Some(RecvEndpoint::InterThread(rx)) => match rx.poll_recv(cx) {
                 Poll::Ready(Some(msg)) => {
-                    if let Message::StreamClosed = msg {
+                    if msg.is_top_watermark() {
                         self.closed.store(true, Ordering::SeqCst);
                         self.recv_endpoint = None;
                     }

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -152,13 +152,13 @@ impl OperatorExecutor {
                 .unwrap();
             event_runner_handle.await.unwrap();
 
+            // TODO: only destroy operator if all read streams got StreamClosed.
             slog::debug!(
                 self.logger,
                 "Destroying operator with name {:?} and ID {}.",
                 self.config.name(),
                 self.config.id(),
             );
-
             self.operator.destroy();
         }
     }

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -150,7 +150,7 @@ impl OperatorExecutor {
             notifier_tx
                 .broadcast(EventRunnerMessage::DestroyOperator)
                 .unwrap();
-            event_runner_handle.await;
+            event_runner_handle.await.unwrap();
 
             slog::debug!(
                 self.logger,
@@ -169,7 +169,7 @@ impl OperatorExecutor {
         mut notifier_rx: watch::Receiver<EventRunnerMessage>,
     ) {
         // Wait for notification for events added.
-        while let Some(_) = notifier_rx.recv().await {
+        while let Some(EventRunnerMessage::AddedEvents) = notifier_rx.recv().await {
             while let Some(event) = { event_queue.lock().await.pop() } {
                 (event.callback)();
             }

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -154,7 +154,7 @@ impl OperatorExecutor {
 
             slog::debug!(
                 self.logger,
-                "All streams closed. Destroying operator with name {:?} and ID {}.",
+                "Destroying operator with name {:?} and ID {}.",
                 self.config.name(),
                 self.config.id(),
             );

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1,5 +1,4 @@
-use pyo3::prelude::*;
-use pyo3::types::*;
+use pyo3::{prelude::*, types::*};
 
 use std::sync::{Arc, Mutex};
 
@@ -10,7 +9,10 @@ use tokio::{
 
 use crate::{
     communication::ControlMessage,
-    dataflow::{graph::default_graph, stream::InternalReadStream, ReadStream, WriteStream},
+    dataflow::{
+        graph::default_graph, stream::InternalReadStream, Operator, OperatorConfig, ReadStream,
+        WriteStream,
+    },
     node::{
         operator_event::OperatorEvent,
         operator_executor::{OperatorExecutor, OperatorExecutorStream},
@@ -20,9 +22,12 @@ use crate::{
     Configuration, Uuid,
 };
 
+mod py_message;
 mod py_stream;
 
 use py_stream::{PyExtractStream, PyIngestStream, PyLoopStream, PyReadStream, PyWriteStream};
+
+pub(crate) use py_message::PyMessage;
 
 #[pymodule]
 fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
@@ -31,6 +36,7 @@ fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyWriteStream>()?;
     m.add_class::<PyIngestStream>()?;
     m.add_class::<PyExtractStream>()?;
+    m.add_class::<PyMessage>()?;
 
     #[pyfn(m, "connect")]
     fn connect_py(
@@ -58,6 +64,7 @@ fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
         // Register the operator
         let op_id = crate::OperatorId::new_deterministic();
         let name: Option<String> = py_config.getattr(py, "name")?.extract(py)?;
+        let name_clone = name.clone();
         let flow_watermarks: bool = py_config.getattr(py, "flow_watermarks")?.extract(py)?;
         let read_stream_ids: Vec<Uuid> = connect_read_streams
             .iter()
@@ -213,7 +220,11 @@ if flow_watermarks and len(read_streams) > 0 and len(write_streams) > 0:
                     e.print(py)
                 }
 
-                OperatorExecutor::new(op_ex_streams, logger)
+                let mut config: OperatorConfig<()> = OperatorConfig::new();
+                config.name = name_clone.clone();
+                config.id = op_id;
+                config.flow_watermarks = flow_watermarks;
+                OperatorExecutor::new(PyOperator {}, config, op_ex_streams, logger)
             };
 
         default_graph::add_operator(
@@ -299,12 +310,20 @@ if flow_watermarks and len(read_streams) > 0 and len(write_streams) > 0:
 
     #[pyfn(m, "add_watermark_callback")]
     fn add_watermark_callback_py(
-        py: Python,
         read_streams: Vec<&PyReadStream>,
         callback: PyObject,
     ) -> PyResult<()> {
-        py_stream::add_watermark_callback(py, read_streams, callback)
+        py_stream::add_watermark_callback(read_streams, callback)
     }
 
     Ok(())
+}
+
+struct PyOperator {}
+
+impl Operator for PyOperator {
+    fn destroy(&mut self) {
+        let logger = crate::get_terminal_logger();
+        slog::debug!(logger, "Destroying PyOperator");
+    }
 }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -2,10 +2,7 @@ use pyo3::{prelude::*, types::*};
 
 use std::sync::{Arc, Mutex};
 
-use tokio::{
-    stream::Stream,
-    sync::mpsc::{UnboundedReceiver, UnboundedSender},
-};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::{
     communication::ControlMessage,
@@ -14,8 +11,7 @@ use crate::{
         WriteStream,
     },
     node::{
-        operator_event::OperatorEvent,
-        operator_executor::{OperatorExecutor, OperatorExecutorStream},
+        operator_executor::{OperatorExecutor, OperatorExecutorStream, OperatorExecutorStreamT},
         Node, NodeId,
     },
     scheduler::channel_manager::ChannelManager,
@@ -116,8 +112,7 @@ fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
                     .collect();
 
                 // Create operator executor streams from read streams
-                let mut op_ex_streams: Vec<Box<dyn Send + Stream<Item = Vec<OperatorEvent>>>> =
-                    Vec::new();
+                let mut op_ex_streams: Vec<Box<dyn OperatorExecutorStreamT>> = Vec::new();
                 for py_read_stream in py_read_streams.iter() {
                     op_ex_streams.push(Box::new(OperatorExecutorStream::from(
                         &py_read_stream.read_stream,

--- a/src/python/py_message.rs
+++ b/src/python/py_message.rs
@@ -1,0 +1,82 @@
+use pyo3::{exceptions, prelude::*, types::PyBytes};
+
+use crate::dataflow::{Message, Timestamp};
+
+#[pyclass]
+pub(crate) struct PyMessage {
+    msg: Message<Vec<u8>>,
+}
+
+#[pymethods]
+impl PyMessage {
+    #[new]
+    fn new<'a>(
+        obj: &PyRawObject,
+        timestamp_coordinates: Option<Vec<u64>>,
+        data: Option<&'a PyBytes>,
+    ) -> PyResult<()> {
+        if timestamp_coordinates.is_none() && data.is_some() {
+            return Err(exceptions::ValueError::py_err(
+                "Passing a non-None value to data when timestamp_coordinates=None is not allowed",
+            ));
+        }
+        let msg = match (timestamp_coordinates, data) {
+            (Some(t), Some(d)) => Message::new_message(Timestamp::new(t), Vec::from(d.as_bytes())),
+            (Some(t), None) => Message::new_watermark(Timestamp::new(t)),
+            (None, None) => Message::new_stream_closed(),
+            (None, Some(_)) => unreachable!(),
+        };
+        obj.init(Self { msg });
+        Ok(())
+    }
+
+    #[getter(data)]
+    fn data<'a>(&self, py: Python<'a>) -> Option<&'a PyBytes> {
+        match &self.msg {
+            Message::TimestampedData(d) => Some(PyBytes::new(py, &d.data[..])),
+            _ => None,
+        }
+    }
+
+    #[getter(timestamp)]
+    fn timestamp(&self) -> Option<Vec<u64>> {
+        match &self.msg {
+            Message::TimestampedData(d) => Some(d.timestamp.time.clone()),
+            Message::Watermark(t) => Some(t.time.clone()),
+            _ => None,
+        }
+    }
+
+    fn is_timestamped_data(&self) -> bool {
+        match &self.msg {
+            Message::TimestampedData(_) => true,
+            _ => false,
+        }
+    }
+
+    fn is_watermark(&self) -> bool {
+        match &self.msg {
+            Message::Watermark(_) => true,
+            _ => false,
+        }
+    }
+
+    fn is_stream_closed(&self) -> bool {
+        match &self.msg {
+            Message::StreamClosed => true,
+            _ => false,
+        }
+    }
+}
+
+impl From<Message<Vec<u8>>> for PyMessage {
+    fn from(msg: Message<Vec<u8>>) -> Self {
+        Self { msg }
+    }
+}
+
+impl From<&PyMessage> for Message<Vec<u8>> {
+    fn from(py_message: &PyMessage) -> Self {
+        py_message.msg.clone()
+    }
+}

--- a/src/python/py_message.rs
+++ b/src/python/py_message.rs
@@ -22,7 +22,7 @@ impl PyMessage {
             ));
         }
         let msg = if is_top_watermark {
-            Message::new_top_watermark()
+            Message::new_watermark(Timestamp::top())
         } else {
             match (timestamp_coordinates, data) {
                 (Some(t), Some(d)) => {

--- a/src/python/py_stream/mod.rs
+++ b/src/python/py_stream/mod.rs
@@ -1,5 +1,4 @@
-use pyo3::exceptions;
-use pyo3::prelude::*;
+use pyo3::{exceptions, prelude::*};
 
 use crate::dataflow::StatefulReadStream;
 
@@ -18,12 +17,11 @@ pub use py_write_stream::PyWriteStream;
 // TODO: find a nicer implementation
 // TODO: find a way to add write streams without introducing n^2 different if statements
 pub fn add_watermark_callback(
-    py: Python,
     read_streams: Vec<&PyReadStream>,
     callback: PyObject,
 ) -> PyResult<()> {
     if read_streams.len() == 1 {
-        read_streams[0].add_watermark_callback(py, callback);
+        read_streams[0].add_watermark_callback(callback);
         return Ok(());
     }
 

--- a/src/python/py_stream/py_extract_stream.rs
+++ b/src/python/py_stream/py_extract_stream.rs
@@ -1,6 +1,6 @@
-use pyo3::{exceptions, prelude::*, types::PyBytes};
+use pyo3::{exceptions, prelude::*};
 
-use crate::dataflow::{stream::ExtractStream, Message};
+use crate::{dataflow::stream::ExtractStream, python::PyMessage};
 
 use super::PyReadStream;
 
@@ -18,16 +18,15 @@ impl PyExtractStream {
         });
     }
 
-    fn read<'p>(&mut self, py: Python<'p>) -> PyResult<(Vec<u64>, Option<&'p PyBytes>)> {
+    fn read<'p>(&mut self, py: Python<'p>) -> PyResult<PyMessage> {
         let result = py.allow_threads(|| self.extract_stream.read());
         match result {
-            Some(Message::TimestampedData(msg)) => {
-                Ok((msg.timestamp.time, Some(PyBytes::new(py, &msg.data[..]))))
-            }
-            Some(Message::Watermark(timestamp)) => Ok((timestamp.time, None)),
-            None => Err(PyErr::new::<exceptions::Exception, _>(
-                "Unable to to read from stream",
-            )),
+            Ok(msg) => Ok(PyMessage::from(msg)),
+            Err(e) => Err(exceptions::Exception::py_err(format!(
+                "Unable to to read from stream {}: {:?}",
+                self.extract_stream.get_id(),
+                e
+            ))),
         }
     }
 }

--- a/src/python/py_stream/py_extract_stream.rs
+++ b/src/python/py_stream/py_extract_stream.rs
@@ -18,6 +18,10 @@ impl PyExtractStream {
         });
     }
 
+    fn is_closed(&self) -> bool {
+        self.extract_stream.is_closed()
+    }
+
     fn read<'p>(&mut self, py: Python<'p>) -> PyResult<PyMessage> {
         let result = py.allow_threads(|| self.extract_stream.read());
         match result {

--- a/src/python/py_stream/py_ingest_stream.rs
+++ b/src/python/py_stream/py_ingest_stream.rs
@@ -1,12 +1,12 @@
-use pyo3::prelude::*;
-use pyo3::types::PyBytes;
+use pyo3::{exceptions, prelude::*};
 
 use crate::{
     dataflow::{
         stream::{IngestStream, ReadStream, WriteStreamT},
-        Message, Timestamp,
+        Message,
     },
     node::NodeId,
+    python::PyMessage,
 };
 
 use super::PyReadStream;
@@ -25,27 +25,17 @@ impl PyIngestStream {
         });
     }
 
-    fn send(&mut self, _py: Python, timestamp: Vec<u64>, data: &PyBytes) -> PyResult<bool> {
-        let timestamp = Timestamp::new(timestamp);
-        let data = Vec::from(data.as_bytes());
-        match self
-            .ingest_stream
-            .send(Message::new_message(timestamp, data))
-        {
-            Ok(_) => Ok(true),
-            _ => Ok(false),
-        }
+    fn send(&mut self, msg: &PyMessage) -> PyResult<()> {
+        self.ingest_stream.send(Message::from(msg)).map_err(|e| {
+            exceptions::Exception::py_err(format!(
+                "Error sending message on ingest stream {}: {:?}",
+                self.ingest_stream.get_id(),
+                e
+            ))
+        })
     }
 
-    fn send_watermark(&mut self, _py: Python<'_>, timestamp: Vec<u64>) -> PyResult<bool> {
-        let timestamp = Timestamp::new(timestamp);
-        match self.ingest_stream.send(Message::new_watermark(timestamp)) {
-            Ok(_) => Ok(true),
-            _ => Ok(false),
-        }
-    }
-
-    fn to_py_read_stream(&self, _py: Python) -> PyReadStream {
+    fn to_py_read_stream(&self) -> PyReadStream {
         PyReadStream::from(ReadStream::from(&self.ingest_stream))
     }
 }

--- a/src/python/py_stream/py_ingest_stream.rs
+++ b/src/python/py_stream/py_ingest_stream.rs
@@ -25,6 +25,10 @@ impl PyIngestStream {
         });
     }
 
+    fn is_closed(&self) -> bool {
+        self.ingest_stream.is_closed()
+    }
+
     fn send(&mut self, msg: &PyMessage) -> PyResult<()> {
         self.ingest_stream.send(Message::from(msg)).map_err(|e| {
             exceptions::Exception::py_err(format!(

--- a/src/python/py_stream/py_loop_stream.rs
+++ b/src/python/py_stream/py_loop_stream.rs
@@ -18,11 +18,11 @@ impl PyLoopStream {
         });
     }
 
-    fn set(&self, _py: Python, read_stream: &PyReadStream) {
+    fn set(&self, read_stream: &PyReadStream) {
         self.loop_stream.set(&read_stream.read_stream);
     }
 
-    fn to_py_read_stream(&self, _py: Python) -> PyReadStream {
+    fn to_py_read_stream(&self) -> PyReadStream {
         PyReadStream::from(ReadStream::from(&self.loop_stream))
     }
 }

--- a/src/python/py_stream/py_read_stream.rs
+++ b/src/python/py_stream/py_read_stream.rs
@@ -21,6 +21,10 @@ impl PyReadStream {
         });
     }
 
+    fn is_closed(&self) -> bool {
+        self.read_stream.is_closed()
+    }
+
     /// Returns (timestamp, data)
     fn read(&mut self) -> PyResult<PyMessage> {
         match self.read_stream.read() {

--- a/src/python/py_stream/py_read_stream.rs
+++ b/src/python/py_stream/py_read_stream.rs
@@ -65,7 +65,7 @@ impl PyReadStream {
         self.read_stream.add_watermark_callback(move |timestamp| {
             let gil = Python::acquire_gil();
             let py = gil.python();
-            match callback.call1(py, (timestamp.time.clone(),)) {
+            match callback.call1(py, (timestamp.time.clone(), timestamp.is_top())) {
                 Ok(_) => (),
                 Err(e) => e.print(py),
             };

--- a/src/python/py_stream/py_read_stream.rs
+++ b/src/python/py_stream/py_read_stream.rs
@@ -1,25 +1,11 @@
 use pyo3::{exceptions, prelude::*, types::PyBytes};
 
-use crate::dataflow::{stream::StreamId, Message, ReadStream};
+use crate::{
+    dataflow::{stream::errors::TryReadError, ReadStream},
+    python::PyMessage,
+};
 
 use super::PyWriteStream;
-
-fn process_message<'p>(
-    py: Python<'p>,
-    stream_id: StreamId,
-    msg: Option<Message<Vec<u8>>>,
-) -> PyResult<(Vec<u64>, Option<&'p PyBytes>)> {
-    match msg {
-        Some(Message::TimestampedData(msg)) => {
-            Ok((msg.timestamp.time, Some(PyBytes::new(py, &msg.data[..]))))
-        }
-        Some(Message::Watermark(timestamp)) => Ok((timestamp.time, None)),
-        None => Err(PyErr::new::<exceptions::Exception, _>(format!(
-            "Unable to to read from stream: stream {} has no endpoints",
-            stream_id
-        ))),
-    }
-}
 
 #[pyclass]
 pub struct PyReadStream {
@@ -36,23 +22,30 @@ impl PyReadStream {
     }
 
     /// Returns (timestamp, data)
-    fn read<'p>(&mut self, py: Python<'p>) -> PyResult<(Vec<u64>, Option<&'p PyBytes>)> {
-        process_message(py, self.read_stream.get_id(), self.read_stream.read())
-    }
-
-    fn try_read<'p>(
-        &mut self,
-        py: Python<'p>,
-    ) -> PyResult<Option<(Vec<u64>, Option<&'p PyBytes>)>> {
-        match self.read_stream.try_read() {
-            Some(msg) => {
-                Some(process_message(py, self.read_stream.get_id(), Some(msg))).transpose()
-            }
-            None => Ok(None),
+    fn read(&mut self) -> PyResult<PyMessage> {
+        match self.read_stream.read() {
+            Ok(msg) => Ok(PyMessage::from(msg)),
+            Err(e) => Err(exceptions::Exception::py_err(format!(
+                "Unable to to read from stream {}: {:?}",
+                self.read_stream.get_id(),
+                e
+            ))),
         }
     }
 
-    pub fn add_callback(&self, _py: Python, callback: PyObject) {
+    fn try_read(&mut self) -> PyResult<Option<PyMessage>> {
+        match self.read_stream.try_read() {
+            Ok(msg) => Ok(Some(PyMessage::from(msg))),
+            Err(TryReadError::Empty) => Ok(None),
+            Err(e) => Err(exceptions::Exception::py_err(format!(
+                "Unable to to read from stream {}: {:?}",
+                self.read_stream.get_id(),
+                e
+            ))),
+        }
+    }
+
+    pub fn add_callback(&self, callback: PyObject) {
         self.read_stream.add_callback(move |_timestamp, data| {
             let gil = Python::acquire_gil();
             let py = gil.python();
@@ -64,7 +57,7 @@ impl PyReadStream {
         })
     }
 
-    pub fn add_watermark_callback(&self, _py: Python, callback: PyObject) {
+    pub fn add_watermark_callback(&self, callback: PyObject) {
         self.read_stream.add_watermark_callback(move |timestamp| {
             let gil = Python::acquire_gil();
             let py = gil.python();

--- a/src/python/py_stream/py_write_stream.rs
+++ b/src/python/py_stream/py_write_stream.rs
@@ -19,6 +19,10 @@ impl PyWriteStream {
         });
     }
 
+    fn is_closed(&self) -> bool {
+        self.write_stream.is_closed()
+    }
+
     fn send(&mut self, msg: &PyMessage) -> PyResult<()> {
         self.write_stream.send(Message::from(msg)).map_err(|e| {
             exceptions::Exception::py_err(format!(

--- a/src/python/py_stream/py_write_stream.rs
+++ b/src/python/py_stream/py_write_stream.rs
@@ -1,7 +1,9 @@
-use pyo3::prelude::*;
-use pyo3::types::PyBytes;
+use pyo3::{exceptions, prelude::*};
 
-use crate::dataflow::{stream::WriteStreamT, Message, Timestamp, WriteStream};
+use crate::{
+    dataflow::{stream::WriteStreamT, Message, WriteStream},
+    python::PyMessage,
+};
 
 #[pyclass]
 pub struct PyWriteStream {
@@ -17,24 +19,14 @@ impl PyWriteStream {
         });
     }
 
-    fn send(&mut self, _py: Python<'_>, timestamp: Vec<u64>, data: &PyBytes) -> PyResult<bool> {
-        let timestamp = Timestamp::new(timestamp);
-        let data = Vec::from(data.as_bytes());
-        match self
-            .write_stream
-            .send(Message::new_message(timestamp, data))
-        {
-            Ok(_) => Ok(true),
-            _ => Ok(false),
-        }
-    }
-
-    fn send_watermark(&mut self, _py: Python<'_>, timestamp: Vec<u64>) -> PyResult<bool> {
-        let timestamp = Timestamp::new(timestamp);
-        match self.write_stream.send(Message::new_watermark(timestamp)) {
-            Ok(_) => Ok(true),
-            _ => Ok(false),
-        }
+    fn send(&mut self, msg: &PyMessage) -> PyResult<()> {
+        self.write_stream.send(Message::from(msg)).map_err(|e| {
+            exceptions::Exception::py_err(format!(
+                "Error sending message on ingest stream {}: {:?}",
+                self.write_stream.get_id(),
+                e
+            ))
+        })
     }
 }
 

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -99,14 +99,14 @@ impl Operator for SquareOperator {}
 pub struct DestroyOperator {}
 
 impl DestroyOperator {
-    pub fn new(config: OperatorConfig<()>, read_stream: ReadStream<usize>) -> Self {
+    pub fn new(_config: OperatorConfig<()>, read_stream: ReadStream<usize>) -> Self {
         read_stream.add_callback(Self::msg_callback);
         Self {}
     }
 
     pub fn connect(_read_stream: &ReadStream<usize>) {}
 
-    pub fn msg_callback(t: Timestamp, data: usize) {
+    pub fn msg_callback(_t: Timestamp, data: usize) {
         let logger = erdos::get_terminal_logger();
         slog::debug!(logger, "DestroyOperator: received {}", data);
     }
@@ -166,8 +166,6 @@ fn test_ingest() {
             ))
             .unwrap();
     }
-
-    thread::sleep(std::time::Duration::from_millis(1000));
 }
 
 #[test]
@@ -216,8 +214,6 @@ fn test_ingest_extract() {
         let result = extract_stream.read();
         slog::debug!(logger, "Received {:?}", result);
     }
-
-    thread::sleep(std::time::Duration::from_millis(1000));
 }
 
 #[test]
@@ -254,6 +250,4 @@ fn test_destroy() {
     assert_eq!(ingest_stream.send(msg), Err(WriteStreamError::Closed));
     assert_eq!(extract_stream.read(), Err(ReadError::Closed));
     assert_eq!(extract_stream.try_read(), Err(TryReadError::Closed));
-
-    thread::sleep(std::time::Duration::from_millis(1000));
 }

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -236,7 +236,7 @@ fn test_destroy() {
     let received_msg = extract_stream.read().unwrap();
     slog::debug!(logger, "ExtractStream: received {:?}", received_msg);
 
-    let msg = Message::StreamClosed;
+    let msg = Message::new_top_watermark();
     slog::debug!(logger, "IngestStream: sending {:?}", msg);
     ingest_stream.send(msg).unwrap();
 

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -264,7 +264,7 @@ fn test_destroy() {
     let received_msg = extract_stream.read().unwrap();
     slog::debug!(logger, "ExtractStream: received {:?}", received_msg);
 
-    let msg = Message::new_top_watermark();
+    let msg = Message::new_watermark(Timestamp::top());
     slog::debug!(logger, "IngestStream: sending {:?}", msg);
     ingest_stream.send(msg).unwrap();
 
@@ -304,7 +304,9 @@ fn test_only_destroy_if_closed() {
         ingest_stream_2.send(watermark_msg.clone()).unwrap();
 
         // Only close 1 of the ingest streams.
-        ingest_stream_1.send(Message::new_top_watermark()).unwrap();
+        ingest_stream_1
+            .send(Message::new_watermark(Timestamp::top()))
+            .unwrap();
 
         extract_stream
     };
@@ -343,14 +345,18 @@ fn test_close_write_streams_on_destroy() {
     assert_eq!(Message::new_watermark(Timestamp::new(vec![1])), msg);
 
     // Close both ingest streams.
-    ingest_stream_1.send(Message::new_top_watermark()).unwrap();
-    ingest_stream_2.send(Message::new_top_watermark()).unwrap();
+    ingest_stream_1
+        .send(Message::new_watermark(Timestamp::top()))
+        .unwrap();
+    ingest_stream_2
+        .send(Message::new_watermark(Timestamp::top()))
+        .unwrap();
     assert!(ingest_stream_1.is_closed());
     assert!(ingest_stream_2.is_closed());
 
     // Receive top watermark.
     let msg = extract_stream.read().unwrap();
-    assert_eq!(msg, Message::new_top_watermark());
+    assert_eq!(msg, Message::new_watermark(Timestamp::top()));
     assert_eq!(extract_stream.try_read(), Err(TryReadError::Closed));
     assert!(extract_stream.is_closed());
 }

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -158,7 +158,7 @@ fn test_extract() {
         let msg = extract_stream.read();
         assert_eq!(
             msg,
-            Some(Message::new_message(
+            Ok(Message::new_message(
                 Timestamp::new(vec![count as u64]),
                 count as usize
             ))

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -249,6 +249,8 @@ fn test_destroy() {
 
     // Check that the stream is closed.
     let msg = Message::new_message(Timestamp::new(vec![0]), 0);
+    assert!(ingest_stream.is_closed());
+    assert!(extract_stream.is_closed());
     assert_eq!(ingest_stream.send(msg), Err(WriteStreamError::Closed));
     assert_eq!(extract_stream.read(), Err(ReadError::Closed));
     assert_eq!(extract_stream.try_read(), Err(TryReadError::Closed));

--- a/tests/loop_test.rs
+++ b/tests/loop_test.rs
@@ -44,7 +44,7 @@ impl LoopOperator {
         }
 
         for _ in 0..self.num_iterations {
-            if let Some(Message::TimestampedData(mut timestamped_data)) = self.read_stream.read() {
+            if let Ok(Message::TimestampedData(mut timestamped_data)) = self.read_stream.read() {
                 println!("LoopOp: received {:?}", timestamped_data);
                 timestamped_data.data += 1;
                 timestamped_data.timestamp.time[0] += 1;

--- a/tests/watermark_test.rs
+++ b/tests/watermark_test.rs
@@ -174,7 +174,7 @@ fn test_multi_stream_watermark_callbacks() {
         eprintln!("{:?}", msg);
         assert_eq!(
             msg,
-            Some(Message::new_watermark(Timestamp::new(vec![count as u64])))
+            Ok(Message::new_watermark(Timestamp::new(vec![count as u64])))
         );
     }
 }


### PR DESCRIPTION
This PR adds operator destructors by implementing Operator::destroy which are invoked when all of an operator's read streams are closed.

To close a read stream, send a top watermark e.g. with `Message::new_top_watermark()`.

Also makes several improvements to the Python/Rust interface, and adds tests and examples.