### PR TITLE
Replace fire with argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Then run the following to clone the repository and build ERDOS:
 ```console
 rustup default nightly  # use nightly Rust toolchain
 git clone https://github.com/erdos-project/erdos.git && cd erdos
-pip3 install fire
 cargo build
 ```
 
@@ -54,7 +53,6 @@ Then run the following to clone the repository and build ERDOS:
 ```console
 rustup default nightly  # use nightly Rust toolchain
 git clone https://github.com/erdos-project/erdos.git && cd erdos
-pip3 install fire
 python3 python/setup.py develop
 ```
 

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@ fn make_callback_builder() -> Result<(), String> {
 
     let child = Command::new("python3")
         .arg(callback_builder_script.to_str().unwrap())
-        .args(&["build", "15", "8"])
+        .args(&["15", "8"])
         .stdout(Stdio::from(callback_builder_file))
         .spawn()
         .map_err(|e| format!("make_callback_builder: {}", e.to_string()))?;

--- a/scripts/make_callback_builder.py
+++ b/scripts/make_callback_builder.py
@@ -494,9 +494,15 @@ def generate_code(num_rs, num_ws):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate callback builders for m read streams and n write streams.")
-    parser.add_argument("read_streams", type=int, help="number of read streams")
-    parser.add_argument("write_streams", type=int, help="number of write streams")
+    parser = argparse.ArgumentParser(
+        description=
+        "Generate callback builders for m read streams and n write streams.")
+    parser.add_argument("read_streams",
+                        type=int,
+                        help="number of read streams")
+    parser.add_argument("write_streams",
+                        type=int,
+                        help="number of write streams")
 
     args = parser.parse_args()
     generate_code(args.read_streams, args.write_streams)

--- a/scripts/make_callback_builder.py
+++ b/scripts/make_callback_builder.py
@@ -1,5 +1,5 @@
 # flake8: noqa E501
-import fire
+import argparse
 import itertools
 
 rust_imports = """// # Callback Builders for Multiple Streams
@@ -469,30 +469,34 @@ def make_builder(num_rs,
         received_watermark_assignments=received_watermark_assignments)
 
 
-class CLI(object):
-    def build(self, num_rs, num_ws):
-        print(rust_imports.format(num_rs=num_rs, num_ws=num_ws))
-        for i in range(1, num_rs + 1):
-            for j in range(num_ws + 1):
-                if i == 1 and j == 0:
-                    continue
-                include_add_read_stream = (i < num_rs)
-                include_add_write_stream = (j < num_ws)
-                print(
-                    make_builder(
-                        i,
-                        j,
-                        False,
-                        include_add_read_stream=include_add_read_stream,
-                        include_add_write_stream=include_add_write_stream))
-                print(
-                    make_builder(
-                        i,
-                        j,
-                        True,
-                        include_add_read_stream=include_add_read_stream,
-                        include_add_write_stream=include_add_write_stream))
+def generate_code(num_rs, num_ws):
+    print(rust_imports.format(num_rs=num_rs, num_ws=num_ws))
+    for i in range(1, num_rs + 1):
+        for j in range(num_ws + 1):
+            if i == 1 and j == 0:
+                continue
+            include_add_read_stream = (i < num_rs)
+            include_add_write_stream = (j < num_ws)
+            print(
+                make_builder(
+                    i,
+                    j,
+                    False,
+                    include_add_read_stream=include_add_read_stream,
+                    include_add_write_stream=include_add_write_stream))
+            print(
+                make_builder(
+                    i,
+                    j,
+                    True,
+                    include_add_read_stream=include_add_read_stream,
+                    include_add_write_stream=include_add_write_stream))
 
 
 if __name__ == "__main__":
-    fire.Fire(CLI)
+    parser = argparse.ArgumentParser(description="Generate callback builders for m read streams and n write streams.")
+    parser.add_argument("read_streams", type=int, help="number of read streams")
+    parser.add_argument("write_streams", type=int, help="number of write streams")
+
+    args = parser.parse_args()
+    generate_code(args.read_streams, args.write_streams)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! is responsible for connecting operators via streams.
 //! For information on building operators, see the [§ Operators](#operators).
 //!
-//! ```no_run
+//! ```ignore
 //! // Capture arguments to set up an ERDOS node.
 //! let args = erdos::new_app("ObjectCounter");
 //! // Create an ERDOS node which runs the application.


### PR DESCRIPTION
Replaces fire with argparse in the Python script that generates the callback builders.

This change removes a step from the install process.