### PR TITLE
Simplify and document OperatorConfig builder pattern

### DIFF
--- a/src/dataflow/operator.rs
+++ b/src/dataflow/operator.rs
@@ -21,12 +21,13 @@ pub struct OperatorConfig<T: Clone> {
     /// Currently the ID is inaccessible from the driver, but is set when the config
     /// is passed to the operator.
     pub id: OperatorId,
-    /// A generically typed argument to the operator.
+    /// A generically typed argument to the [`Operator`].
     pub arg: Option<T>,
-    /// Whether the operator should automatically send
-    /// [watermark messages](crate::Message::Watermark) on all
-    /// [`WriteStream`](crate::dataflow::WriteStream)s for timestamp `t` upon
-    /// receiving watermarks with timestamp greater than `t` on all
+    /// Whether the [`Operator`] should automatically send
+    /// [watermark messages](crate::dataflow::Message::Watermark) on all
+    /// [`WriteStream`](crate::dataflow::WriteStream)s for
+    /// [`Timestamp`](crate::dataflow::Timestamp) `t` upon receiving watermarks with
+    /// [`Timestamp`](crate::dataflow::Timestamp) greater than `t` on all
     /// [`ReadStream`](crate::dataflow::ReadStream)s.
     /// Note that watermarks only flow after all watermark callbacks with timestamp
     /// less than `t` complete. Watermarks flow after [`Operator::run`] finishes
@@ -36,7 +37,7 @@ pub struct OperatorConfig<T: Clone> {
     pub node_id: NodeId,
     /// Number of parallel tasks which process callbacks.
     /// A higher number may result in more parallelism; however this may be limited
-    /// by dependencies on state and timestamps.
+    /// by dependencies on [`State`](crate::dataflow::State) and timestamps.
     pub num_event_runners: usize,
 }
 

--- a/src/dataflow/operators/join_operator.rs
+++ b/src/dataflow/operators/join_operator.rs
@@ -71,23 +71,27 @@ impl<D: Data> StreamState<D> {
 }
 
 /// An operator that joins two incoming streams of type D1 and D2 into a stream of type D3 using
-/// the closure provided.
+/// the function provided.
 ///
 /// # Example
 /// The below example shows how to use a JoinOperator to sum two streams of incoming u32 messages,
 /// and return them as u64 messages.
 ///
 /// ```
-/// use erdos::dataflow::{stream::IngestStream, operators::JoinOperator, OperatorConfig};
-/// use erdos::*;
-/// let mut config = OperatorConfig::new();
-/// config.name("JoinOperator").arg(
-///     |left_data: Vec<u32>, right_data: Vec<u32>| -> u64 {
+/// # use erdos::dataflow::{stream::IngestStream, operators::JoinOperator, OperatorConfig};
+/// # use erdos::*;
+/// #
+/// # let mut left_u32_stream = IngestStream::new(0);
+/// # let mut right_u32_stream = IngestStream::new(0);
+/// #
+/// // Add the joining function as an argument to the operator via the OperatorConfig.
+/// let join_config = OperatorConfig::new()
+///     .name("JoinOperator")
+///     .arg(|left_data: Vec<u32>, right_data: Vec<u32>| -> u64 {
 ///         (left_data.iter().sum::<u32>() + right_data.iter().sum::<u32>()) as u64
 ///     });
-/// let mut ingest_l = IngestStream::new(0);
-/// let mut ingest_r = IngestStream::new(0);
-/// let output_stream = connect_1_write!(JoinOperator<u32, u32, u64>, config, ingest_l, ingest_r);
+/// let output_stream = connect_1_write!(
+///     JoinOperator<u32, u32, u64>, join_config,left_u32_stream, right_u32_stream);
 /// ```
 pub struct JoinOperator<D1: Data, D2: Data, D3: Data> {
     phantom_data: PhantomData<(D1, D2, D3)>,

--- a/src/dataflow/operators/map_operator.rs
+++ b/src/dataflow/operators/map_operator.rs
@@ -6,20 +6,23 @@ use serde::Deserialize;
 use std::marker::PhantomData;
 
 /// An operator that maps an incoming stream of type D1 to a stream of type D2 using the provided
-/// closure.
+/// function.
 ///
 /// # Example
 /// The below example shows how to use a MapOperator to double an incoming stream of u32 messages,
 /// and return them as u64 messages.
 ///
 /// ```
-/// use erdos::dataflow::{stream::IngestStream, operators::MapOperator, OperatorConfig};
-/// use erdos::*;
-/// let mut map_config = OperatorConfig::new();
-/// map_config.name("MapOperator").arg(
-///     |data: &u32| -> u64 { (data * 2) as u64 });
-/// let mut ingest_stream = IngestStream::new(0);
-/// let output_read_stream = connect_1_write!(MapOperator<u32, u64>, map_config, ingest_stream);
+/// # use erdos::dataflow::{stream::IngestStream, operators::MapOperator, OperatorConfig};
+/// # use erdos::*;
+/// #
+/// # let mut u32_stream = IngestStream::new(0);
+/// #
+/// // Add the mapping function as an argument to the operator via the OperatorConfig.
+/// let map_config = OperatorConfig::new()
+///     .name("MapOperator")
+///     .arg(|data: &u32| -> u64 { (*data as u64) * 2 });
+/// let u64_stream = connect_1_write!(MapOperator<u32, u64>, map_config, u32_stream);
 /// ```
 pub struct MapOperator<D1: Data, D2: Data> {
     phantom_data: PhantomData<(D1, D2)>,

--- a/src/dataflow/operators/map_operator.rs
+++ b/src/dataflow/operators/map_operator.rs
@@ -21,7 +21,7 @@ use std::marker::PhantomData;
 /// // Add the mapping function as an argument to the operator via the OperatorConfig.
 /// let map_config = OperatorConfig::new()
 ///     .name("MapOperator")
-///     .arg(|data: &u32| -> u64 { (*data as u64) * 2 });
+///     .arg(|data: &u32| -> u64 { (data * 2) as u64 });
 /// let u64_stream = connect_1_write!(MapOperator<u32, u64>, map_config, u32_stream);
 /// ```
 pub struct MapOperator<D1: Data, D2: Data> {

--- a/src/dataflow/stream/extract_stream.rs
+++ b/src/dataflow/stream/extract_stream.rs
@@ -28,18 +28,18 @@ use super::{
 /// [`MapOperator`](crate::dataflow::operators::MapOperator), and retrieve the mapped values
 /// through an [`ExtractStream`].
 /// ```
-/// use erdos::dataflow::{
-///     stream::{IngestStream, ExtractStream},
-///     operators::MapOperator,
-///     OperatorConfig, Message, Timestamp
-/// };
-/// use erdos::*;
-///
-/// let mut map_config = OperatorConfig::new();
-/// map_config.name("MapOperator").arg(
-///     |data: &u32| -> u64 { (data * 2) as u64 });
-///
-/// // Create an IngestStream. The driver is assigned an ID of 0.
+/// # use erdos::dataflow::{
+/// #    stream::{IngestStream, ExtractStream},
+/// #    operators::MapOperator,
+/// #    OperatorConfig, Message, Timestamp
+/// # };
+/// # use erdos::*;
+/// #
+/// # let map_config = OperatorConfig::new()
+//  #     .name("MapOperator")
+/// #     .arg(|data: &u32| -> u64 { (data * 2) as u64 });
+/// #
+/// // Create an IngestStream which runs on node 0.
 /// let mut ingest_stream = IngestStream::new(0); // or IngestStream::new_with_name(0, "driver")
 ///
 /// // Create an ExtractStream from the ReadStream of the MapOperator.

--- a/src/dataflow/stream/ingest_stream.rs
+++ b/src/dataflow/stream/ingest_stream.rs
@@ -23,17 +23,17 @@ use super::{errors::WriteStreamError, StreamId, WriteStream, WriteStreamT};
 /// The below example shows how to use a [`MapOperator`](crate::dataflow::operators::MapOperator)
 /// to double an incoming stream of [`u32`] messages, and return them as [`u64`] messages.
 /// ```
-/// use erdos::dataflow::{
-///     stream::IngestStream,
-///     operators::MapOperator,
-///     OperatorConfig, Message, Timestamp
-/// };
-/// use erdos::*;
-///
-/// let mut map_config = OperatorConfig::new();
-/// map_config.name("MapOperator").arg(
-///     |data: &u32| -> u64 { (data * 2) as u64 });
-///
+/// # use erdos::dataflow::{
+/// #    stream::IngestStream,
+/// #    operators::MapOperator,
+/// #    OperatorConfig, Message, Timestamp
+/// # };
+/// # use erdos::*;
+/// #
+/// # let map_config = OperatorConfig::new()
+//  #     .name("MapOperator")
+/// #     .arg(|data: &u32| -> u64 { (data * 2) as u64 });
+/// #
 /// // Create an IngestStream. The driver is assigned an ID of 0.
 /// let mut ingest_stream = IngestStream::new(0); // or IngestStream::new_with_name(0, "driver")
 /// let output_read_stream = connect_1_write!(MapOperator<u32, u64>, map_config, ingest_stream);

--- a/tests/watermark_test.rs
+++ b/tests/watermark_test.rs
@@ -104,11 +104,13 @@ fn test_flow_watermarks() {
     let node = Node::new(config);
 
     let s1 = connect_1_write!(SendOperator, OperatorConfig::new().name("SendOperator"));
-    let mut map_config = OperatorConfig::new();
-    map_config
-        .name("MapOperator")
-        .arg(|a: &usize| -> usize { *a });
-    let s2 = connect_1_write!(MapOperator<usize, usize>, map_config, s1);
+    let s2 = connect_1_write!(
+        MapOperator<usize, usize>,
+        OperatorConfig::new()
+            .name("MapOperator")
+            .arg(|a: &usize| -> usize { *a }),
+        s1
+    );
     connect_0_write!(
         RecvOperator,
         OperatorConfig::new().name("RecvOperator").arg(true),
@@ -126,12 +128,14 @@ fn test_no_flow_watermarks() {
     let node = Node::new(config);
 
     let s1 = connect_1_write!(SendOperator, OperatorConfig::new().name("SendOperator"));
-    let mut map_config = OperatorConfig::new();
-    map_config
-        .name("MapOperator")
-        .arg(|a: &usize| -> usize { *a })
-        .flow_watermarks(false);
-    let s2 = connect_1_write!(MapOperator<usize, usize>, map_config, s1);
+    let s2 = connect_1_write!(
+        MapOperator<usize, usize>,
+        OperatorConfig::new()
+            .name("MapOperator")
+            .arg(|a: &usize| -> usize { *a })
+            .flow_watermarks(false),
+        s1
+    );
     connect_0_write!(
         RecvOperator,
         OperatorConfig::new()


### PR DESCRIPTION
Also updates documentation for `JoinOperator` and `MapOperator` to fix builder pattern, rename streams, and hide lines unnecessary to the example in the documentation.