### PR TITLE
Enable nightly builds for Python wheels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,8 @@ jobs:
   build-rust:
     name: "Rust Build"
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -24,42 +22,32 @@ jobs:
           profile: minimal
           override: true
           components: rustfmt, rust-src
-
       - name: Check Rust formatting
         run: cargo fmt -- --check
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
-
       - name: Build
         run: cargo build --verbose
-
       - name: Run tests
         run: cargo test --verbose
 
   build-python:
     name: "Python ${{ matrix.python-version }} Build"
-
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-
     steps:
       - uses: actions/checkout@v2
-
       - name: Setup python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
       - name: Install Python dependencies
         run: |
           python -m pip install setuptools_rust flake8 yapf flake8-quotes
-
       - name: Check Python formatting
         run: |
           flake8 --inline-quotes="double" ./doc/
@@ -68,14 +56,12 @@ jobs:
           yapf --diff --recursive ./doc/
           yapf --diff --recursive ./python/
           yapf --diff --recursive ./scripts/
-
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
           components: rustfmt
-
       - name: Build
         # Building with develop is faster than with install
         run: python python/setup.py develop

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
 
 env:
@@ -12,33 +12,32 @@ env:
 jobs:
   build-rust:
     name: "Rust Build"
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install latest Rust nightly
-      uses: actions-rs/toolchain@v1
-      with:
+      - name: Install latest Rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           profile: minimal
           override: true
           components: rustfmt, rust-src
 
-    - name: Check Rust formatting
-      run: cargo fmt -- --check
+      - name: Check Rust formatting
+        run: cargo fmt -- --check
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.6
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
 
-    - name: Build
-      run: cargo build --verbose
+      - name: Build
+        run: cargo build --verbose
 
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Run tests
+        run: cargo test --verbose
 
   build-python:
     name: "Python ${{ matrix.python-version }} Build"
@@ -48,7 +47,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -73,9 +72,9 @@ jobs:
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
-            override: true
-            components: rustfmt
+          toolchain: nightly
+          override: true
+          components: rustfmt
 
       - name: Build
         # Building with develop is faster than with install

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,10 +10,8 @@ env:
 jobs:
   rustdoc:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -21,32 +19,25 @@ jobs:
           profile: minimal
           override: true
           components: rustfmt, rust-src
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
-
       - name: Install Python dependencies
         run: python -m pip install fire
-
       - name: Build Documentation
         run: cargo doc --all --no-deps
 
   pythondoc:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
-
       - name: Install Python dependencies
         run: python -m pip install -r doc/requirements-doc.txt
-
       - name: Build Documentation
         run: |
           cd doc

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,7 +1,7 @@
 name: Documentation
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
 
 env:
@@ -12,30 +12,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install latest Rust nightly
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        profile: minimal
-        override: true
-        components: rustfmt, rust-src
+      - name: Install latest Rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+          components: rustfmt, rust-src
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.6
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
 
-    - name: Install Python dependencies
-      run: python -m pip install fire
+      - name: Install Python dependencies
+        run: python -m pip install fire
 
