### PR TITLE
Fix warnings

### DIFF
--- a/src/dataflow/operators/map_operator.rs
+++ b/src/dataflow/operators/map_operator.rs
@@ -22,8 +22,6 @@ use std::marker::PhantomData;
 /// let output_read_stream = connect_1_write!(MapOperator<u32, u64>, map_config, ingest_stream);
 /// ```
 pub struct MapOperator<D1: Data, D2: Data> {
-    /// The name given to the specific instance of the MapOperator.
-    name: String,
     phantom_data: PhantomData<(D1, D2)>,
 }
 
@@ -60,7 +58,6 @@ impl<'a, D1: Data, D2: Data + Deserialize<'a>> MapOperator<D1, D2> {
             },
         );
         Self {
-            name,
             phantom_data: PhantomData,
         }
     }
@@ -87,7 +84,12 @@ impl<'a, D1: Data, D2: Data + Deserialize<'a>> MapOperator<D1, D2> {
         map_function: &F,
     ) {
         let result: D2 = map_function(msg);
-        output_stream.send(Message::new_message(t.clone(), result));
+        output_stream
+            .send(Message::new_message(t.clone(), result))
+            .expect(&format!(
+                "Map operator unable to send message on stream {}",
+                output_stream.get_id()
+            ));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,8 @@ macro_rules! make_operator {
     };
 }
 
-/// Makes a closure that initializes the operator and returns the corresponding [`OperatorExecutor`].
+/// Makes a closure that initializes the operator and returns a corresponding
+/// [`OperatorExecutor`](crate::node::operator_executor::OperatorExecutor).
 ///
 /// Note: this is intended as an internal macro called by connect_x_write!
 #[macro_export]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,12 @@ fn main() {
         SourceOperator,
         OperatorConfig::new().name("SourceOperator2")
     );
-    let _s3 = connect_1_write!(JoinOperator<usize, usize, usize>, OperatorConfig::new().name("JoinOperator").arg(|left: Vec<usize>, right: Vec<usize>| -> usize { left.iter().sum() }), s1, s2);
+    let _s3 = connect_1_write!(JoinOperator<usize, usize, usize>, OperatorConfig::new().name("JoinOperator").arg(
+        |left: Vec<usize>, right: Vec<usize>| -> usize {
+            let left_sum: usize = left.iter().sum();
+            let right_sum: usize = right.iter().sum();
+            left_sum + right_sum
+        }), s1, s2);
 
     node.run();
 }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use pyo3::{exceptions, prelude::*, types::*};
