### PR TITLE
Implement zero-copy communication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rand = "0.3"
 serde = { version = "1.0.99", features = ["derive"] }
 slog = "2.4.2"
 slog-term = "2.4.2"
-tokio = { version = "0.2.11", features = ["sync", "tcp", "io-util", "rt-core", "rt-threaded", "time", "macros", "stream"] }
+tokio = { version = "0.2.11", features = ["sync", "tcp", "io-util", "rt-core", "rt-threaded", "time", "macros", "stream", "blocking"] }
 tokio-util = { version = "0.2.0", features = ["codec"] }
 tokio-serde-bincode = "0.2"
 uuid = { version = "0.7", features = ["v4", "v5", "serde"] }

--- a/benches/latency.rs
+++ b/benches/latency.rs
@@ -81,10 +81,10 @@ impl FiveStreamReceiver {
         WriteStream::new()
     }
 
-    pub fn data_callback(t: Timestamp, sender_datas: Vec<SenderData>, state: &mut Vec<Duration>) {
+    pub fn data_callback(t: &Timestamp, sender_datas: &Vec<SenderData>, state: &mut Vec<Duration>) {
         let recv_time = SystemTime::now();
         *state = sender_datas
-            .into_iter()
+            .iter()
             .map(|data| recv_time.duration_since(data.send_time).unwrap())
             .collect();
     }
@@ -131,8 +131,8 @@ impl SenderData {
 }
 
 /// Added to a [`MapOperator`] to create senders.
-fn sender_fn(msg_size: usize) -> Vec<SenderData> {
-    vec![SenderData::new(msg_size)]
+fn sender_fn(msg_size: &usize) -> Vec<SenderData> {
+    vec![SenderData::new(*msg_size)]
 }
 
 /// Added to a [`JoinOperator`] to join data sent by senders.
@@ -145,7 +145,7 @@ fn join_fn(left: Vec<Vec<SenderData>>, right: Vec<Vec<SenderData>>) -> Vec<Sende
 
 /// Added to a [`MapOperator`] to create receivers.
 /// Measures the latencies of the potentially joined messages and sends the result.
-fn receiver_fn(sender_datas: Vec<SenderData>) -> Vec<Duration> {
+fn receiver_fn(sender_datas: &Vec<SenderData>) -> Vec<Duration> {
     let recv_time = SystemTime::now();
     sender_datas
         .into_iter()

--- a/scripts/make_callback_builder.py
+++ b/scripts/make_callback_builder.py
@@ -332,10 +332,10 @@ def make_receive_watermark(num_rs, num_ws, has_state):
     args = ", ".join(
         itertools.chain(
             ["&current_low_watermark"],
-            [("{{ let state = unsafe { Arc::get_mut_unchecked(&mut state) };"
+            [("{ let state = unsafe { Arc::get_mut_unchecked(&mut state) };"
               "state.set_access_context(AccessContext::WatermarkCallback); "
-              "state.set_current_time(current_low_watermark.clone()); state }}"
-              )] if has_state else [],
+              "state.set_current_time(current_low_watermark.clone()); state }")
+             ] if has_state else [],
             map(
                 lambda x:
                 ("{{ let state = unsafe {{ Arc::get_mut_unchecked(&mut rs{x}_state) }}; "

--- a/src/communication/errors.rs
+++ b/src/communication/errors.rs
@@ -66,7 +66,7 @@ impl From<CodecError> for CommunicationError {
 #[derive(Debug)]
 pub enum CodecError {
     IoError(io::Error),
-    /// Bincode serialization/deserialization error. It is raised when the `MessageHeader` serialization
+    /// Bincode serialization/deserialization error. It is raised when the `MessageMetadata` serialization
     /// fails. This should not ever happen.
     BincodeError(bincode::Error),
 }

--- a/src/communication/message_codec.rs
+++ b/src/communication/message_codec.rs
@@ -108,16 +108,14 @@ impl Encoder for MessageCodec {
     /// serialized message.
     fn encode(&mut self, msg: InterProcessMessage, buf: &mut BytesMut) -> Result<(), CodecError> {
         // Serialize and write the header.
-        let (metadata, data, send_us) = match msg {
+        let (metadata, data) = match msg {
             InterProcessMessage::Deserialized {
                 metadata,
                 data,
-                send_us,
-            } => (metadata, data, send_us),
+            } => (metadata, data),
             InterProcessMessage::Serialized {
                 metadata,
                 bytes,
-                decode_us,
             } => unreachable!(),
         };
 

--- a/src/communication/message_codec.rs
+++ b/src/communication/message_codec.rs
@@ -3,7 +3,7 @@ use bytes::{BufMut, BytesMut};
 use std::fmt::Debug;
 use tokio_util::codec::{Decoder, Encoder};
 
-use crate::communication::{CodecError, MessageMetadata, SerializedMessage};
+use crate::communication::{CodecError, InterProcessMessage, MessageMetadata};
 
 const HEADER_SIZE: usize = 8;
 
@@ -19,7 +19,7 @@ enum DecodeStatus {
     },
 }
 
-/// Encodes messages into bytes, and decodes bytes into SerializedMessages.
+/// Encodes messages into bytes, and decodes bytes into InterProcessMessages.
 ///
 /// For each message, the codec first writes the size of its message header,
 /// then the message header, and finally the content of the message.
@@ -39,14 +39,14 @@ impl MessageCodec {
 }
 
 impl Decoder for MessageCodec {
-    type Item = SerializedMessage;
+    type Item = InterProcessMessage;
     type Error = CodecError;
 
-    /// Decodes a bunch of bytes into a SerializedMessage.
+    /// Decodes a bunch of bytes into a InterProcessMessage.
     ///
     /// It first tries to read the header_size, then the header, and finally the
     /// message content.
-    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<SerializedMessage>, CodecError> {
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<InterProcessMessage>, CodecError> {
         match self.status {
             DecodeStatus::Header => {
                 if buf.len() >= HEADER_SIZE {
@@ -81,11 +81,11 @@ impl Decoder for MessageCodec {
             }
             DecodeStatus::Data { data_size } => {
                 if buf.len() >= data_size {
-                    let data = buf.split_to(data_size);
+                    let bytes = buf.split_to(data_size);
                     self.status = DecodeStatus::Header;
-                    let msg = SerializedMessage {
+                    let msg = InterProcessMessage::Serialized {
                         metadata: self.msg_metadata.take().unwrap(),
-                        data,
+                        bytes,
                     };
                     buf.reserve(20_000_000);
 
@@ -99,27 +99,35 @@ impl Decoder for MessageCodec {
 }
 
 impl Encoder for MessageCodec {
-    type Item = SerializedMessage;
+    type Item = InterProcessMessage;
     type Error = CodecError;
 
-    /// Encondes a SerializedMessage into a bunch of bytes.
+    /// Encondes a InterProcessMessage into a bunch of bytes.
     ///
     /// It first writes the header_size, then the header, and finally the
     /// serialized message.
-    fn encode(&mut self, msg: SerializedMessage, buf: &mut BytesMut) -> Result<(), CodecError> {
+    fn encode(&mut self, msg: InterProcessMessage, buf: &mut BytesMut) -> Result<(), CodecError> {
         // Serialize and write the header.
-        let metadata = bincode::serialize(&msg.metadata).map_err(CodecError::from)?;
+        let (metadata, data) = match msg {
+            InterProcessMessage::Deserialized { metadata, data } => (metadata, data),
+            InterProcessMessage::Serialized { metadata, bytes } => unreachable!(),
+        };
+
+        let metadata_serialized = bincode::serialize(&metadata).map_err(CodecError::from)?;
+        let data_serialized = data.encode().unwrap();
+
         // Write the size of the serialized header.
         let mut header: Vec<u8> = Vec::with_capacity(HEADER_SIZE);
-        header.write_u32::<NetworkEndian>(metadata.len() as u32)?;
-        header.write_u32::<NetworkEndian>(msg.data.len() as u32)?;
-        // Reserve space for header size, header, and message.
-        // buf.reserve(HEADER_SIZE + metadata.len() + msg.data.len());
+        header.write_u32::<NetworkEndian>(metadata_serialized.len() as u32)?;
+        header.write_u32::<NetworkEndian>(data_serialized.len() as u32)?;
         buf.put_slice(&header[..]);
-        buf.put_slice(&metadata[..]);
-        // Write the message data.
-        buf.put_slice(&msg.data[..]);
-        // TODO: pre-allocate a constant size to speed up
+
+        buf.put_slice(&metadata_serialized[..]);
+
+        buf.put_slice(&data_serialized[..]);
+
+        // Pre-allocate a constant size to speed up.
+        // TODO: make this configurable.
         buf.reserve(20_000_000);
         Ok(())
     }

--- a/src/communication/mod.rs
+++ b/src/communication/mod.rs
@@ -46,24 +46,20 @@ pub enum ControlMessage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MessageHeader {
+pub struct MessageMetadata {
     pub stream_id: StreamId,
-    pub data_size: usize,
 }
 
 #[derive(Debug, Clone)]
 pub struct SerializedMessage {
-    pub header: MessageHeader,
+    pub metadata: MessageMetadata,
     pub data: BytesMut,
 }
 
 impl SerializedMessage {
     pub fn new(data: BytesMut, stream_id: StreamId) -> Self {
         Self {
-            header: MessageHeader {
-                stream_id,
-                data_size: data.len(),
-            },
+            metadata: MessageMetadata { stream_id },
             data,
         }
     }

--- a/src/communication/mod.rs
+++ b/src/communication/mod.rs
@@ -60,12 +60,10 @@ pub enum InterProcessMessage {
     Serialized {
         metadata: MessageMetadata,
         bytes: BytesMut,
-        decode_us: u128,
     },
     Deserialized {
         metadata: MessageMetadata,
         data: Arc<dyn Serializable + Send + Sync>,
-        send_us: u128,
     },
 }
 
@@ -74,7 +72,6 @@ impl InterProcessMessage {
         Self::Serialized {
             metadata,
             bytes,
-            decode_us: crate::current_time_us(),
         }
     }
 
@@ -85,7 +82,6 @@ impl InterProcessMessage {
         Self::Deserialized {
             metadata: MessageMetadata { stream_id },
             data,
-            send_us: crate::current_time_us(),
         }
     }
 }

--- a/src/communication/mod.rs
+++ b/src/communication/mod.rs
@@ -60,16 +60,22 @@ pub enum InterProcessMessage {
     Serialized {
         metadata: MessageMetadata,
         bytes: BytesMut,
+        decode_us: u128,
     },
     Deserialized {
         metadata: MessageMetadata,
         data: Arc<dyn Serializable + Send + Sync>,
+        send_us: u128,
     },
 }
 
 impl InterProcessMessage {
     pub fn new_serialized(bytes: BytesMut, metadata: MessageMetadata) -> Self {
-        Self::Serialized { metadata, bytes }
+        Self::Serialized {
+            metadata,
+            bytes,
+            decode_us: crate::current_time_us(),
+        }
     }
 
     pub fn new_deserialized(
@@ -79,6 +85,7 @@ impl InterProcessMessage {
         Self::Deserialized {
             metadata: MessageMetadata { stream_id },
             data,
+            send_us: crate::current_time_us(),
         }
     }
 }

--- a/src/communication/mod.rs
+++ b/src/communication/mod.rs
@@ -33,11 +33,7 @@ use tokio::{
     time::delay_for,
 };
 
-use crate::{
-    dataflow::{stream::StreamId, Data},
-    node::node::NodeId,
-    OperatorId,
-};
+use crate::{dataflow::stream::StreamId, node::node::NodeId, OperatorId};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ControlMessage {
@@ -69,10 +65,7 @@ pub enum InterProcessMessage {
 
 impl InterProcessMessage {
     pub fn new_serialized(bytes: BytesMut, metadata: MessageMetadata) -> Self {
-        Self::Serialized {
-            metadata,
-            bytes,
-        }
+        Self::Serialized { metadata, bytes }
     }
 
     pub fn new_deserialized(

--- a/src/communication/pusher.rs
+++ b/src/communication/pusher.rs
@@ -65,10 +65,16 @@ where
 
     fn send(&mut self, mut buf: BytesMut) -> Result<(), CommunicationError> {
         if !self.endpoints.is_empty() {
+            let start = crate::current_time_us();
             let msg = match Deserializable::decode(&mut buf)? {
                 DeserializedMessage::<D>::Owned(msg) => msg,
                 DeserializedMessage::<D>::Ref(msg) => msg.clone(),
             };
+            println!(
+                "Deserializing {} bytes took {} us",
+                buf.len(),
+                crate::current_time_us() - start
+            );
             let msg_arc = Arc::new(msg);
             for endpoint in self.endpoints.iter_mut() {
                 endpoint.send(Arc::clone(&msg_arc))?;

--- a/src/communication/pusher.rs
+++ b/src/communication/pusher.rs
@@ -65,16 +65,10 @@ where
 
     fn send(&mut self, mut buf: BytesMut) -> Result<(), CommunicationError> {
         if !self.endpoints.is_empty() {
-            let start = crate::current_time_us();
             let msg = match Deserializable::decode(&mut buf)? {
                 DeserializedMessage::<D>::Owned(msg) => msg,
                 DeserializedMessage::<D>::Ref(msg) => msg.clone(),
             };
-            println!(
-                "Deserializing {} bytes took {} us",
-                buf.len(),
-                crate::current_time_us() - start
-            );
             let msg_arc = Arc::new(msg);
             for endpoint in self.endpoints.iter_mut() {
                 endpoint.send(Arc::clone(&msg_arc))?;

--- a/src/communication/receivers.rs
+++ b/src/communication/receivers.rs
@@ -74,7 +74,7 @@ impl DataReceiver {
                     // Note: we may want to update the pushers less frequently.
                     self.update_pushers();
                     // Send the message.
-                    match self.stream_id_to_pusher.get_mut(&msg.header.stream_id) {
+                    match self.stream_id_to_pusher.get_mut(&msg.metadata.stream_id) {
                         Some(pusher) => {
                             if let Err(e) = pusher.send(msg.data) {
                                 return Err(e);

--- a/src/communication/receivers.rs
+++ b/src/communication/receivers.rs
@@ -78,12 +78,10 @@ impl DataReceiver {
                         InterProcessMessage::Serialized {
                             metadata,
                             bytes,
-                            decode_us,
                         } => (metadata, bytes),
                         InterProcessMessage::Deserialized {
                             metadata,
                             data,
-                            send_us,
                         } => unreachable!(),
                     };
                     match self.stream_id_to_pusher.get_mut(&metadata.stream_id) {

--- a/src/communication/receivers.rs
+++ b/src/communication/receivers.rs
@@ -22,7 +22,7 @@ use crate::{
 
 /// Listens on a TCP stream, and pushes messages it receives to operator executors.
 #[allow(dead_code)]
-pub struct DataReceiver {
+pub(crate) struct DataReceiver {
     /// The id of the node the stream is receiving data from.
     node_id: NodeId,
     /// Framed TCP read stream.
@@ -38,7 +38,7 @@ pub struct DataReceiver {
 }
 
 impl DataReceiver {
-    pub async fn new(
+    pub(crate) async fn new(
         node_id: NodeId,
         stream: SplitStream<Framed<TcpStream, MessageCodec>>,
         channels_to_receivers: Arc<Mutex<ChannelsToReceivers>>,
@@ -61,7 +61,7 @@ impl DataReceiver {
         }
     }
 
-    pub async fn run(&mut self) -> Result<(), CommunicationError> {
+    pub(crate) async fn run(&mut self) -> Result<(), CommunicationError> {
         // Notify `ControlMessageHandler` that receiver is initialized.
         self.control_tx
             .send(ControlMessage::DataReceiverInitialized(self.node_id))
@@ -75,18 +75,15 @@ impl DataReceiver {
                     self.update_pushers();
                     // Send the message.
                     let (metadata, bytes) = match msg {
-                        InterProcessMessage::Serialized {
-                            metadata,
-                            bytes,
-                        } => (metadata, bytes),
+                        InterProcessMessage::Serialized { metadata, bytes } => (metadata, bytes),
                         InterProcessMessage::Deserialized {
-                            metadata,
-                            data,
+                            metadata: _,
+                            data: _,
                         } => unreachable!(),
                     };
                     match self.stream_id_to_pusher.get_mut(&metadata.stream_id) {
                         Some(pusher) => {
-                            if let Err(e) = pusher.send(bytes) {
+                            if let Err(e) = pusher.send_from_bytes(bytes) {
                                 return Err(e);
                             }
                         }
@@ -113,7 +110,9 @@ impl DataReceiver {
 /// Receives TCP messages, and pushes them to operators endpoints.
 /// The function receives a vector of framed TCP receiver halves.
 /// It launches a task that listens for new messages for each TCP connection.
-pub async fn run_receivers(mut receivers: Vec<DataReceiver>) -> Result<(), CommunicationError> {
+pub(crate) async fn run_receivers(
+    mut receivers: Vec<DataReceiver>,
+) -> Result<(), CommunicationError> {
     // Wait for all futures to finish. It will happen only when all streams are closed.
     future::join_all(receivers.iter_mut().map(|receiver| receiver.run())).await;
     Ok(())
@@ -121,7 +120,7 @@ pub async fn run_receivers(mut receivers: Vec<DataReceiver>) -> Result<(), Commu
 
 /// Listens on a TCP stream, and pushes control messages it receives to the node.
 #[allow(dead_code)]
-pub struct ControlReceiver {
+pub(crate) struct ControlReceiver {
     /// The id of the node the stream is receiving data from.
     node_id: NodeId,
     /// Framed TCP read stream.
@@ -133,7 +132,7 @@ pub struct ControlReceiver {
 }
 
 impl ControlReceiver {
-    pub fn new(
+    pub(crate) fn new(
         node_id: NodeId,
         stream: SplitStream<Framed<TcpStream, ControlMessageCodec>>,
         control_handler: &mut ControlMessageHandler,
@@ -149,7 +148,7 @@ impl ControlReceiver {
         }
     }
 
-    pub async fn run(&mut self) -> Result<(), CommunicationError> {
+    pub(crate) async fn run(&mut self) -> Result<(), CommunicationError> {
         // TODO: update `self.channel_to_handler` for up-to-date mappings.
         // between channels and handlers (e.g. for fault-tolerance).
         // Notify `ControlMessageHandler` that sender is initialized.
@@ -173,7 +172,7 @@ impl ControlReceiver {
 /// Receives TCP messages, and pushes them to the ControlHandler
 /// The function receives a vector of framed TCP receiver halves.
 /// It launches a task that listens for new messages for each TCP connection.
-pub async fn run_control_receivers(
+pub(crate) async fn run_control_receivers(
     mut receivers: Vec<ControlReceiver>,
 ) -> Result<(), CommunicationError> {
     // Wait for all futures to finish. It will happen only when all streams are closed.

--- a/src/communication/receivers.rs
+++ b/src/communication/receivers.rs
@@ -75,8 +75,16 @@ impl DataReceiver {
                     self.update_pushers();
                     // Send the message.
                     let (metadata, bytes) = match msg {
-                        InterProcessMessage::Serialized { metadata, bytes } => (metadata, bytes),
-                        InterProcessMessage::Deserialized { metadata, data } => unreachable!(),
+                        InterProcessMessage::Serialized {
+                            metadata,
+                            bytes,
+                            decode_us,
+                        } => (metadata, bytes),
+                        InterProcessMessage::Deserialized {
+                            metadata,
+                            data,
+                            send_us,
+                        } => unreachable!(),
                     };
                     match self.stream_id_to_pusher.get_mut(&metadata.stream_id) {
                         Some(pusher) => {

--- a/src/communication/senders.rs
+++ b/src/communication/senders.rs
@@ -82,7 +82,7 @@ impl DataSender {
 pub async fn run_senders(mut senders: Vec<DataSender>) -> Result<(), CommunicationError> {
     // Waits until all futures complete. This code will only be reached
     // when all the mpsc channels are closed.
-    future::join_all(senders.iter_mut().map(|sender| sender.run())).await;
+    future::join_all(senders.into_iter().map(|mut sender| tokio::spawn(async move { sender.run().await }))).await;
     Ok(())
 }
 

--- a/src/communication/serializable.rs
+++ b/src/communication/serializable.rs
@@ -3,7 +3,7 @@ use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::Debug,
-    io::{Error, ErrorKind},
+    io::{Error, ErrorKind, Write},
 };
 
 use crate::communication::CommunicationError;
@@ -15,24 +15,66 @@ pub enum DeserializedMessage<'a, T> {
     Owned(T),
 }
 
-/// Trait automatically derived for all messages that derive `Serialize` and `Deserialize`.
-pub trait Serializable<'a>: Sized {
+/// Trait automatically derived for all messages that derive `Serialize`.
+pub trait Serializable {
     fn encode(&self) -> Result<BytesMut, CommunicationError>;
-    fn decode(buf: &'a mut BytesMut) -> Result<DeserializedMessage<'a, Self>, CommunicationError>;
+    fn encode_into(&self, buffer: &mut Vec<u8>) -> Result<(), CommunicationError>;
+    fn serialized_size(&self) -> Result<usize, CommunicationError>;
 }
 
-impl<'a, D> Serializable<'a> for D
+impl<D> Serializable for D
 where
-    D: Debug + Clone + Send + Serialize + Deserialize<'a>,
+    D: Debug + Clone + Send + Serialize,
 {
     default fn encode(&self) -> Result<BytesMut, CommunicationError> {
-        let serialized_msg = bincode::serialize(self).map_err(|e| CommunicationError::from(e))?;
-        // TODO: check whether this introduces extra copies
-        // On v0.5.4, BytesMut does not implement From<Vec<u8>>
+        let serialized_msg = bincode::serialize(self).map_err(CommunicationError::from)?;
         let serialized_msg: BytesMut = BytesMut::from(&serialized_msg[..]);
         Ok(serialized_msg)
     }
 
+    default fn encode_into(&self, buffer: &mut Vec<u8>) -> Result<(), CommunicationError> {
+        bincode::serialize_into(buffer, self).map_err(CommunicationError::from)
+    }
+
+    default fn serialized_size(&self) -> Result<usize, CommunicationError> {
+        bincode::serialized_size(&self)
+            .map(|x| x as usize)
+            .map_err(CommunicationError::from)
+    }
+}
+
+/// Specialized version used when messages derive `Abomonation`.
+impl<D> Serializable for D
+where
+    for<'a> D: Debug + Clone + Send + Serialize + Deserialize<'a> + Abomonation,
+{
+    fn encode(&self) -> Result<BytesMut, CommunicationError> {
+        let mut serialized_msg: Vec<u8> = Vec::with_capacity(measure(self));
+        unsafe {
+            encode(self, &mut serialized_msg).map_err(CommunicationError::AbomonationError)?;
+        }
+        let serialized_msg: BytesMut = BytesMut::from(&serialized_msg[..]);
+        Ok(serialized_msg)
+    }
+
+    fn encode_into(&self, buffer: &mut Vec<u8>) -> Result<(), CommunicationError> {
+        unsafe { encode(self, buffer).map_err(CommunicationError::AbomonationError) }
+    }
+
+    fn serialized_size(&self) -> Result<usize, CommunicationError> {
+        Ok(abomonation::measure(self))
+    }
+}
+
+/// Trait automatically derived for all messages that derive `Deserialize`.
+pub trait Deserializable<'a>: Sized {
+    fn decode(buf: &'a mut BytesMut) -> Result<DeserializedMessage<'a, Self>, CommunicationError>;
+}
+
+impl<'a, D> Deserializable<'a> for D
+where
+    D: Debug + Clone + Send + Deserialize<'a>,
+{
     default fn decode(
         buf: &'a mut BytesMut,
     ) -> Result<DeserializedMessage<'a, D>, CommunicationError> {
@@ -42,22 +84,10 @@ where
 }
 
 /// Specialized version used when messages derive `Abomonation`.
-impl<'a, D> Serializable<'a> for D
+impl<'a, D> Deserializable<'a> for D
 where
-    D: Debug + Clone + Send + Serialize + Deserialize<'a> + Abomonation,
+    D: Debug + Clone + Send + Deserialize<'a> + Abomonation,
 {
-    fn encode(&self) -> Result<BytesMut, CommunicationError> {
-        let mut serialized_msg: Vec<u8> = Vec::with_capacity(measure(self));
-        unsafe {
-            encode(self, &mut serialized_msg)
-                .map_err(|e| CommunicationError::AbomonationError(e))?;
-        }
-        // TODO: check whether this introduces extra copies
-        // On v0.5.4, BytesMut does not implement From<Vec<u8>>
-        let serialized_msg: BytesMut = BytesMut::from(&serialized_msg[..]);
-        Ok(serialized_msg)
-    }
-
     fn decode(buf: &'a mut BytesMut) -> Result<DeserializedMessage<'a, D>, CommunicationError> {
         let (msg, _) = {
             unsafe {

--- a/src/communication/serializable.rs
+++ b/src/communication/serializable.rs
@@ -3,7 +3,7 @@ use bytes::{buf::ext::BufMutExt, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::Debug,
-    io::{Error, ErrorKind, Write},
+    io::{Error, ErrorKind},
 };
 
 use crate::communication::CommunicationError;

--- a/src/dataflow/message.rs
+++ b/src/dataflow/message.rs
@@ -4,9 +4,12 @@ use std::fmt::Debug;
 
 /// Trait for valid message data. The data must be clonable, sendable between threads and
 /// serializable.
-pub trait Data: 'static + Clone + Send + Debug + Serialize {}
+pub trait Data: 'static + Clone + Send + Sync + Debug + Serialize {}
 /// Any type that is clonable, sendable, and can be serialized and dereserialized implements `Data`.
-impl<T> Data for T where for<'a> T: 'static + Clone + Send + Debug + Serialize + Deserialize<'a> {}
+impl<T> Data for T where
+    for<'a> T: 'static + Clone + Send + Sync + Debug + Serialize + Deserialize<'a>
+{
+}
 
 /// Operators send messages on streams. A message can be either a `Watermark` or a `TimestampedData`.
 #[derive(Clone, Debug, Serialize, Deserialize, Abomonation)]

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -35,8 +35,8 @@ mod tests {
     fn test_callback() {
         let rs: ReadStream<String> = ReadStream::new();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        rs.add_callback(move |_t: Timestamp, msg: String| {
-            tx.send(msg).unwrap();
+        rs.add_callback(move |_t: &Timestamp, msg: &String| {
+            tx.send(msg.clone()).unwrap();
         });
 
         // Generate events from message
@@ -99,7 +99,7 @@ mod tests {
         let state = CounterState { count: 0 };
         let srs = rs.add_state(state);
         let irs: Rc<RefCell<InternalReadStream<usize>>> = (&rs).into();
-        srs.add_callback(|_t: Timestamp, data: usize, state: &mut CounterState| {
+        srs.add_callback(|_t: &Timestamp, data: &usize, state: &mut CounterState| {
             state.count += data
         });
 
@@ -313,7 +313,7 @@ mod tests {
         let rs: ReadStream<String> = ReadStream::new();
         let irs: Rc<RefCell<InternalReadStream<String>>> = (&rs).into();
         let (tx1, mut rx1) = mpsc::unbounded_channel();
-        rs.add_callback(move |_t: Timestamp, _msg: String| {
+        rs.add_callback(move |_t: &Timestamp, _msg: &String| {
             tx1.send("callback invoked").unwrap();
         });
         let (tx2, mut rx2) = mpsc::unbounded_channel();

--- a/src/dataflow/operators/join_operator.rs
+++ b/src/dataflow/operators/join_operator.rs
@@ -146,15 +146,15 @@ impl<'a, D1: Data, D2: Data, D3: Data + Deserialize<'a>> JoinOperator<D1, D2, D3
     /// The function to be called when a message is received on the left input stream.
     /// This callback adds the data received in the message to the state associated with the
     /// stream.
-    fn on_left_data_callback(t: Timestamp, msg: D1, state: &mut StreamState<D1>) {
-        state.add_msg(&t, msg);
+    fn on_left_data_callback(t: &Timestamp, msg: &D1, state: &mut StreamState<D1>) {
+        state.add_msg(t, msg.clone());
     }
 
     /// The function to be called when a message is received on the right input stream.
     /// This callback adds the data received in the message to the state associated with the
     /// stream.
-    fn on_right_data_callback(t: Timestamp, msg: D2, state: &mut StreamState<D2>) {
-        state.add_msg(&t, msg);
+    fn on_right_data_callback(t: &Timestamp, msg: &D2, state: &mut StreamState<D2>) {
+        state.add_msg(t, msg.clone());
     }
 
     /// The function to be called when a watermark is received on both the left and the right

--- a/src/dataflow/stream/internal_stateful_read_stream.rs
+++ b/src/dataflow/stream/internal_stateful_read_stream.rs
@@ -21,7 +21,7 @@ pub struct InternalStatefulReadStream<D: Data, S: State> {
     /// simultaneously.
     state: Arc<S>,
     /// Callbacks registered on the stream.
-    callbacks: Vec<Arc<dyn Fn(Timestamp, D, &mut S)>>,
+    callbacks: Vec<Arc<dyn Fn(&Timestamp, &D, &mut S)>>,
     /// Watermark callbacks registered on the stream.
     watermark_cbs: Vec<Arc<dyn Fn(&Timestamp, &mut S)>>,
     /// Vector of stream bundles that must be invoked when this stream receives a message.
@@ -46,7 +46,7 @@ impl<D: Data, S: State> InternalStatefulReadStream<D, S> {
     /// Add a callback to be invoked when the stream receives a message.
     /// The callback will be invoked for each message, and will receive the
     /// message and the stream's state as arguments.
-    pub fn add_callback<F: 'static + Fn(Timestamp, D, &mut S)>(&mut self, callback: F) {
+    pub fn add_callback<F: 'static + Fn(&Timestamp, &D, &mut S)>(&mut self, callback: F) {
         self.callbacks.push(Arc::new(callback));
     }
 
@@ -92,7 +92,7 @@ impl<D: Data, S: State> EventMakerT for InternalStatefulReadStream<D, S> {
                                     unsafe { Arc::get_mut_unchecked(&mut state_arc) };
                                 state_ref_mut.set_access_context(AccessContext::Callback);
                                 state_ref_mut.set_current_time(msg.timestamp.clone());
-                                (callback)(msg_copy.timestamp, msg_copy.data, state_ref_mut)
+                                (callback)(&msg_copy.timestamp, &msg_copy.data, state_ref_mut)
                             }
                         },
                     ));

--- a/src/dataflow/stream/mod.rs
+++ b/src/dataflow/stream/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     dataflow::{Data, Message},
     node::operator_event::OperatorEvent,
@@ -32,7 +34,7 @@ pub trait EventMakerT {
     fn get_id(&self) -> StreamId;
 
     /// Returns the vector of events that a message receipt generates.
-    fn make_events(&self, msg: Message<Self::EventDataType>) -> Vec<OperatorEvent>;
+    fn make_events(&self, msg: Arc<Message<Self::EventDataType>>) -> Vec<OperatorEvent>;
 }
 
 pub trait WriteStreamT<D: Data> {

--- a/src/dataflow/stream/mod.rs
+++ b/src/dataflow/stream/mod.rs
@@ -98,7 +98,7 @@ mod tests {
             ws.send(msg2).unwrap();
         });
         let first_msg = rt.block_on(rx.recv()).unwrap();
-        match first_msg {
+        match &*first_msg {
             Message::TimestampedData(td) => {
                 assert_eq!(td.data, 1);
             }
@@ -107,7 +107,7 @@ mod tests {
             }
         }
         let second_msg = rt.block_on(rx.recv()).unwrap();
-        match second_msg {
+        match &*second_msg {
             Message::TimestampedData(td) => {
                 assert_eq!(td.data, 2);
             }
@@ -133,7 +133,7 @@ mod tests {
             ws.send(w2).unwrap();
         });
         let w1 = rt.block_on(rx.recv()).unwrap();
-        match w1 {
+        match &*w1 {
             Message::Watermark(t) => {
                 assert_eq!(t.time[0], 1);
             }
@@ -142,7 +142,7 @@ mod tests {
             }
         }
         let w2 = rt.block_on(rx.recv()).unwrap();
-        match w2 {
+        match &*w2 {
             Message::Watermark(t) => {
                 assert_eq!(t.time[0], 2);
             }

--- a/src/dataflow/stream/read_stream.rs
+++ b/src/dataflow/stream/read_stream.rs
@@ -24,7 +24,7 @@ impl<D: Data> ReadStream<D> {
     }
 
     /// Add a callback to be invoked when the stream receives a message.
-    pub fn add_callback<F: 'static + Fn(Timestamp, D)>(&self, callback: F) {
+    pub fn add_callback<F: 'static + Fn(&Timestamp, &D)>(&self, callback: F) {
         self.internal_stream.borrow_mut().add_callback(callback);
     }
 

--- a/src/dataflow/stream/stateful_read_stream.rs
+++ b/src/dataflow/stream/stateful_read_stream.rs
@@ -23,7 +23,7 @@ impl<D: Data, T: State> StatefulReadStream<D, T> {
     /// Add a callback to be invoked when the stream receives a message.
     /// The callback will be invoked for each message, and will receive the
     /// message and the stream's state as arguments.
-    pub fn add_callback<F: 'static + Fn(Timestamp, D, &mut T)>(&self, callback: F) {
+    pub fn add_callback<F: 'static + Fn(&Timestamp, &D, &mut T)>(&self, callback: F) {
         self.internal_stream.borrow_mut().add_callback(callback);
     }
 

--- a/src/dataflow/stream/write_stream.rs
+++ b/src/dataflow/stream/write_stream.rs
@@ -121,7 +121,6 @@ impl<D: Data> fmt::Debug for WriteStream<D> {
 impl<'a, D: Data + Deserialize<'a>> WriteStreamT<D> for WriteStream<D> {
     /// Specialized implementation for when the Data does not implement `Abomonation`.
     fn send(&mut self, msg: Message<D>) -> Result<(), WriteStreamError> {
-        let start = crate::current_time_us();
         if self.stream_closed {
             return Err(WriteStreamError::Closed);
         }
@@ -148,7 +147,6 @@ impl<'a, D: Data + Deserialize<'a>> WriteStreamT<D> for WriteStream<D> {
             self.inter_thread_endpoints = Vec::with_capacity(0);
             self.inter_process_endpoints = Vec::with_capacity(0);
         }
-        println!("WriteStream::send took {} us", crate::current_time_us() - start);
         Ok(())
     }
 }

--- a/src/dataflow/stream/write_stream.rs
+++ b/src/dataflow/stream/write_stream.rs
@@ -121,6 +121,7 @@ impl<D: Data> fmt::Debug for WriteStream<D> {
 impl<'a, D: Data + Deserialize<'a>> WriteStreamT<D> for WriteStream<D> {
     /// Specialized implementation for when the Data does not implement `Abomonation`.
     fn send(&mut self, msg: Message<D>) -> Result<(), WriteStreamError> {
+        let start = crate::current_time_us();
         if self.stream_closed {
             return Err(WriteStreamError::Closed);
         }
@@ -147,6 +148,7 @@ impl<'a, D: Data + Deserialize<'a>> WriteStreamT<D> for WriteStream<D> {
             self.inter_thread_endpoints = Vec::with_capacity(0);
             self.inter_process_endpoints = Vec::with_capacity(0);
         }
+        println!("WriteStream::send took {} us", crate::current_time_us() - start);
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,10 +468,3 @@ pub fn new_app(name: &str) -> clap::App {
                 .help("Exports the dataflow graph as a DOT file to the provided filename"),
         )
 }
-
-fn current_time_us() -> u128 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_micros()
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,3 +468,10 @@ pub fn new_app(name: &str) -> clap::App {
                 .help("Exports the dataflow graph as a DOT file to the provided filename"),
         )
 }
+
+fn current_time_us() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -42,7 +42,7 @@ pub trait OperatorExecutorStreamT: Send + Stream<Item = Vec<OperatorEvent>> {
 
 pub struct OperatorExecutorStream<D: Data> {
     stream: Rc<RefCell<InternalReadStream<D>>>,
-    recv_endpoint: Option<RecvEndpoint<Message<D>>>,
+    recv_endpoint: Option<RecvEndpoint<Arc<Message<D>>>>,
     closed: Arc<AtomicBool>,
 }
 
@@ -83,8 +83,7 @@ impl<D: Data> Stream for OperatorExecutorStream<D> {
                         self.closed.store(true, Ordering::SeqCst);
                         self.recv_endpoint = None;
                     }
-                    let msg_arc = Arc::new(msg);
-                    Poll::Ready(Some(self.stream.borrow().make_events(msg_arc)))
+                    Poll::Ready(Some(self.stream.borrow().make_events(msg)))
                 }
                 Poll::Ready(None) => Poll::Ready(None),
                 Poll::Pending => Poll::Pending,

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -211,7 +211,8 @@ impl OperatorExecutor {
         );
 
         // Callbacks are not invoked while the operator is running.
-        self.operator.run();
+        tokio::task::block_in_place(|| self.operator.run());
+        // self.operator.run();
 
         if let Some(mut event_stream) = self.event_stream.take() {
             // Launch consumers

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -83,7 +83,8 @@ impl<D: Data> Stream for OperatorExecutorStream<D> {
                         self.closed.store(true, Ordering::SeqCst);
                         self.recv_endpoint = None;
                     }
-                    Poll::Ready(Some(self.stream.borrow().make_events(msg)))
+                    let msg_arc = Arc::new(msg);
+                    Poll::Ready(Some(self.stream.borrow().make_events(msg_arc)))
                 }
                 Poll::Ready(None) => Poll::Ready(None),
                 Poll::Pending => Poll::Pending,

--- a/src/scheduler/endpoints_manager.rs
+++ b/src/scheduler/endpoints_manager.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
-    communication::{PusherT, SerializedMessage},
+    communication::{InterProcessMessage, PusherT},
     dataflow::stream::StreamId,
     node::NodeId,
 };
@@ -44,7 +44,7 @@ impl ChannelsToReceivers {
 /// Wrapper used to store mappings between node ids and `mpsc::UnboundedSender` to sender threads.
 pub struct ChannelsToSenders {
     /// The ith sender corresponds to a TCP connection to the ith node.
-    senders: HashMap<NodeId, UnboundedSender<SerializedMessage>>,
+    senders: HashMap<NodeId, UnboundedSender<InterProcessMessage>>,
 }
 
 impl ChannelsToSenders {
@@ -58,7 +58,7 @@ impl ChannelsToSenders {
     pub fn add_sender(
         &mut self,
         node_id: NodeId,
-        sender: tokio::sync::mpsc::UnboundedSender<SerializedMessage>,
+        sender: tokio::sync::mpsc::UnboundedSender<InterProcessMessage>,
     ) {
         self.senders.insert(node_id, sender);
     }
@@ -67,7 +67,7 @@ impl ChannelsToSenders {
     pub fn clone_channel(
         &self,
         node_id: NodeId,
-    ) -> Option<tokio::sync::mpsc::UnboundedSender<SerializedMessage>> {
+    ) -> Option<tokio::sync::mpsc::UnboundedSender<InterProcessMessage>> {
         self.senders.get(&node_id).map(|c| c.clone())
     }
 }

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -56,8 +56,8 @@ impl RecvOperator {
 
     pub fn connect(_read_stream: &ReadStream<usize>) {}
 
-    pub fn msg_callback(_t: Timestamp, msg: usize) {
-        println!("RecvOperator: received {}", msg);
+    pub fn msg_callback(_t: &Timestamp, data: &usize) {
+        println!("RecvOperator: received {}", data);
     }
 }
 
@@ -82,10 +82,10 @@ impl SquareOperator {
         WriteStream::new()
     }
 
-    pub fn msg_callback(t: Timestamp, data: usize, write_stream: &mut WriteStream<usize>) {
+    pub fn msg_callback(t: &Timestamp, data: &usize, write_stream: &mut WriteStream<usize>) {
         println!("SquareOperator: received {}", data);
         write_stream
-            .send(Message::new_message(t, data * data))
+            .send(Message::new_message(t.clone(), data * data))
             .unwrap();
     }
 }
@@ -102,7 +102,7 @@ impl DestroyOperator {
 
     pub fn connect(_read_stream: &ReadStream<usize>) {}
 
-    pub fn msg_callback(_t: Timestamp, data: usize) {
+    pub fn msg_callback(_t: &Timestamp, data: &usize) {
         let logger = erdos::get_terminal_logger();
         slog::debug!(logger, "DestroyOperator: received {}", data);
     }

--- a/tests/operator_test.rs
+++ b/tests/operator_test.rs
@@ -49,7 +49,7 @@ fn test_input_receiver_map() {
     let mut map_config = OperatorConfig::new();
     map_config
         .name("MapOperator")
-        .arg(|data: u32| -> u64 { (data * 2) as u64 });
+        .arg(|data: &u32| -> u64 { (data * 2) as u64 });
     let s2 = connect_1_write!(MapOperator<u32, u64>, map_config, s1);
     let mut extract_stream = ExtractStream::new(0, &s2);
 

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -50,8 +50,8 @@ impl TimeVersionedStateOp {
         WriteStream::new()
     }
 
-    pub fn callback(_t: Timestamp, data: usize, cb_state: &mut TimeVersionedState<(), usize>) {
-        cb_state.append(data);
+    pub fn callback(_t: &Timestamp, data: &usize, cb_state: &mut TimeVersionedState<(), usize>) {
+        cb_state.append(*data);
     }
 
     fn watermark_callback_helper(

--- a/tests/watermark_test.rs
+++ b/tests/watermark_test.rs
@@ -107,7 +107,7 @@ fn test_flow_watermarks() {
     let mut map_config = OperatorConfig::new();
     map_config
         .name("MapOperator")
-        .arg(|a: usize| -> usize { a });
+        .arg(|a: &usize| -> usize { *a });
     let s2 = connect_1_write!(MapOperator<usize, usize>, map_config, s1);
     connect_0_write!(
         RecvOperator,
@@ -129,7 +129,7 @@ fn test_no_flow_watermarks() {
     let mut map_config = OperatorConfig::new();
     map_config
         .name("MapOperator")
-        .arg(|a: usize| -> usize { a })
+        .arg(|a: &usize| -> usize { *a })
         .flow_watermarks(false);
     let s2 = connect_1_write!(MapOperator<usize, usize>, map_config, s1);
     connect_0_write!(


### PR DESCRIPTION
- Adds zero-copy communication for operators colocated on the same node.
- Zero-copy mechanisms speed up cross-node communication by reducing copies on the communication path.
- Further speed up cross-node communication by serializing directly into the network buffer.
- Operators receive references to timestamps and messages rather than taking ownership to further reduce copies.