### PR TITLE
Use a BinaryHeap to order events.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 #![feature(get_mut_unchecked)]
 #![feature(specialization)]
 #![feature(box_into_pin)]
+#![feature(vec_remove_item)]
 
 extern crate abomonation;
 #[macro_use]

--- a/src/node/lattice.rs
+++ b/src/node/lattice.rs
@@ -522,32 +522,29 @@ mod test {
     /// callbacks of newer timestamps.
     #[test]
     fn test_ordered_concurrent_execution() {
-        // Since this bug involves non-deterministic order. Run it for n tries.
-        for i in 0..20 {
-            let mut lattice: ExecutionLattice = ExecutionLattice::new();
-            block_on(lattice.add_event(OperatorEvent::new(Timestamp::new(vec![1]), true, || ())));
-            block_on(lattice.add_event(OperatorEvent::new(Timestamp::new(vec![2]), false, || ())));
-            block_on(lattice.add_event(OperatorEvent::new(Timestamp::new(vec![3]), false, || ())));
+        let mut lattice: ExecutionLattice = ExecutionLattice::new();
+        block_on(lattice.add_event(OperatorEvent::new(Timestamp::new(vec![2]), false, || ())));
+        block_on(lattice.add_event(OperatorEvent::new(Timestamp::new(vec![1]), true, || ())));
+        block_on(lattice.add_event(OperatorEvent::new(Timestamp::new(vec![3]), false, || ())));
 
-            let (event, event_id) = block_on(lattice.get_event()).unwrap();
-            assert_eq!(
-                event.timestamp.time[0] == 1 && event.is_watermark_callback,
-                true,
-                "The wrong event was returned by the lattice."
-            );
+        let (event, event_id) = block_on(lattice.get_event()).unwrap();
+        assert_eq!(
+            event.timestamp.time[0] == 1 && event.is_watermark_callback,
+            true,
+            "The wrong event was returned by the lattice."
+        );
 
-            let (event_2, event_id_2) = block_on(lattice.get_event()).unwrap();
-            assert_eq!(
-                event_2.timestamp.time[0] == 1 && !event_2.is_watermark_callback,
-                true,
-                "The wrong event was returned by the lattice."
-            );
-            let (event_3, event_id_3) = block_on(lattice.get_event()).unwrap();
-            assert_eq!(
-                event_3.timestamp.time[0] == 1 && !event_3.is_watermark_callback,
-                true,
-                "The wrong event was returned by the lattice."
-            );
-        }
-    }
+        let (event_2, event_id_2) = block_on(lattice.get_event()).unwrap();
+        assert_eq!(
+            event_2.timestamp.time[0] == 2 && !event_2.is_watermark_callback,
+            true,
+            "The wrong event was returned by the lattice."
+        );
+        let (event_3, event_id_3) = block_on(lattice.get_event()).unwrap();
+        assert_eq!(
+            event_3.timestamp.time[0] == 3 && !event_3.is_watermark_callback,
+            true,
+            "The wrong event was returned by the lattice."
+        );
+   }
 }

--- a/src/node/lattice.rs
+++ b/src/node/lattice.rs
@@ -85,13 +85,19 @@ impl Ord for RunnableEvent {
                 Ordering::Greater => Ordering::Less,
                 Ordering::Equal => {
                     // Break ties with the order of insertion into the lattice.
-                    self.node_index.index().cmp(&other.node_index.index()).reverse()
+                    self.node_index
+                        .index()
+                        .cmp(&other.node_index.index())
+                        .reverse()
                 }
             },
             _ => {
                 // We don't have enough information about the timestamps.
                 // Order based on the order of insertion into the lattice.
-                self.node_index.index().cmp(&other.node_index.index()).reverse()
+                self.node_index
+                    .index()
+                    .cmp(&other.node_index.index())
+                    .reverse()
             }
         }
     }


### PR DESCRIPTION
- This change uses a BinaryHeap instead of a Vec to order events that are ready to run. (hopefully prevent starvation)
- Adds a new test to ensure that the behavior is as expected.