-    - name: Build Documentation
-      run: cargo doc --all --no-deps
+      - name: Build Documentation
+        run: cargo doc --all --no-deps
 
   pythondoc:
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -22,4 +22,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: python-wheels
-          path: dist
+          path: dist/*manylinux1*.whl

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -15,6 +15,9 @@ jobs:
         uses: docker://quay.io/pypa/manylinux1_x86_64
         env:
           CARGO_TERM_COLOR: always
+        with:
+          entrypoint: /github/workspace/python/build-wheels.sh
+          args: github-actions
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -2,7 +2,7 @@ name: Python Wheels
 on:
   push:
     branches: [master]
-    pull_request:
+  pull_request:
 
 jobs:
   build-wheels:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,0 +1,29 @@
+name: Python Wheels
+on:
+  push:
+    branches: [master]
+    pull_request:
+
+jobs:
+  build-wheels:
+    name: Build Python Wheels
+    runs-on: ubuntu-latest
+    container:
+      image: docker://quay.io/pypa/manylinux1_x86_64
+      env:
+        CARGO_TERM_COLOR: always
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest Rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+          components: rust-src
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: python-wheels
+          path: dist

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,8 +1,7 @@
 name: Python Wheels
 on:
-  push:
-    branches: [master]
-  pull_request:
+  schedule:
+    - cron: "0 7 * * *" # 12am Pacific Time / 7am UTC
 
 jobs:
   build-wheels:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -8,20 +8,13 @@ jobs:
   build-wheels:
     name: Build Python Wheels
     runs-on: ubuntu-latest
-    container:
-      image: docker://quay.io/pypa/manylinux1_x86_64
-      env:
-        CARGO_TERM_COLOR: always
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest Rust nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
-          components: rust-src
+      - name: Build Wheels in Docker
+        uses: docker://quay.io/pypa/manylinux1_x86_64
+        env:
+          CARGO_TERM_COLOR: always
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -21,5 +21,5 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
-          name: python-wheels
+          name: erdos-python-nightly-wheels
           path: dist/*manylinux1*.whl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erdos"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The ERDOS Team"]
 edition = "2018"
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ERDOS is a platform for developing self-driving cars and robotics applications.
 [![Crates.io][crates-badge]][crates-url]
 [![Build Status](https://github.com/erdos-project/erdos/workflows/CI/badge.svg)](https://github.com/erdos-project/erdos/actions)
 [![Documentation Status](https://readthedocs.org/projects/erdos/badge/?version=latest)](https://erdos.readthedocs.io/en/latest/?badge=latest)
-[![Documentation](https://docs.rs/erdos/badge.svg)](https://docs.rs/erdos/0.2.0/erdos/)
+[![Documentation](https://docs.rs/erdos/badge.svg)](https://docs.rs/erdos/)
 
 [crates-badge]: https://img.shields.io/crates/v/erdos.svg
 [crates-url]: https://crates.io/crates/erdos

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -23,9 +23,9 @@ copyright = u"2018, The ERDOS Team"
 author = u"The ERDOS Team"
 
 # The short X.Y version
-version = u"0.2"
+version = u"0.3"
 # The full version, including alpha/beta/rc tags
-release = u"0.2.0"
+release = u"0.3.1"
 
 # -- General configuration ---------------------------------------------------
 

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-06-22 --profile minimal -y
+curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2020-06-22 --profile minimal -y
 source $HOME/.cargo/env
 
 if [ "$1" == github-actions ]; then

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -10,7 +10,8 @@ else
     cd /io
 fi
 
-for PYBIN in /opt/python/{cp35-cp35m,cp36-cp36m,cp37-cp37m,cp38-cp38}/bin; do
+# for PYBIN in /opt/python/{cp35-cp35m,cp36-cp36m,cp37-cp37m,cp38-cp38}/bin; do
+for PYBIN in /opt/python/{cp38-cp38}/bin; do
     export PATH_BACKUP=$PATH
     PATH="$PYBIN:$PATH"
     # Require wheel==0.31.1 because auditwheel breaks on newer versions
@@ -20,5 +21,6 @@ for PYBIN in /opt/python/{cp35-cp35m,cp36-cp36m,cp37-cp37m,cp38-cp38}/bin; do
 done
 
 for whl in dist/*.whl; do
+    pip3 install -U wheel==0.31.1 --user  # Prevent failure on github-actions
     auditwheel repair "$whl" -w dist/
 done

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -10,24 +10,14 @@ else
     cd /io
 fi
 
-# for PYBIN in /opt/python/{cp35-cp35m,cp36-cp36m,cp37-cp37m,cp38-cp38}/bin; do
-#     export PATH_BACKUP=$PATH
-#     PATH="$PYBIN:$PATH"
-#     # Require wheel==0.31.1 because auditwheel breaks on newer versions
-#     "${PYBIN}/pip" install -U setuptools wheel==0.31.1 setuptools-rust
-#     "${PYBIN}/python" python/setup.py bdist_wheel
-#     PATH=$PATH_BACKUP
-# done
+for PYBIN in /opt/python/{cp35-cp35m,cp36-cp36m,cp37-cp37m,cp38-cp38}/bin; do
+    "${PYBIN}/pip" install -U setuptools wheel setuptools-rust
+    "${PYBIN}/python" python/setup.py bdist_wheel
+done
 
-PYBIN=/opt/python/cp38-cp38/bin
-export PATH_BACKUP=$PATH
-PATH="$PYBIN:$PATH"
-"${PYBIN}/pip" install -U setuptools wheel setuptools-rust
-"${PYBIN}/python" python/setup.py bdist_wheel
-PATH=$PATH_BACKUP
-
-"${PYBIN}/pip" install -U auditwheel # Prevent failure on github-actions
+# Update auditwheel on python3.8 to avoid errors.
+/opt/python/cp38-cp38/bin/pip install -U auditwheel
 
 for whl in dist/*.whl; do
-    auditwheel repair "$whl" -w dist/
+    /opt/python/cp38-cp38/bin/python -m auditwheel repair "$whl" -w dist/
 done

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly --profile minimal -y
+curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-06-22 --profile minimal -y
 source $HOME/.cargo/env
 
 if [ "$1" == github-actions ]; then

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -11,14 +11,21 @@ else
 fi
 
 # for PYBIN in /opt/python/{cp35-cp35m,cp36-cp36m,cp37-cp37m,cp38-cp38}/bin; do
-for PYBIN in /opt/python/{cp38-cp38}/bin; do
-    export PATH_BACKUP=$PATH
-    PATH="$PYBIN:$PATH"
-    # Require wheel==0.31.1 because auditwheel breaks on newer versions
-    "${PYBIN}/pip" install -U setuptools wheel==0.31.1 setuptools-rust
-    "${PYBIN}/python" python/setup.py bdist_wheel
-    PATH=$PATH_BACKUP
-done
+#     export PATH_BACKUP=$PATH
+#     PATH="$PYBIN:$PATH"
+#     # Require wheel==0.31.1 because auditwheel breaks on newer versions
+#     "${PYBIN}/pip" install -U setuptools wheel==0.31.1 setuptools-rust
+#     "${PYBIN}/python" python/setup.py bdist_wheel
+#     PATH=$PATH_BACKUP
+# done
+
+PYBIN=/opt/python/cp38-cp38/bin
+export PATH_BACKUP=$PATH
+PATH="$PYBIN:$PATH"
+# Require wheel==0.31.1 because auditwheel breaks on newer versions
+"${PYBIN}/pip" install -U setuptools wheel==0.31.1 setuptools-rust
+"${PYBIN}/python" python/setup.py bdist_wheel
+PATH=$PATH_BACKUP
 
 for whl in dist/*.whl; do
     pip3 install -U wheel==0.31.1 --user  # Prevent failure on github-actions

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 set -ex
 
-curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
-export PATH="$HOME/.cargo/bin:$PATH"
-rustup default nightly-2020-06-22
+if [ "$1" != github-actions ]; then
+    curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
+    export PATH="$HOME/.cargo/bin:$PATH"
+    rustup default nightly-2020-06-22
 
-cd /io
+    cd /io
+fi
 
 for PYBIN in /opt/python/{cp35-cp35m,cp36-cp36m,cp37-cp37m,cp38-cp38}/bin; do
     export PATH_BACKUP=$PATH

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -22,12 +22,12 @@ fi
 PYBIN=/opt/python/cp38-cp38/bin
 export PATH_BACKUP=$PATH
 PATH="$PYBIN:$PATH"
-# Require wheel==0.31.1 because auditwheel breaks on newer versions
-"${PYBIN}/pip" install -U setuptools wheel==0.31.1 setuptools-rust
+"${PYBIN}/pip" install -U setuptools wheel setuptools-rust
 "${PYBIN}/python" python/setup.py bdist_wheel
 PATH=$PATH_BACKUP
 
+"${PYBIN}/pip" install -U auditwheel # Prevent failure on github-actions
+
 for whl in dist/*.whl; do
-    pip3 install -U wheel==0.31.1 --user  # Prevent failure on github-actions
     auditwheel repair "$whl" -w dist/
 done

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 set -ex
 
-curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
-export PATH="$HOME/.cargo/bin:$PATH"
-rustup default nightly
+curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly --profile minimal -y
+source $HOME/.cargo/env
 
 if [ "$1" == github-actions ]; then
     cd /github/workspace/

--- a/python/build-wheels.sh
+++ b/python/build-wheels.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 set -ex
 
-if [ "$1" != github-actions ]; then
-    curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
-    export PATH="$HOME/.cargo/bin:$PATH"
-    rustup default nightly-2020-06-22
+curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
+export PATH="$HOME/.cargo/bin:$PATH"
+rustup default nightly
 
+if [ "$1" == github-actions ]; then
+    cd /github/workspace/
+else
     cd /io
 fi
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,7 +10,7 @@ requires = ["fire", "numpy"]
 
 setup(
     name="erdos",
-    version="0.3.0",
+    version="0.3.1",
     rust_extensions=[
         RustExtension("erdos.internal",
                       path="Cargo.toml",


### PR DESCRIPTION
Enables nightly builds for Python wheels via GitHub actions. Builds start at 12am Pacific (7am UTC) and take around 30 minutes to finish. Also updated the script for building wheels.

This should be merged after #143.