### PR TITLE
Modify use of global dataflow graph for use with other executors

### DIFF
--- a/src/dataflow/graph/default_graph.rs
+++ b/src/dataflow/graph/default_graph.rs
@@ -1,3 +1,10 @@
+//! A globally accessible dataflow graph.
+//!
+//! This is used in the driver when connecting new operators,
+//! or setting up [`IngestStream`]s, [`ExtractStream`]s, and [`LoopStream`]s.
+//! The dataflow graph is thread-local; therefore, drivers should not be
+//! multi-threaded and this module should never be used from an asynchronous
+//! context.
 use std::cell::RefCell;
 
 use serde::Deserialize;

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -23,7 +23,7 @@ use crate::communication::{
     senders::{self, ControlSender, DataSender},
     ControlMessage, ControlMessageCodec, ControlMessageHandler, MessageCodec,
 };
-use crate::dataflow::graph::default_graph;
+use crate::dataflow::graph::{default_graph, Graph};
 use crate::scheduler::{
     self,
     channel_manager::ChannelManager,
@@ -44,6 +44,8 @@ pub struct Node {
     config: Configuration,
     /// Unique node id.
     id: NodeId,
+    /// Dataflow graph which the node will execute.
+    dataflow_graph: Option<Graph>,
     /// Structure to be used to send `Sender` updates to receiver threads.
     channels_to_receivers: Arc<Mutex<ChannelsToReceivers>>,
     /// Structure to be used to send messages to sender threads.
@@ -66,6 +68,7 @@ impl Node {
         Self {
             config,
             id,
+            dataflow_graph: None,
             channels_to_receivers: Arc::new(Mutex::new(ChannelsToReceivers::new())),
             channels_to_senders: Arc::new(Mutex::new(ChannelsToSenders::new())),
             control_handler: ControlMessageHandler::new(logger),
@@ -80,6 +83,10 @@ impl Node {
     /// The method never returns.
     pub fn run(&mut self) {
         slog::debug!(self.config.logger, "Node {}: running", self.id);
+        // Set the dataflow graph if it hasn't been set already.
+        if self.dataflow_graph.is_none() {
+            self.dataflow_graph = Some(default_graph::clone());
+        }
         // Build a runtime with n threads.
         let mut runtime = Builder::new()
             .threaded_scheduler()
@@ -99,10 +106,9 @@ impl Node {
         // Clone to avoid move to other thread.
         let shutdown_tx = self.shutdown_tx.clone();
         // Copy dataflow graph to the other thread
-        let graph = default_graph::clone();
+        self.dataflow_graph = Some(default_graph::clone());
         let initialized = self.initialized.clone();
         let thread_handle = thread::spawn(move || {
-            default_graph::set(graph);
             self.run();
         });
         // Wait for ERDOS to start up.
@@ -282,7 +288,11 @@ impl Node {
     async fn run_operators(&mut self) -> Result<(), String> {
         self.wait_for_communication_layer_initialized().await?;
 
-        let graph = scheduler::schedule(&default_graph::clone());
+        let graph_ref = self
+            .dataflow_graph
+            .as_ref()
+            .unwrap_or_else(|| panic!("Node {}: dataflow graph must be set."));
+        let graph = scheduler::schedule(graph_ref);
         if let Some(filename) = &self.config.graph_filename {
             graph.to_dot(filename.as_str()).map_err(|e| e.to_string())?;
         }


### PR DESCRIPTION
Fixes the use of the global dataflow graph in `node.rs` to be compatible with other executors.

The global dataflow graph is a thread local variable. Because tokio's `runtime.block_on` donates the current thread to the asynchronous task when `Node::async_run` is called, this works out. However, this leads to a bug when using a runtime that spawns `Node::async_run` onto another thread where the global dataflow graph used by `async_run` is unpopulated.

The fix assigns the populated global dataflow graph to `node.dataflow_graph` which is then safely used across asynchronous functions.