### PR TITLE
[Python] Enable shutting down dataflows

### DIFF
--- a/python/erdos/__init__.py
+++ b/python/erdos/__init__.py
@@ -153,7 +153,10 @@ def run_async(graph_filename=None, start_port=9000):
 
     # The driver must always be on node 0 otherwise ingest and extract streams
     # will break
-    _internal.run_async(0, data_addresses, control_addresses, graph_filename)
+    py_node_handle = _internal.run_async(0, data_addresses, control_addresses,
+                                         graph_filename)
+
+    return NodeHandle(py_node_handle, processes)
 
 
 def add_watermark_callback(read_streams, write_streams, callback):
@@ -220,3 +223,19 @@ def profile_method(**decorator_kwargs):
         return wrapper
 
     return decorator
+
+
+class NodeHandle(object):
+    """Used to shutdown a dataflow created by `run_async`."""
+    def __init__(self, py_node_handle, processes):
+        self.py_node_handle = py_node_handle
+        self.processes = processes
+
+    def shutdown(self):
+        """Shuts down the dataflow."""
+        print("shutting down other processes")
+        for p in self.processes:
+            p.terminate()
+        print("shutting down node")
+        self.py_node_handle.shutdown_node()
+        print("done shutting down")

--- a/python/examples/close_streams.py
+++ b/python/examples/close_streams.py
@@ -20,9 +20,6 @@ def main():
 
     handle = erdos.run_async()
 
-    import time
-    time.sleep(1)
-
     timestamp = erdos.Timestamp(is_top=True)
     send_msg = erdos.WatermarkMessage(timestamp)
     print("IngestStream: sending {send_msg}".format(send_msg=send_msg))

--- a/python/examples/close_streams.py
+++ b/python/examples/close_streams.py
@@ -18,7 +18,10 @@ def main():
     (s, ) = erdos.connect(NoopOp, erdos.OperatorConfig(), [ingest_stream])
     extract_stream = erdos.ExtractStream(s)
 
-    erdos.run_async()
+    handle = erdos.run_async()
+
+    import time
+    time.sleep(1)
 
     timestamp = erdos.Timestamp(is_top=True)
     send_msg = erdos.WatermarkMessage(timestamp)
@@ -30,6 +33,8 @@ def main():
     print("ExtractStream: received {recv_msg}".format(recv_msg=recv_msg))
     assert recv_msg.is_top
     assert extract_stream.is_closed()
+
+    handle.shutdown()
 
 
 if __name__ == "__main__":

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -414,8 +414,9 @@ pub struct NodeHandle {
     shutdown_tx: Sender<()>,
 }
 
+// TODO: distinguish between shutting down the dataflow and shutting down the node.
 impl NodeHandle {
-    /// Waits for the associated ERDO S node to finish.
+    /// Waits for the associated ERDOS node to finish.
     pub fn join(self) -> Result<(), String> {
         self.thread_handle.join().map_err(|e| format!("{:?}", e))
     }


### PR DESCRIPTION
`run_async` now returns a `NodeHandle` which implements the `shutdown` method for the dataflow.

For example:
```python
node_handle = erdos.run_async()

node_handle.shutdown()
```

Other changes:
- updated the close stream example to shut down.
- fixed a bug that caused errors when `config.name` is `None`