### PR TITLE
[Rust] Fix new nightly errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ERDOS is a platform for developing self-driving cars and robotics applications.
 keywords = ["data-flow", "robotics", "autonomos", "driving"]
 
 [dependencies]
-abomonation = "0.7.3"
+abomonation = { git = "https://github.com/erdos-project/abomonation" }
 abomonation_derive = "0.5.0"
 async-trait = "0.1.18"
 bincode = "1.2.1"

--- a/src/communication/serializable.rs
+++ b/src/communication/serializable.rs
@@ -47,7 +47,7 @@ where
 /// Specialized version used when messages derive `Abomonation`.
 impl<D> Serializable for D
 where
-    for<'a> D: Debug + Clone + Send + Serialize + Deserialize<'a> + Abomonation,
+    D: Debug + Clone + Send + Serialize + Abomonation,
 {
     fn encode(&self) -> Result<BytesMut, CommunicationError> {
         let mut serialized_msg: Vec<u8> = Vec::with_capacity(measure(self));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,6 @@
 #![feature(min_specialization)]
 #![feature(rustc_attrs)]
 #![feature(box_into_pin)]
-#![feature(vec_remove_item)]
 
 pub use ::slog;
 pub use ::tokio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,8 @@
 //! messages out of order.
 
 #![feature(get_mut_unchecked)]
-#![feature(specialization)]
+#![feature(min_specialization)]
+#![feature(rustc_attrs)]
 #![feature(box_into_pin)]
 #![feature(vec_remove_item)]
 

--- a/src/node/lattice.rs
+++ b/src/node/lattice.rs
@@ -299,9 +299,7 @@ impl ExecutionLattice {
             }
             run_queue.clear();
 
-            for n in &remove_roots {
-                roots.remove_item(n);
-            }
+            roots.retain(|e| !remove_roots.contains(e));
 
             for item in old_run_queue {
                 if !remove_roots.contains(&item) {
@@ -353,7 +351,12 @@ impl ExecutionLattice {
         let node_id: NodeIndex<u32> = NodeIndex::new(event_id);
 
         // Throw an error if the item was not in the roots.
-        roots.remove_item(&RunnableEvent::new(node_id)).unwrap();
+        let event = RunnableEvent::new(node_id);
+        let event_idx = roots
+            .iter()
+            .position(|e| e == &event)
+            .expect("Item must be in the roots of the lattice.");
+        roots.remove(event_idx);
 
         // Go over the children of the node, and check which ones have no dependencies on other
         // nodes, and add them to the list of the roots.


### PR DESCRIPTION
- The Rust specialization feature rust-lang/rust#31844 is unsound and throws a warning on the latest nightly. This PR moves to min_specialization which fixes the warning.
   - [Forks abomonation](https://github.com/erdos-project/abomonation) in order to allow specialization on structs that implement `Abomonation`.
- Replaces use of `Vec::remove_item` to end reliance on the deprecated `vec_remove_item` feature.