### PR TITLE
Reorganize modules to restrict visibility

### DIFF
--- a/src/communication/control_message_handler.rs
+++ b/src/communication/control_message_handler.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use slog::Logger;
+use slog::{self, Logger};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use crate::node::NodeId;
@@ -43,9 +43,10 @@ impl ControlMessageHandler {
         tx: UnboundedSender<ControlMessage>,
     ) {
         if let Some(_) = self.channels_to_control_senders.insert(node_id, tx) {
-            error!(
+            slog::error!(
                 self.logger,
-                "ControlMessageHandler: overwrote channel to control sender for node {}", node_id
+                "ControlMessageHandler: overwrote channel to control sender for node {}",
+                node_id
             );
         }
     }
@@ -77,9 +78,10 @@ impl ControlMessageHandler {
         tx: UnboundedSender<ControlMessage>,
     ) {
         if let Some(_) = self.channels_to_control_receivers.insert(node_id, tx) {
-            error!(
+            slog::error!(
                 self.logger,
-                "ControlMessageHandler: overwrote channel to control receiver for node {}", node_id
+                "ControlMessageHandler: overwrote channel to control receiver for node {}",
+                node_id
             );
         }
     }
@@ -111,9 +113,10 @@ impl ControlMessageHandler {
         tx: UnboundedSender<ControlMessage>,
     ) {
         if let Some(_) = self.channels_to_data_senders.insert(node_id, tx) {
-            error!(
+            slog::error!(
                 self.logger,
-                "ControlMessageHandler: overwrote channel to data sender for node {}", node_id
+                "ControlMessageHandler: overwrote channel to data sender for node {}",
+                node_id
             );
         }
     }
@@ -145,9 +148,10 @@ impl ControlMessageHandler {
         tx: UnboundedSender<ControlMessage>,
     ) {
         if let Some(_) = self.channels_to_data_receivers.insert(node_id, tx) {
-            error!(
+            slog::error!(
                 self.logger,
-                "ControlMessageHandler: overwrote channel to data receiver for node {}", node_id
+                "ControlMessageHandler: overwrote channel to data receiver for node {}",
+                node_id
             );
         }
     }

--- a/src/communication/control_message_handler.rs
+++ b/src/communication/control_message_handler.rs
@@ -22,6 +22,7 @@ pub struct ControlMessageHandler {
     channels_to_nodes: HashMap<NodeId, UnboundedSender<ControlMessage>>,
 }
 
+#[allow(dead_code)]
 impl ControlMessageHandler {
     pub fn new(logger: Logger) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();

--- a/src/communication/receivers.rs
+++ b/src/communication/receivers.rs
@@ -16,7 +16,7 @@ use crate::{
         InterProcessMessage, MessageCodec, PusherT,
     },
     dataflow::stream::StreamId,
-    node::node::NodeId,
+    node::NodeId,
     scheduler::endpoints_manager::ChannelsToReceivers,
 };
 

--- a/src/communication/senders.rs
+++ b/src/communication/senders.rs
@@ -15,7 +15,7 @@ use crate::communication::{
     CommunicationError, ControlMessage, ControlMessageCodec, ControlMessageHandler,
     InterProcessMessage, MessageCodec,
 };
-use crate::node::node::NodeId;
+use crate::node::NodeId;
 use crate::scheduler::endpoints_manager::ChannelsToSenders;
 
 #[allow(dead_code)]

--- a/src/dataflow/graph/mod.rs
+++ b/src/dataflow/graph/mod.rs
@@ -7,14 +7,20 @@ use crate::{
     scheduler::channel_manager::ChannelManager,
 };
 
-pub mod default_graph;
-pub mod edge;
-pub mod graph;
-pub mod vertex;
+// Private submodules
+mod edge;
+mod graph;
+mod vertex;
 
-pub use edge::{Channel, ChannelMetadata, StreamMetadata};
+// Public submodules
+pub mod default_graph;
+
+// Crate-wide exports
+pub(crate) use edge::{Channel, ChannelMetadata, StreamMetadata};
+pub(crate) use vertex::{DriverMetadata, OperatorMetadata, Vertex};
+
+// Public exports
 pub use graph::Graph;
-pub use vertex::{DriverMetadata, OperatorMetadata, Vertex};
 
 pub trait OperatorRunner:
     'static

--- a/src/dataflow/message.rs
+++ b/src/dataflow/message.rs
@@ -1,6 +1,7 @@
+use std::{cmp::Ordering, fmt::Debug};
+
+use abomonation_derive::*;
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
-use std::fmt::Debug;
 
 /// Trait for valid message data. The data must be clonable, sendable between threads and
 /// serializable.
@@ -12,7 +13,7 @@ impl<T> Data for T where
 }
 
 /// Operators send messages on streams. A message can be either a `Watermark` or a `TimestampedData`.
-#[derive(Clone, Debug, Serialize, Deserialize, Abomonation)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Message<D: Data> {
     TimestampedData(TimestampedData<D>),
     Watermark(Timestamp),

--- a/src/dataflow/message.rs
+++ b/src/dataflow/message.rs
@@ -13,7 +13,7 @@ impl<T> Data for T where
 }
 
 /// Operators send messages on streams. A message can be either a `Watermark` or a `TimestampedData`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Abomonation)]
 pub enum Message<D: Data> {
     TimestampedData(TimestampedData<D>),
     Watermark(Timestamp),

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -1,4 +1,4 @@
-// Export the modules to be visible outside of the dataflow module.
+// Public submodules
 pub mod callback_builder;
 pub mod graph;
 pub mod message;
@@ -7,13 +7,14 @@ pub mod operators;
 pub mod state;
 pub mod stream;
 
-// Re-export structs as if they were defined here.
+// Crate-wide exports
+pub(crate) use stream::EventMakerT;
+
+// Public exports
 pub use message::{Data, Message, Timestamp, TimestampedData};
 pub use operator::{Operator, OperatorConfig};
 pub use state::State;
-pub use stream::{
-    EventMakerT, LoopStream, ReadStream, StatefulReadStream, WriteStream, WriteStreamError,
-};
+pub use stream::{LoopStream, ReadStream, StatefulReadStream, WriteStream};
 
 #[cfg(test)]
 mod tests {

--- a/src/dataflow/operators/mod.rs
+++ b/src/dataflow/operators/mod.rs
@@ -1,7 +1,9 @@
-pub mod join_operator;
-pub mod map_operator;
-pub mod source_operator;
+// Private submodules
+mod join_operator;
+mod map_operator;
+mod source_operator;
 
+// Public exports
 pub use crate::dataflow::operators::join_operator::JoinOperator;
 pub use crate::dataflow::operators::map_operator::MapOperator;
 pub use crate::dataflow::operators::source_operator::SourceOperator;

--- a/src/dataflow/stream/ingest_stream.rs
+++ b/src/dataflow/stream/ingest_stream.rs
@@ -7,12 +7,12 @@ use std::{
 use serde::Deserialize;
 
 use crate::{
-    dataflow::{graph::default_graph, Data, Message, WriteStreamError},
+    dataflow::{graph::default_graph, Data, Message},
     node::NodeId,
     scheduler::channel_manager::ChannelManager,
 };
 
-use super::{StreamId, WriteStream, WriteStreamT};
+use super::{errors::WriteStreamError, StreamId, WriteStream, WriteStreamT};
 
 pub struct IngestStream<D>
 where

--- a/src/dataflow/stream/mod.rs
+++ b/src/dataflow/stream/mod.rs
@@ -5,17 +5,23 @@ use crate::{
     node::operator_event::OperatorEvent,
 };
 
-pub mod errors;
-pub mod extract_stream;
-pub mod ingest_stream;
-pub mod internal_read_stream;
-pub mod internal_stateful_read_stream;
-pub mod loop_stream;
-pub mod read_stream;
-pub mod stateful_read_stream;
-pub mod write_stream;
+// Private submodules
+mod extract_stream;
+mod ingest_stream;
+mod internal_read_stream;
+mod internal_stateful_read_stream;
+mod loop_stream;
+mod read_stream;
+mod stateful_read_stream;
+mod write_stream;
 
-pub use errors::WriteStreamError;
+// Public submodules
+pub mod errors;
+
+// Private imports
+use errors::WriteStreamError;
+
+// Public exports
 pub use extract_stream::ExtractStream;
 pub use ingest_stream::IngestStream;
 pub use internal_read_stream::InternalReadStream;
@@ -27,7 +33,7 @@ pub use write_stream::WriteStream;
 
 pub type StreamId = crate::Uuid;
 
-pub trait EventMakerT {
+pub(crate) trait EventMakerT {
     type EventDataType: Data;
 
     /// Returns the id of the stream.

--- a/src/dataflow/stream/write_stream.rs
+++ b/src/dataflow/stream/write_stream.rs
@@ -4,10 +4,10 @@ use serde::Deserialize;
 
 use crate::{
     communication::{Pusher, SendEndpoint},
-    dataflow::{Data, Message, Timestamp, WriteStreamError},
+    dataflow::{Data, Message, Timestamp},
 };
 
-use super::{StreamId, WriteStreamT};
+use super::{errors::WriteStreamError, StreamId, WriteStreamT};
 
 // TODO: refactor with internal write stream
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,17 +33,13 @@
 #![feature(box_into_pin)]
 #![feature(vec_remove_item)]
 
-extern crate abomonation;
-#[macro_use]
-extern crate abomonation_derive;
-extern crate bincode;
-extern crate clap;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-pub extern crate slog;
-extern crate slog_term;
-pub extern crate tokio;
+pub use ::slog;
+pub use ::tokio;
+
+use abomonation_derive::*;
+use clap;
+use lazy_static::lazy_static;
+use slog_term;
 
 // Libraries used in this file.
 use clap::{App, Arg};
@@ -54,15 +50,20 @@ use slog_term::term_full;
 use std::{cell::RefCell, fmt};
 use uuid;
 
-// Export the modules to be visible outside of the library.
-pub mod communication;
+// Private submodules
 pub mod configuration;
-pub mod dataflow;
-pub mod node;
 #[cfg(feature = "python")]
 pub mod python;
+
+// Crate-wide visible submodules
+
+// Public submodules
+pub mod communication;
+pub mod dataflow;
+pub mod node;
 pub mod scheduler;
 
+// Public exports
 pub use configuration::Configuration;
 pub use dataflow::OperatorConfig;
 
@@ -423,7 +424,7 @@ pub fn reset() {
 
 lazy_static! {
     static ref TERMINAL_LOGGER: Logger =
-        Logger::root(std::sync::Mutex::new(term_full()).fuse(), o!());
+        Logger::root(std::sync::Mutex::new(term_full()).fuse(), slog::o!());
 }
 
 pub fn get_terminal_logger() -> slog::Logger {

--- a/src/node/lattice.rs
+++ b/src/node/lattice.rs
@@ -119,7 +119,7 @@ impl PartialOrd for RunnableEvent {
 /// # Example
 /// The below example shows how to insert events into the Lattice and retrieve runnable events from
 /// the lattice.
-/// ```
+/// ```ignore
 /// use erdos::node::{operator_event::OperatorEvent, lattice::ExecutionLattice};
 /// use erdos::dataflow::Timestamp;
 /// use futures::executor::block_on;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,8 +1,12 @@
-// Modules visible outside of the node module.
-pub mod node;
-pub mod operator_event;
-pub mod operator_executor;
-pub mod lattice;
+// Private submodules
+mod lattice;
+mod node;
 
-// Re-export structs as if they were defined here.
+// Crate-wide visible submodules
+pub(crate) mod operator_event;
+
+// Public submodules
+pub mod operator_executor;
+
+// Public exports
 pub use node::{Node, NodeHandle, NodeId};

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1,7 +1,6 @@
-use pyo3::{exceptions, prelude::*, types::*};
-
 use std::sync::{Arc, Mutex};
 
+use pyo3::{exceptions, prelude::*, types::*};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::{
@@ -11,20 +10,20 @@ use crate::{
         WriteStream,
     },
     node::{
-        node::NodeHandle,
         operator_executor::{OperatorExecutor, OperatorExecutorStream, OperatorExecutorStreamT},
-        Node, NodeId,
+        Node, NodeHandle, NodeId,
     },
     scheduler::channel_manager::ChannelManager,
     Configuration, Uuid,
 };
 
+// Private submodules
 mod py_message;
 mod py_stream;
 
+// Private imports
+use py_message::PyMessage;
 use py_stream::{PyExtractStream, PyIngestStream, PyLoopStream, PyReadStream, PyWriteStream};
-
-pub(crate) use py_message::PyMessage;
 
 #[pymodule]
 fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
@@ -348,7 +347,7 @@ impl Operator for PyOperator {
 }
 
 #[pyclass]
-pub(crate) struct PyNodeHandle {
+struct PyNodeHandle {
     node_handle: Option<NodeHandle>,
 }
 

--- a/src/python/py_stream/mod.rs
+++ b/src/python/py_stream/mod.rs
@@ -2,12 +2,14 @@ use pyo3::{exceptions, prelude::*};
 
 use crate::dataflow::StatefulReadStream;
 
+// Private submodules
 mod py_extract_stream;
 mod py_ingest_stream;
 mod py_loop_stream;
 mod py_read_stream;
 mod py_write_stream;
 
+// Public exports
 pub use py_extract_stream::PyExtractStream;
 pub use py_ingest_stream::PyIngestStream;
 pub use py_loop_stream::PyLoopStream;

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -1,12 +1,14 @@
 use crate::dataflow::graph::{Channel, Graph, Vertex};
 
-// Export the modules to be visible outside of the scheduler module.
+// Crate-wide visible submodules
+pub(crate) mod endpoints_manager;
+
+// Public exports
 pub mod channel_manager;
-pub mod endpoints_manager;
 
 /// Schedules a dataflow graph. Assigns operators to nodes and updates channels.
 /// After running this method, there should be no unscheduled channels remaining.
-pub fn schedule(graph: &Graph) -> Graph {
+pub(crate) fn schedule(graph: &Graph) -> Graph {
     let mut scheduled_graph = graph.clone();
     for stream in scheduled_graph.get_streams_ref_mut() {
         let source_node_id = match stream.get_source() {


### PR DESCRIPTION
Reorganizes `mod.rs` files so they follow the following format:
```rust
// Library imports (e.g. from std)

// Private submodules

// Crate-wide visible submodules

// Public submodules

// Private imports

// Crate-wide exports

// Public exports

// Functions, struct declarations, implementation, etc.
```
Also restricts visibility of submodules and other objects to reduce the amount of internal objects visible in the public documentation.
