### PR TITLE
Refactor operator event ordering and lattice

### DIFF
--- a/src/node/lattice.rs
+++ b/src/node/lattice.rs
@@ -309,7 +309,7 @@ impl ExecutionLattice {
             }
         }
 
-        if forest.node_count() > 25 {
+        if forest.node_count() > 100 {
             slog::warn!(
                 crate::get_terminal_logger(),
                 "{} operator events queued in lattice. Increase number of operator executors or decrease incoming \

--- a/src/node/lattice.rs
+++ b/src/node/lattice.rs
@@ -205,9 +205,9 @@ impl ExecutionLattice {
             // For example, A -> C is redundant if A -> B -> C.
             let mut preceding_events: HashSet<NodeIndex<u32>> = HashSet::new();
             // The added event depends on these nodes.
-            let mut children: Vec<NodeIndex<u32>> = Vec::new();
+            let mut children: HashSet<NodeIndex<u32>> = HashSet::new();
             // Other nodes depend on the added event.
-            let mut parents: Vec<NodeIndex<u32>> = Vec::new();
+            let mut parents: HashSet<NodeIndex<u32>> = HashSet::new();
             // These nodes are no longer leaves after the added event is inserted into the graph.
             let mut demoted_leaves: Vec<NodeIndex> = Vec::new();
             // These edges are redundant and must be removed.
@@ -241,7 +241,7 @@ impl ExecutionLattice {
                                     .count()
                                     == 0
                                 {
-                                    parents.push(visited_node_idx);
+                                    parents.insert(visited_node_idx);
                                     for n in run_queue.iter() {
                                         if n.node_index.index() == visited_node_idx.index() {
                                             demoted_leaves.push(n.node_index);
@@ -260,13 +260,13 @@ impl ExecutionLattice {
                                     if parent_event > &added_event {
                                         // The added event precedes the parent, so the parent
                                         // depends on the added event.
-                                        parents.push(parent_idx);
+                                        parents.insert(parent_idx);
                                     }
                                 }
                             }
                             Ordering::Greater => {
                                 // The added event depends on the visited event.
-                                children.push(visited_node_idx);
+                                children.insert(visited_node_idx);
                                 preceding_events.insert(visited_node_idx);
                                 // Add dependencies from the parents of the visited node to the added event.
                                 // Also, note edges that become redundant for removal.
@@ -278,7 +278,7 @@ impl ExecutionLattice {
                                     if parent_event > &added_event {
                                         // The added event precedes the parent, so the parent
                                         // depends on the added event.
-                                        parents.push(parent_idx);
+                                        parents.insert(parent_idx);
                                         // Edge from parent to visited node becomes redundant.
                                         let redundant_edge =
                                             forest.find_edge(parent_idx, visited_node_idx).unwrap();
@@ -296,7 +296,7 @@ impl ExecutionLattice {
                         {
                             let parent_node = forest.node_weight(parent).unwrap().as_ref().unwrap();
                             if parent_node > &added_event {
-                                parents.push(parent);
+                                parents.insert(parent);
                             }
                         }
                     }

--- a/src/node/lattice.rs
+++ b/src/node/lattice.rs
@@ -114,7 +114,7 @@ impl PartialOrd for RunnableEvent {
 }
 
 /// `ExecutionLattice` is a data structure that maintains [`OperatorEvent`]s in a
-/// [dependency graph](https://en.wikipedia.org/wiki/Dependency_graph) according the partial order
+/// [dependency graph](https://en.wikipedia.org/wiki/Dependency_graph) according to the partial order
 /// defined.
 ///
 /// Events can be added to the lattice using the `add_events` function, and retrieved using the

--- a/src/node/lattice.rs
+++ b/src/node/lattice.rs
@@ -319,7 +319,7 @@ impl ExecutionLattice {
 
         if forest.node_count() > 100 {
             slog::warn!(
-                crate::get_terminal_logger(),
+                crate::TERMINAL_LOGGER,
                 "{} operator events queued in lattice. Increase number of operator executors or decrease incoming \
                 message frequency to reduce load.", forest.node_count()
             )

--- a/src/node/lattice.rs
+++ b/src/node/lattice.rs
@@ -308,6 +308,14 @@ impl ExecutionLattice {
                 run_queue.push(RunnableEvent::new(event_ix).with_timestamp(event_timestamp));
             }
         }
+
+        if forest.node_count() > 25 {
+            slog::warn!(
+                crate::get_terminal_logger(),
+                "{} operator events queued in lattice. Increase number of operator executors or decrease incoming \
+                message frequency to reduce load.", forest.node_count()
+            )
+        }
     }
 
     /// Retrieve an event to be executed from the lattice.


### PR DESCRIPTION
- Changes operator event ordering s.t. `x < y` implies `x` *precedes* `y`.
- Reverse edges on lattice dependency graph to match [convention](https://en.wikipedia.org/wiki/Dependency_graph).
- Add warning if more than 25 events queued in lattice.
- Add `to_dot` method to lattice for easier visualization/debugging.
- Code refactoring and comments on lattice.
- Tests use `assert` instead of `assert_eq(*, true)`.