+use slog;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::{
@@ -82,7 +83,7 @@ fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
         let operator_runner =
             move |channel_manager: Arc<Mutex<ChannelManager>>,
                   control_sender: UnboundedSender<ControlMessage>,
-                  mut control_receiver: UnboundedReceiver<ControlMessage>| {
+                  control_receiver: UnboundedReceiver<ControlMessage>| {
                 // Create python streams from endpoints
                 let py_read_streams: Vec<PyReadStream> = read_stream_ids_clone
                     .clone()
@@ -199,9 +200,10 @@ if flow_watermarks and len(read_streams) > 0 and len(write_streams) > 0:
                 // Notify node that operator is done setting up
                 let logger = crate::get_terminal_logger();
                 if let Err(e) = control_sender.send(ControlMessage::OperatorInitialized(op_id)) {
-                    error!(
+                    slog::error!(
                         logger,
-                        "Error sending OperatorInitialized message to control handler: {:?}", e
+                        "Error sending OperatorInitialized message to control handler: {:?}",
+                        e
                     );
                 }
 

--- a/src/python/py_stream/py_ingest_stream.rs
+++ b/src/python/py_stream/py_ingest_stream.rs
@@ -2,7 +2,7 @@ use pyo3::{exceptions, prelude::*};
 
 use crate::{
     dataflow::{
-        stream::{IngestStream, ReadStream, WriteStreamT},
+        stream::{IngestStream, ReadStream},
         Message,
     },
     node::NodeId,

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -121,9 +121,9 @@ pub struct TwoStreamDestroyOperator {}
 impl TwoStreamDestroyOperator {
     pub fn new(
         _config: OperatorConfig<()>,
-        left_stream: ReadStream<usize>,
-        right_stream: ReadStream<usize>,
-        write_stream: WriteStream<bool>,
+        _left_stream: ReadStream<usize>,
+        _right_stream: ReadStream<usize>,
+        _write_stream: WriteStream<bool>,
     ) -> Self {
         Self {}
     }

--- a/tests/macro_tests.rs
+++ b/tests/macro_tests.rs
@@ -6,27 +6,24 @@ use erdos::dataflow::{
 use erdos::node::Node;
 
 use erdos::*;
-use std::thread;
 
 mod utils;
 
 /// Operator that outputs 10 integers on two output streams.
 pub struct TwoOutputZeroInputGenerator {
-    name: String,
-    output_stream_a: WriteStream<u32>,
-    output_stream_b: WriteStream<u32>,
+    write_stream_a: WriteStream<u32>,
+    write_stream_b: WriteStream<u32>,
 }
 
 impl TwoOutputZeroInputGenerator {
     pub fn new(
-        config: OperatorConfig<()>,
-        output_stream_a: WriteStream<u32>,
-        output_stream_b: WriteStream<u32>,
+        _config: OperatorConfig<()>,
+        write_stream_a: WriteStream<u32>,
+        write_stream_b: WriteStream<u32>,
     ) -> Self {
         Self {
-            name: config.name.unwrap(),
-            output_stream_a,
-            output_stream_b,
+            write_stream_a,
+            write_stream_b,
         }
     }
 
@@ -38,10 +35,12 @@ impl TwoOutputZeroInputGenerator {
 impl Operator for TwoOutputZeroInputGenerator {
     fn run(&mut self) {
         for i in 0..10 {
-            self.output_stream_a
-                .send(Message::new_message(Timestamp::new(vec![i as u64]), i));
-            self.output_stream_b
-                .send(Message::new_message(Timestamp::new(vec![i as u64]), i));
+            self.write_stream_a
+                .send(Message::new_message(Timestamp::new(vec![i as u64]), i))
+                .unwrap();
+            self.write_stream_b
+                .send(Message::new_message(Timestamp::new(vec![i as u64]), i))
+                .unwrap();
         }
     }
 }
@@ -84,28 +83,26 @@ fn test_two_output_zero_input_generator() {
 
 /// Operator that outputs 10 integers on two output streams, with one input stream.
 pub struct TwoOutputOneInputGenerator {
-    name: String,
-    read_stream: ReadStream<u32>,
-    output_stream_a: WriteStream<u32>,
-    output_stream_b: WriteStream<u32>,
+    _read_stream: ReadStream<u32>,
+    write_stream_a: WriteStream<u32>,
+    write_stream_b: WriteStream<u32>,
 }
 
 impl TwoOutputOneInputGenerator {
     pub fn new(
-        config: OperatorConfig<()>,
-        read_stream: ReadStream<u32>,
-        output_stream_a: WriteStream<u32>,
-        output_stream_b: WriteStream<u32>,
+        _config: OperatorConfig<()>,
+        _read_stream: ReadStream<u32>,
+        write_stream_a: WriteStream<u32>,
+        write_stream_b: WriteStream<u32>,
     ) -> Self {
         Self {
-            name: config.name.unwrap(),
-            read_stream,
-            output_stream_a,
-            output_stream_b,
+            _read_stream,
+            write_stream_a,
+            write_stream_b,
         }
     }
 
-    pub fn connect(read_stream: &ReadStream<u32>) -> (WriteStream<u32>, WriteStream<u32>) {
+    pub fn connect(_read_stream: &ReadStream<u32>) -> (WriteStream<u32>, WriteStream<u32>) {
         (WriteStream::new(), WriteStream::new())
     }
 }
@@ -113,10 +110,12 @@ impl TwoOutputOneInputGenerator {
 impl Operator for TwoOutputOneInputGenerator {
     fn run(&mut self) {
         for i in 0..10 {
-            self.output_stream_a
-                .send(Message::new_message(Timestamp::new(vec![i as u64]), i));
-            self.output_stream_b
-                .send(Message::new_message(Timestamp::new(vec![i as u64]), i));
+            self.write_stream_a
+                .send(Message::new_message(Timestamp::new(vec![i as u64]), i))
+                .unwrap();
+            self.write_stream_b
+                .send(Message::new_message(Timestamp::new(vec![i as u64]), i))
+                .unwrap();
         }
     }
 }
@@ -161,24 +160,22 @@ fn test_two_output_one_input_generator() {
 
 /// Operator that outputs 10 integers on three output streams.
 pub struct ThreeOutputZeroInputGenerator {
-    name: String,
-    output_stream_a: WriteStream<u32>,
-    output_stream_b: WriteStream<u32>,
-    output_stream_c: WriteStream<u32>,
+    write_stream_a: WriteStream<u32>,
+    write_stream_b: WriteStream<u32>,
+    write_stream_c: WriteStream<u32>,
 }
 
 impl ThreeOutputZeroInputGenerator {
     pub fn new(
-        config: OperatorConfig<()>,
-        output_stream_a: WriteStream<u32>,
-        output_stream_b: WriteStream<u32>,
-        output_stream_c: WriteStream<u32>,
+        _config: OperatorConfig<()>,
+        write_stream_a: WriteStream<u32>,
+        write_stream_b: WriteStream<u32>,
+        write_stream_c: WriteStream<u32>,
     ) -> Self {
         Self {
-            name: config.name.unwrap(),
-            output_stream_a,
-            output_stream_b,
-            output_stream_c,
+            write_stream_a,
+            write_stream_b,
+            write_stream_c,
         }
     }
 
@@ -190,12 +187,15 @@ impl ThreeOutputZeroInputGenerator {
 impl Operator for ThreeOutputZeroInputGenerator {
     fn run(&mut self) {
         for i in 0..10 {
-            self.output_stream_a
-                .send(Message::new_message(Timestamp::new(vec![i as u64]), i));
-            self.output_stream_b
-                .send(Message::new_message(Timestamp::new(vec![i as u64]), i));
-            self.output_stream_c
-                .send(Message::new_message(Timestamp::new(vec![i as u64]), i));
+            self.write_stream_a
+                .send(Message::new_message(Timestamp::new(vec![i as u64]), i))
+                .unwrap();
+            self.write_stream_b
+                .send(Message::new_message(Timestamp::new(vec![i as u64]), i))
+                .unwrap();
+            self.write_stream_c
+                .send(Message::new_message(Timestamp::new(vec![i as u64]), i))
+                .unwrap();
         }
     }
 }
@@ -247,32 +247,30 @@ fn test_three_output_zero_input_generator() {
 
 /// Operator that outputs 10 integers on three output streams, with one input stream.
 pub struct ThreeOutputOneInputGenerator {
-    name: String,
-    input_stream: ReadStream<u32>,
-    output_stream_a: WriteStream<u32>,
-    output_stream_b: WriteStream<u32>,
-    output_stream_c: WriteStream<u32>,
+    _read_stream: ReadStream<u32>,
+    write_stream_a: WriteStream<u32>,
+    write_stream_b: WriteStream<u32>,
+    write_stream_c: WriteStream<u32>,
 }
 
 impl ThreeOutputOneInputGenerator {
     pub fn new(
-        config: OperatorConfig<()>,
-        input_stream: ReadStream<u32>,
-        output_stream_a: WriteStream<u32>,
-        output_stream_b: WriteStream<u32>,
-        output_stream_c: WriteStream<u32>,
+        _config: OperatorConfig<()>,
+        read_stream: ReadStream<u32>,
+        write_stream_a: WriteStream<u32>,
+        write_stream_b: WriteStream<u32>,
+        write_stream_c: WriteStream<u32>,
     ) -> Self {
         Self {
-            name: config.name.unwrap(),
-            input_stream,
-            output_stream_a,
-            output_stream_b,
-            output_stream_c,
+            _read_stream: read_stream,
+            write_stream_a,
+            write_stream_b,
+            write_stream_c,
         }
     }
 
     pub fn connect(
-        input_stream: &ReadStream<u32>,
+        _read_stream: &ReadStream<u32>,
     ) -> (WriteStream<u32>, WriteStream<u32>, WriteStream<u32>) {
         (WriteStream::new(), WriteStream::new(), WriteStream::new())
     }
@@ -281,12 +279,15 @@ impl ThreeOutputOneInputGenerator {
 impl Operator for ThreeOutputOneInputGenerator {
     fn run(&mut self) {
         for i in 0..10 {
-            self.output_stream_a
-                .send(Message::new_message(Timestamp::new(vec![i as u64]), i));
-            self.output_stream_b
-                .send(Message::new_message(Timestamp::new(vec![i as u64]), i));
-            self.output_stream_c
-                .send(Message::new_message(Timestamp::new(vec![i as u64]), i));
+            self.write_stream_a
+                .send(Message::new_message(Timestamp::new(vec![i as u64]), i))
+                .unwrap();
+            self.write_stream_b
+                .send(Message::new_message(Timestamp::new(vec![i as u64]), i))
+                .unwrap();
+            self.write_stream_c
+                .send(Message::new_message(Timestamp::new(vec![i as u64]), i))
+                .unwrap();
         }
     }
 }

--- a/tests/operator_test.rs
+++ b/tests/operator_test.rs
@@ -3,25 +3,20 @@ use erdos::dataflow::{
     operators::JoinOperator,
     operators::MapOperator,
     stream::{ExtractStream, WriteStreamT},
-    Message, Operator, OperatorConfig, ReadStream, Timestamp, WriteStream,
+    Message, Operator, OperatorConfig, Timestamp, WriteStream,
 };
 use erdos::node::Node;
 use erdos::*;
-use std::thread;
 
 mod utils;
 
 pub struct InputGenOp {
-    name: String,
     output_stream: WriteStream<u32>,
 }
 
 impl InputGenOp {
-    pub fn new(config: OperatorConfig<()>, output_stream: WriteStream<u32>) -> Self {
-        Self {
-            name: config.name.unwrap(),
-            output_stream,
-        }
+    pub fn new(_config: OperatorConfig<()>, output_stream: WriteStream<u32>) -> Self {
+        Self { output_stream }
     }
 
     pub fn connect() -> WriteStream<u32> {
@@ -33,9 +28,11 @@ impl Operator for InputGenOp {
     fn run(&mut self) {
         for i in 0..10 {
             self.output_stream
-                .send(Message::new_message(Timestamp::new(vec![i as u64]), i));
+                .send(Message::new_message(Timestamp::new(vec![i as u64]), i))
+                .unwrap();
             self.output_stream
-                .send(Message::new_watermark(Timestamp::new(vec![i as u64])));
+                .send(Message::new_watermark(Timestamp::new(vec![i as u64])))
+                .unwrap();
         }
     }
 }

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -1,6 +1,3 @@
-use std::thread;
-use std::time::Duration;
-
 use slog;
 
 mod utils;
@@ -9,11 +6,8 @@ use erdos::{
     self,
     dataflow::{
         message::*,
-        state::{State, TimeVersionedState},
-        stream::{
-            errors::{ReadError, TryReadError, WriteStreamError},
-            ExtractStream, IngestStream, WriteStreamT,
-        },
+        state::TimeVersionedState,
+        stream::{ExtractStream, IngestStream, WriteStreamT},
         Operator, OperatorConfig, ReadStream, WriteStream,
     },
     node::Node,
@@ -46,12 +40,12 @@ impl TimeVersionedStateOp {
         Self {}
     }
 
-    pub fn connect(read_stream: &ReadStream<usize>) -> WriteStream<Option<usize>> {
+    pub fn connect(_read_stream: &ReadStream<usize>) -> WriteStream<Option<usize>> {
         WriteStream::new()
     }
 
     pub fn callback(_t: &Timestamp, data: &usize, cb_state: &mut TimeVersionedState<(), usize>) {
-        cb_state.append(*data);
+        cb_state.append(*data).expect("Error appending state");
     }
 
     fn watermark_callback_helper(


### PR DESCRIPTION
Fixes warnings when building ERDOS, tests, or the documentation.

Also fixes a minor bug introduced in the python bridge.

Makes variable naming in the tests more consistent. 