### PR TITLE
Make pyo3 an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ chashmap = "2.2.2"
 clap = "2.33.0"
 futures = "0.3.1"
 futures-util = "0.3.1"
-pyo3 = { version = "0.8.2", features=["unsound-subclass"] }
+pyo3 = { version = "0.8.2", features = ["unsound-subclass"], optional = true }
 rand = "0.3"
 serde = { version = "1.0.99", features = ["derive"] }
 slog = "2.4.2"
@@ -40,7 +40,7 @@ criterion = "0.1.2"
 
 [features]
 default = []
-python = []  # Target python with 'cargo build --features=python
+python = ["pyo3"]  # Target python with 'cargo build --features=python
 
 [lib]
 crate-type=["rlib", "cdylib"]   # Required for python


### PR DESCRIPTION
Minor fix which improves build time by making pyo3 an optional dependency. This improves build time when building the core system.

This PR doesn't change the build process; pyo3 is automatically included when building for python.