### PR TITLE
Call Operator::run from OperatorExecutor to remove busy-looping

### DIFF
--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -308,7 +308,7 @@ impl Node {
             let join_handle = tokio::spawn(async move {
                 let mut operator_executor =
                     (operator_info.runner)(channel_manager_copy, operator_tx_copy, rx);
-                operator_executor.execute().await;
+                operator_executor.execute_on_control_message().await;
             });
             join_handles.push(join_handle);
         }

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -308,7 +308,7 @@ impl Node {
             let join_handle = tokio::spawn(async move {
                 let mut operator_executor =
                     (operator_info.runner)(channel_manager_copy, operator_tx_copy, rx);
-                operator_executor.execute_on_control_message().await;
+                operator_executor.execute().await;
             });
             join_handles.push(join_handle);
         }

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -30,8 +30,10 @@ impl SendOperator {
     pub fn connect() -> WriteStream<usize> {
         WriteStream::new()
     }
+}
 
-    pub fn run(&mut self) {
+impl Operator for SendOperator {
+    fn run(&mut self) {
         for count in 0..5 {
             println!("SendOperator: sending {}", count);
             self.write_stream
@@ -44,8 +46,6 @@ impl SendOperator {
     }
 }
 
-impl Operator for SendOperator {}
-
 pub struct RecvOperator {}
 
 impl RecvOperator {
@@ -55,8 +55,6 @@ impl RecvOperator {
     }
 
     pub fn connect(_read_stream: &ReadStream<usize>) {}
-
-    pub fn run(&self) {}
 
     pub fn msg_callback(_t: Timestamp, msg: usize) {
         println!("RecvOperator: received {}", msg);
@@ -83,8 +81,6 @@ impl SquareOperator {
     pub fn connect(_read_stream: &ReadStream<usize>) -> WriteStream<usize> {
         WriteStream::new()
     }
-
-    pub fn run(&self) {}
 
     pub fn msg_callback(t: Timestamp, data: usize, write_stream: &mut WriteStream<usize>) {
         println!("SquareOperator: received {}", data);

--- a/tests/loop_test.rs
+++ b/tests/loop_test.rs
@@ -35,8 +35,10 @@ impl LoopOperator {
     pub fn connect(_read_stream: &ReadStream<usize>) -> WriteStream<usize> {
         WriteStream::new()
     }
+}
 
-    pub fn run(&mut self) {
+impl Operator for LoopOperator {
+    fn run(&mut self) {
         if self.send_first_msg {
             let msg = Message::new_message(Timestamp::new(vec![0]), 0);
             println!("LoopOp: sending {:?}", msg);
@@ -59,8 +61,6 @@ impl LoopOperator {
         }
     }
 }
-
-impl Operator for LoopOperator {}
 
 #[test]
 fn test_loop() {

--- a/tests/watermark_test.rs
+++ b/tests/watermark_test.rs
@@ -25,8 +25,10 @@ impl SendOperator {
     pub fn connect() -> WriteStream<usize> {
         WriteStream::new()
     }
+}
 
-    pub fn run(&mut self) {
+impl Operator for SendOperator {
+    fn run(&mut self) {
         for count in 0..5 {
             println!("SendOperator: sending {}", count);
             self.write_stream
@@ -35,8 +37,6 @@ impl SendOperator {
         }
     }
 }
-
-impl Operator for SendOperator {}
 
 pub struct MultiStreamCallbackOperator {}
 
@@ -62,8 +62,6 @@ impl MultiStreamCallbackOperator {
     pub fn watermark_callback(t: &Timestamp, _s1: &(), _s2: &(), ws: &mut WriteStream<usize>) {
         ws.send(Message::new_watermark(t.clone())).unwrap();
     }
-
-    pub fn run(&self) {}
 }
 
 impl Operator for MultiStreamCallbackOperator {}
@@ -85,8 +83,6 @@ impl RecvOperator {
     }
 
     pub fn connect(_read_stream: &ReadStream<usize>) {}
-
-    pub fn run(&self) {}
 
     pub fn watermark_callback(t: &Timestamp, should_flow_watermarks: &mut bool) {
         if *should_flow_watermarks {


### PR DESCRIPTION
OperatorExecutors now call `Operator::run` from an async context. This allows waiting on the `RunOperator` signal using a blocking call instead of busy-looping.

Also fixes some bugs in the tests.

Fixes #102.