### PR TITLE
Fix macro imports for external crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 #![feature(specialization)]
 #![feature(box_into_pin)]
 
-pub extern crate abomonation;
+extern crate abomonation;
 #[macro_use]
 extern crate abomonation_derive;
 extern crate bincode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,14 +32,15 @@
 #![feature(specialization)]
 #![feature(box_into_pin)]
 
-extern crate abomonation;
+pub extern crate abomonation;
 #[macro_use]
 extern crate abomonation_derive;
 extern crate bincode;
 extern crate clap;
 #[macro_use]
-extern crate slog;
+pub extern crate slog;
 extern crate slog_term;
+pub extern crate tokio;
 
 // Libraries used in this file.
 use clap::{App, Arg};
@@ -166,8 +167,6 @@ macro_rules! make_operator_executor {
 #[macro_export]
 macro_rules! imports {
     () => {
-        extern crate slog;
-        extern crate tokio;
         use std::{
             cell::RefCell,
             rc::Rc,
@@ -175,7 +174,8 @@ macro_rules! imports {
             thread,
             time::Duration,
         };
-        use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+        use $crate::slog;
+        use $crate::tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
         use $crate::{
             self,
             communication::ControlMessage,


### PR DESCRIPTION
Re-exports crates used in ERDOS macros so that crates using ERDOS don't need to explicitly import them.

Before, crates using ERDOS would need to add dependencies for slog and tokio in `Cargo.toml`.
This is no longer necessary now.