### PR TITLE
Add Priorities for OperatorEvents

### DIFF
--- a/scripts/make_callback_builder.py
+++ b/scripts/make_callback_builder.py
@@ -279,7 +279,7 @@ make_receive_watermark_template = """
                     {get_states}
                     {clone_write_streams}
                     if !watermark_callbacks.is_empty() || !child_events.is_empty() {{
-                        events.push(OperatorEvent::new(current_low_watermark.clone(), true, move || {{
+                        events.push(OperatorEvent::new(current_low_watermark.clone(), true, 0, move || {{
                             for callback in watermark_callbacks {{
                                 (callback)({args});
                             }}
@@ -297,7 +297,7 @@ make_receive_watermark_template = """
                     {get_states}
                     {clone_write_streams}
                     if !watermark_callbacks.is_empty() || !child_events.is_empty() {{
-                        events.push(OperatorEvent::new(current_low_watermark.clone(), true, move || {{
+                        events.push(OperatorEvent::new(current_low_watermark.clone(), true, 0, move || {{
                             for callback in watermark_callbacks {{
                                 (callback)({args});
                             }}

--- a/scripts/make_callback_builder.py
+++ b/scripts/make_callback_builder.py
@@ -279,7 +279,9 @@ make_receive_watermark_template = """
                     {get_states}
                     {clone_write_streams}
                     if !watermark_callbacks.is_empty() || !child_events.is_empty() {{
-                        let priority = watermark_callbacks.last().unwrap().1;
+                        // TODO: fix this when unbundling operator events.
+                        let priority = watermark_callbacks.last().map(|x| x.1);
+                        let priority = std::cmp::max(child_events.iter().map(|event| event.priority).max(), priority).unwrap_or(0);
                         events.push(OperatorEvent::new(current_low_watermark.clone(), true, priority, move || {{
                             for (callback, _priority) in watermark_callbacks {{
                                 (callback)({args});
@@ -298,7 +300,8 @@ make_receive_watermark_template = """
                     {get_states}
                     {clone_write_streams}
                     if !watermark_callbacks.is_empty() || !child_events.is_empty() {{
-                        let priority = watermark_callbacks.last().unwrap().1;
+                        let priority = watermark_callbacks.last().map(|x| x.1);
+                        let priority = std::cmp::max(child_events.iter().map(|event| event.priority).max(), priority).unwrap_or(0);
                         events.push(OperatorEvent::new(current_low_watermark.clone(), true, priority, move || {{
                             for (callback, _priority) in watermark_callbacks {{
                                 (callback)({args});

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -7,14 +7,15 @@
 #[macro_export]
 macro_rules! flow_watermarks {
     (($($rs:ident),+), ($($ws:ident),+)) => {
-        $crate::add_watermark_callback!(($($rs.add_state(())),+), ($($ws),+), (|timestamp, $($rs),+, $($ws),+| {
+        let cb_builder = $crate::make_callback_builder!(($($rs.add_state(())),+), ($($ws),+));
+        cb_builder.borrow_mut().add_watermark_callback_with_priority(|timestamp, $($rs),+, $($ws),+| {
             $(
                 match $ws.send(Message::new_watermark(timestamp.clone())) {
                     Ok(_) => (),
                     Err(_) => eprintln!("Error flowing watermark"),
                 }
             )+
-        }));
+        }, 127);
     };
     // Cases in which the system doesn't need to flow watermarks
     (($($rs:ident),+), ()) => ();

--- a/src/dataflow/stream/internal_read_stream.rs
+++ b/src/dataflow/stream/internal_read_stream.rs
@@ -197,6 +197,7 @@ impl<D: Data> EventMakerT for InternalReadStream<D> {
                     events.push(OperatorEvent::new(
                         msg_arc.timestamp().clone(),
                         false,
+                        0,
                         move || {
                             (callback)(msg_arc.timestamp(), msg_arc.data().unwrap());
                         },
@@ -218,7 +219,7 @@ impl<D: Data> EventMakerT for InternalReadStream<D> {
                     cbs.push(child_event.callback);
                 }
                 if cbs.len() > 0 {
-                    events.push(OperatorEvent::new(timestamp.clone(), true, move || {
+                    events.push(OperatorEvent::new(timestamp.clone(), true, 0, move || {
                         for cb in cbs {
                             (cb)();
                         }

--- a/src/dataflow/stream/internal_stateful_read_stream.rs
+++ b/src/dataflow/stream/internal_stateful_read_stream.rs
@@ -85,6 +85,7 @@ impl<D: Data, S: State> EventMakerT for InternalStatefulReadStream<D, S> {
                     events.push(OperatorEvent::new(
                         msg.timestamp().clone(),
                         false,
+                        0,
                         move || {
                             for callback in stateful_cbs {
                                 let msg_arc = Arc::clone(&msg);
@@ -128,6 +129,7 @@ impl<D: Data, S: State> EventMakerT for InternalStatefulReadStream<D, S> {
                     events.push(OperatorEvent::new(
                         msg.timestamp().clone(),
                         true,
+                        0,
                         move || {
                             for cb in cbs {
                                 (cb)();

--- a/src/node/lattice.rs
+++ b/src/node/lattice.rs
@@ -129,8 +129,8 @@ impl PartialOrd for RunnableEvent {
 ///
 ///     // Add two events of timestamp 1 and 2 to the lattice with empty callbacks.
 ///     events = vec![
-///         OperatorEvent::new(Timestamp::new(vec![1]), true, || ())
-///         OperatorEvent::new(Timestamp::new(vec![2]), true, || ())
+///         OperatorEvent::new(Timestamp::new(vec![1]), true, 0, || ())
+///         OperatorEvent::new(Timestamp::new(vec![2]), true, 0, || ())
 ///     ];
 ///     lattice.add_events(events).await;
 ///
@@ -410,7 +410,7 @@ mod test {
     #[test]
     fn test_root_addition() {
         let lattice: ExecutionLattice = ExecutionLattice::new();
-        let events = vec![OperatorEvent::new(Timestamp::new(vec![1]), false, || ())];
+        let events = vec![OperatorEvent::new(Timestamp::new(vec![1]), false, 0, || ())];
         block_on(lattice.add_events(events));
 
         // Ensure that the correct event is returned by the lattice.
@@ -434,8 +434,8 @@ mod test {
     fn test_concurrent_messages() {
         let lattice: ExecutionLattice = ExecutionLattice::new();
         let events = vec![
-            OperatorEvent::new(Timestamp::new(vec![1]), false, || ()),
-            OperatorEvent::new(Timestamp::new(vec![1]), false, || ()),
+            OperatorEvent::new(Timestamp::new(vec![1]), false, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![1]), false, 0, || ()),
         ];
         block_on(lattice.add_events(events));
 
@@ -461,9 +461,9 @@ mod test {
     fn test_watermark_post_concurrent_messages() {
         let lattice: ExecutionLattice = ExecutionLattice::new();
         let events = vec![
-            OperatorEvent::new(Timestamp::new(vec![1]), false, || ()),
-            OperatorEvent::new(Timestamp::new(vec![1]), false, || ()),
-            OperatorEvent::new(Timestamp::new(vec![1]), true, || ()),
+            OperatorEvent::new(Timestamp::new(vec![1]), false, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![1]), false, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![1]), true, 0, || ()),
         ];
         block_on(lattice.add_events(events));
         // Check that the first event is returned correctly by the lattice.
@@ -515,9 +515,9 @@ mod test {
     fn test_unordered_watermark() {
         let lattice: ExecutionLattice = ExecutionLattice::new();
         let events = vec![
-            OperatorEvent::new(Timestamp::new(vec![3]), true, || ()),
-            OperatorEvent::new(Timestamp::new(vec![2]), true, || ()),
-            OperatorEvent::new(Timestamp::new(vec![1]), true, || ()),
+            OperatorEvent::new(Timestamp::new(vec![3]), true, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![2]), true, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![1]), true, 0, || ()),
         ];
         block_on(lattice.add_events(events));
 
@@ -560,9 +560,9 @@ mod test {
     fn test_concurrent_messages_diff_timestamps() {
         let lattice: ExecutionLattice = ExecutionLattice::new();
         let events = vec![
-            OperatorEvent::new(Timestamp::new(vec![3]), false, || ()),
-            OperatorEvent::new(Timestamp::new(vec![2]), false, || ()),
-            OperatorEvent::new(Timestamp::new(vec![1]), false, || ()),
+            OperatorEvent::new(Timestamp::new(vec![3]), false, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![2]), false, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![1]), false, 0, || ()),
         ];
         block_on(lattice.add_events(events));
 
@@ -588,12 +588,12 @@ mod test {
     fn test_concurrent_messages_watermarks_diff_timestamps() {
         let lattice: ExecutionLattice = ExecutionLattice::new();
         let events = vec![
-            OperatorEvent::new(Timestamp::new(vec![3]), true, || ()),
-            OperatorEvent::new(Timestamp::new(vec![2]), true, || ()),
-            OperatorEvent::new(Timestamp::new(vec![1]), true, || ()),
-            OperatorEvent::new(Timestamp::new(vec![1]), false, || ()),
-            OperatorEvent::new(Timestamp::new(vec![2]), false, || ()),
-            OperatorEvent::new(Timestamp::new(vec![3]), false, || ()),
+            OperatorEvent::new(Timestamp::new(vec![3]), true, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![2]), true, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![1]), true, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![1]), false, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![2]), false, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![3]), false, 0, || ()),
         ];
         block_on(lattice.add_events(events));
         let (event, event_id) = block_on(lattice.get_event()).unwrap();
@@ -673,9 +673,9 @@ mod test {
     fn test_ordered_concurrent_execution() {
         let lattice: ExecutionLattice = ExecutionLattice::new();
         let events = vec![
-            OperatorEvent::new(Timestamp::new(vec![2]), false, || ()),
-            OperatorEvent::new(Timestamp::new(vec![1]), true, || ()),
-            OperatorEvent::new(Timestamp::new(vec![3]), false, || ()),
+            OperatorEvent::new(Timestamp::new(vec![2]), false, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![1]), true, 0, || ()),
+            OperatorEvent::new(Timestamp::new(vec![3]), false, 0, || ()),
         ];
         block_on(lattice.add_events(events));
 

--- a/src/node/operator_event.rs
+++ b/src/node/operator_event.rs
@@ -13,27 +13,32 @@ use crate::dataflow::Timestamp;
 /// [`ExecutionLattice`](../lattice/struct.ExecutionLattice.html). The `ExecutionLattice` ensures
 /// that the events are processed in the partial order defined by the executor.
 pub struct OperatorEvent {
-    /// The priority of the event.
-    pub priority: u32,
     /// The timestamp of the event; timestamp of the message for regular callbacks, and timestamp of
     /// the watermark for watermark callbacks.
     pub timestamp: Timestamp,
     /// True if the callback is a watermark callback. Used to ensure that watermark callbacks are
     /// invoked after regular callbacks.
     pub is_watermark_callback: bool,
+    /// The priority of the event. Smaller numbers imply higher priority.
+    /// Priority currently only affects the ordering and concurrency of watermark callbacks.
+    /// For two otherwise equal watermark callbacks, the lattice creates a dependency from the lower
+    /// priority event to the higher priority event. Thus, these events cannot run concurrently,
+    /// with the high-priority event running first. An effect is that only watermark callbacks with
+    /// the same priority can run concrurently.
+    pub priority: i8,
     /// The callback invoked when the event is processed.
     pub callback: Box<dyn FnOnce()>,
 }
 
 impl OperatorEvent {
-    /// Creates a new `OperatorEvent`.
     pub fn new(
         t: Timestamp,
         is_watermark_callback: bool,
+        priority: i8,
         callback: impl FnOnce() + 'static,
     ) -> Self {
-        OperatorEvent {
-            priority: 0,
+        Self {
+            priority,
             timestamp: t,
             is_watermark_callback,
             callback: Box::new(callback),
@@ -82,8 +87,11 @@ impl Ord for OperatorEvent {
         match (self.is_watermark_callback, other.is_watermark_callback) {
             (true, true) => {
                 // Both of the events are watermarks, so the watermark with the lower timestamp
-                // should run first.
-                self.timestamp.cmp(&other.timestamp).reverse()
+                // should run first. Ties are broken by priority where asmaller number is higher priority.
+                match self.timestamp.cmp(&other.timestamp).reverse() {
+                    Ordering::Equal => self.priority.cmp(&other.priority).reverse(),
+                    ord => ord,
+                }
             }
             (true, false) => {
                 // `self` is a watermark, and `other` is a normal message callback.
@@ -140,25 +148,83 @@ mod test {
     /// timestamps, and the watermark with the lower timestamp is executed first.
     #[test]
     fn test_watermark_event_orderings() {
-        let watermark_event_a: OperatorEvent =
-            OperatorEvent::new(Timestamp::new(vec![1]), true, || ());
-        let watermark_event_b: OperatorEvent =
-            OperatorEvent::new(Timestamp::new(vec![2]), true, || ());
-        assert_eq!(
-            watermark_event_a < watermark_event_b,
-            false,
-            "Watermark A should not depend on Watermark B."
-        );
-        assert_eq!(
-            watermark_event_b < watermark_event_a,
-            true,
-            "Watermark B should depend on Watermark A."
-        );
-        assert_eq!(
-            watermark_event_b == watermark_event_a,
-            false,
-            "Watermark B should not concurrently with Watermark A."
-        );
+        {
+            let watermark_event_a: OperatorEvent =
+                OperatorEvent::new(Timestamp::new(vec![1]), true, 0, || ());
+            let watermark_event_b: OperatorEvent =
+                OperatorEvent::new(Timestamp::new(vec![2]), true, 0, || ());
+            assert_eq!(
+                watermark_event_a < watermark_event_b,
+                false,
+                "Watermark A should not depend on Watermark B."
+            );
+            assert_eq!(
+                watermark_event_b < watermark_event_a,
+                true,
+                "Watermark B should depend on Watermark A."
+            );
+            assert_eq!(
+                watermark_event_b == watermark_event_a,
+                false,
+                "Watermark B should not concurrently with Watermark A."
+            );
+        }
+        // Test that priorities should break ties only for otherwise equal watermark callbacks.
+        {
+            let watermark_event_a: OperatorEvent =
+                OperatorEvent::new(Timestamp::new(vec![1]), true, -1, || ());
+            let watermark_event_b: OperatorEvent =
+                OperatorEvent::new(Timestamp::new(vec![1]), true, 1, || ());
+            assert!(
+                watermark_event_a > watermark_event_b,
+                "Watermark B should depend on Watermark A"
+            );
+
+            let watermark_event_c: OperatorEvent =
+                OperatorEvent::new(Timestamp::new(vec![0]), true, 0, || ());
+            assert!(
+                watermark_event_a < watermark_event_c,
+                "Watermark A should depend on Watermark C"
+            );
+            assert!(
+                watermark_event_b < watermark_event_c,
+                "Watermark B should depend on Watermark C"
+            );
+
+            let watermark_event_d: OperatorEvent =
+                OperatorEvent::new(Timestamp::new(vec![2]), true, 0, || ());
+            assert!(
+                watermark_event_d < watermark_event_a,
+                "Watermark D should depend on Watermark A"
+            );
+            assert!(
+                watermark_event_d < watermark_event_b,
+                "Watermark D should depend on Watermark B"
+            );
+
+            // Priority should not affect message events
+            let message_event_a: OperatorEvent =
+                OperatorEvent::new(Timestamp::new(vec![1]), false, 0, || ());
+            assert!(
+                watermark_event_a < message_event_a,
+                "Watermark A with timestamp 1 should depend on Message A with timestamp 1"
+            );
+            assert!(
+                watermark_event_b < message_event_a,
+                "Watermark B with timestamp 1 should depend on Message A with timestamp 1"
+            );
+
+            let message_event_b: OperatorEvent =
+                OperatorEvent::new(Timestamp::new(vec![2]), false, 0, || ());
+            assert_eq!(
+                watermark_event_a, message_event_b,
+                "Watermark A and Message A should not depend on each other"
+            );
+            assert_eq!(
+                watermark_event_b, message_event_b,
+                "Watermark A and Message A should not depend on each other"
+            );
+        }
     }
 
     /// This test ensures that two non-watermark messages are rendered equal in their partial order
@@ -166,9 +232,9 @@ mod test {
     #[test]
     fn test_message_event_orderings() {
         let message_event_a: OperatorEvent =
-            OperatorEvent::new(Timestamp::new(vec![1]), false, || ());
+            OperatorEvent::new(Timestamp::new(vec![1]), false, 0, || ());
         let message_event_b: OperatorEvent =
-            OperatorEvent::new(Timestamp::new(vec![2]), false, || ());
+            OperatorEvent::new(Timestamp::new(vec![2]), false, 0, || ());
         assert_eq!(
             message_event_a == message_event_b,
             true,
@@ -192,9 +258,9 @@ mod test {
         // is dependent on the message.
         {
             let message_event_a: OperatorEvent =
-                OperatorEvent::new(Timestamp::new(vec![1]), false, || ());
+                OperatorEvent::new(Timestamp::new(vec![1]), false, 0, || ());
             let watermark_event_b: OperatorEvent =
-                OperatorEvent::new(Timestamp::new(vec![2]), true, || ());
+                OperatorEvent::new(Timestamp::new(vec![2]), true, 0, || ());
             assert_eq!(
                 message_event_a == watermark_event_b,
                 false,
@@ -237,9 +303,9 @@ mod test {
         // watermark.
         {
             let message_event_a: OperatorEvent =
-                OperatorEvent::new(Timestamp::new(vec![1]), false, || ());
+                OperatorEvent::new(Timestamp::new(vec![1]), false, 0, || ());
             let watermark_event_b: OperatorEvent =
-                OperatorEvent::new(Timestamp::new(vec![1]), true, || ());
+                OperatorEvent::new(Timestamp::new(vec![1]), true, 0, || ());
             assert_eq!(
                 message_event_a == watermark_event_b,
                 false,
@@ -282,9 +348,9 @@ mod test {
         // with a watermark of lesser timestamp.
         {
             let message_event_a: OperatorEvent =
-                OperatorEvent::new(Timestamp::new(vec![2]), false, || ());
+                OperatorEvent::new(Timestamp::new(vec![2]), false, 0, || ());
             let watermark_event_b: OperatorEvent =
-                OperatorEvent::new(Timestamp::new(vec![1]), true, || ());
+                OperatorEvent::new(Timestamp::new(vec![1]), true, 0, || ());
             assert_eq!(
                 message_event_a == watermark_event_b,
                 true,

--- a/src/node/operator_event.rs
+++ b/src/node/operator_event.rs
@@ -24,7 +24,7 @@ pub struct OperatorEvent {
     /// For two otherwise equal watermark callbacks, the lattice creates a dependency from the lower
     /// priority event to the higher priority event. Thus, these events cannot run concurrently,
     /// with the high-priority event running first. An effect is that only watermark callbacks with
-    /// the same priority can run concrurently.
+    /// the same priority can run concurrently.
     pub priority: i8,
     /// The callback invoked when the event is processed.
     pub callback: Box<dyn FnOnce()>,

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -227,12 +227,8 @@ impl OperatorExecutor {
             }
             while let Some(events) = event_stream.next().await {
                 {
-                    {
-                        // Add all the received events to the lattice.
-                        for event in events {
-                            self.lattice.add_event(event).await;
-                        }
-                    }
+                    // Add all the received events to the lattice.
+                    self.lattice.add_events(events).await;
                     // Notify receivers that new events were added.
                     notifier_tx
                         .broadcast(EventRunnerMessage::AddedEvents)


### PR DESCRIPTION
Can add priorities to callbacks which are exposed via a bundle's `add_watermark_callback_with_priority` method.

Some details:
- Smaller numbers imply higher priority.
- Priority currently only affects the ordering and concurrency of watermark callbacks.
- For two otherwise equal watermark callbacks, the lattice creates a dependency from the lower priority event to the higher priority event. Thus, these events cannot run concurrently, with the high-priority event running first. An effect is that only watermark callbacks with the same priority can run concurrently.

Unfortunately, this doesn't solve the flow watermarks bug by itself due to the way operator events are created, which I'll take a look at next.