### PR TITLE
Implement try_read for PyExtractStream

### DIFF
--- a/src/python/py_stream/py_extract_stream.rs
+++ b/src/python/py_stream/py_extract_stream.rs
@@ -1,6 +1,6 @@
 use pyo3::{exceptions, prelude::*};
 
-use crate::{dataflow::stream::ExtractStream, python::PyMessage};
+use crate::{dataflow::stream::{ExtractStream, errors::TryReadError}, python::PyMessage};
 
 use super::PyReadStream;
 
@@ -41,6 +41,18 @@ impl PyExtractStream {
                 self.extract_stream.get_id(),
                 e
             ))),
+        }
+    }
+
+    fn try_read<'p>(&mut self) -> PyResult<Option<PyMessage>> {
+        match self.extract_stream.try_read() {
+            Ok(msg) => Ok(Some(PyMessage::from(msg))),
+            Err(TryReadError::Empty) => Ok(None),
+            Err(e) => Err(exceptions::Exception::py_err(format!(
+                "Unable to to read from stream {}: {:?}",
+                self.extract_stream.get_id(),
+                e
+            )))
         }
     }
 }

--- a/src/python/py_stream/py_extract_stream.rs
+++ b/src/python/py_stream/py_extract_stream.rs
@@ -1,6 +1,9 @@
 use pyo3::{exceptions, prelude::*};
 
-use crate::{dataflow::stream::{ExtractStream, errors::TryReadError}, python::PyMessage};
+use crate::{
+    dataflow::stream::{errors::TryReadError, ExtractStream},
+    python::PyMessage,
+};
 
 use super::PyReadStream;
 
@@ -52,7 +55,7 @@ impl PyExtractStream {
                 "Unable to to read from stream {}: {:?}",
                 self.extract_stream.get_id(),
                 e
-            )))
+            ))),
         }
     }
 }


### PR DESCRIPTION
Fixes a bug in the implementation of `ExtractStream.try_read()` in the Python API.

https://github.com/erdos-project/erdos/blob/8b5715a9e1baf35108dd2cc259de5f652adf0da7/python/erdos/streams.py#L301-L309