### PR TITLE
[Python] Add support for multimachine operators.

### DIFF
--- a/python/erdos/__init__.py
+++ b/python/erdos/__init__.py
@@ -215,20 +215,18 @@ def run_async(graph_filename: Optional[str] = None,
             for i in range(_num_py_operators + 1)
         ]
         control_addresses = [
-            "127.0.0.1:{port}".format(port=start_port +
-                                      len(data_addresses) + i)
-            for i in range(_num_py_operators + 1)
+            "127.0.0.1:{port}".format(port=start_port + len(data_addresses) +
+                                      i) for i in range(_num_py_operators + 1)
         ]
     else:
         data_addresses = [
-            node_to_address[i][0] + ":{port}".format(port=start_port +
-                                                     node_to_address[i][1])
+            node_to_address[i][0] +
+            ":{port}".format(port=start_port + node_to_address[i][1])
             for i in range(_num_py_operators + 1)
         ]
         control_addresses = [
-            node_to_address[i][0] + ":{port}".format(port=start_port +
-                                                     len(data_addresses) +
-                                                     node_to_address[i][1])
+            node_to_address[i][0] + ":{port}".format(
+                port=start_port + len(data_addresses) + node_to_address[i][1])
             for i in range(_num_py_operators + 1)
         ]
     logger.debug(

--- a/python/erdos/__init__.py
+++ b/python/erdos/__init__.py
@@ -92,8 +92,8 @@ def connect(
             processes_per_address[config._address] = 1
             node_to_address[0] = (config._address, 1)
         processes_per_address[config._address] = \
-        processes_per_address.get(config._address, 0) + 1
-        node_to_address[node_id] = (config._address, 
+            processes_per_address.get(config._address, 0) + 1
+        node_to_address[node_id] = (config._address,
                                     processes_per_address[config._address])
 
     py_read_streams = []
@@ -226,7 +226,7 @@ def run_async(graph_filename: Optional[str] = None,
             for i in range(_num_py_operators + 1)
         ]
         control_addresses = [
-            node_to_address[i][0] + ":{port}".format(port=start_port + 
+            node_to_address[i][0] + ":{port}".format(port=start_port +
                                                      len(data_addresses) +
                                                      node_to_address[i][1])
             for i in range(_num_py_operators + 1)
@@ -240,8 +240,7 @@ def run_async(graph_filename: Optional[str] = None,
     if not multimachine:
         processes = [
             mp.Process(target=runner,
-                       args=(i, data_addresses,
-                       control_addresses))
+                       args=(i, data_addresses, control_addresses))
             for i in range(1, _num_py_operators + 1)
         ]
     else:
@@ -249,8 +248,7 @@ def run_async(graph_filename: Optional[str] = None,
         local_address = socket.gethostbyname(socket.gethostname())
         processes = [
             mp.Process(target=runner,
-                       args=(i, data_addresses,
-                       control_addresses))
+                       args=(i, data_addresses, control_addresses))
             for i in range(1, _num_py_operators + 1)
             if local_address == node_to_address[i][0]
         ]

--- a/python/erdos/operator.py
+++ b/python/erdos/operator.py
@@ -147,12 +147,14 @@ class OperatorConfig(object):
                  flow_watermarks: bool = True,
                  log_file_name: str = None,
                  csv_log_file_name: str = None,
-                 profile_file_name: str = None):
+                 profile_file_name: str = None,
+                 addr: str = None):
         self._name = name
         self._flow_watermarks = flow_watermarks
         self._log_file_name = log_file_name
         self._csv_log_file_name = csv_log_file_name
         self._profile_file_name = profile_file_name
+        self._addr = addr
 
     @property
     def name(self):

--- a/python/erdos/operator.py
+++ b/python/erdos/operator.py
@@ -148,13 +148,13 @@ class OperatorConfig(object):
                  log_file_name: str = None,
                  csv_log_file_name: str = None,
                  profile_file_name: str = None,
-                 addr: str = None):
+                 address: str = None):
         self._name = name
         self._flow_watermarks = flow_watermarks
         self._log_file_name = log_file_name
         self._csv_log_file_name = csv_log_file_name
         self._profile_file_name = profile_file_name
-        self._addr = addr
+        self._address = address
 
     @property
     def name(self):

--- a/python/examples/multimachine_pipeline.py
+++ b/python/examples/multimachine_pipeline.py
@@ -56,14 +56,13 @@ class PullOp(erdos.Operator):
 
 def main():
     """Creates and runs the dataflow graph."""
-    (count_stream, ) = erdos.connect(SendOp,
-                                     erdos.
-                                     OperatorConfig(address="172.17.0.9"), [])
-    erdos.connect(CallbackOp,
-                  erdos.OperatorConfig(address="172.17.0.10"), [count_stream])
-    erdos.connect(PullOp,
-                  erdos.OperatorConfig(address="172.17.0.11"), [count_stream])
-
+    (count_stream, ) = erdos.connect(
+        SendOp, erdos.OperatorConfig(address="172.17.0.9"), [])
+    erdos.connect(CallbackOp, erdos.OperatorConfig(address="172.17.0.10"),
+                  [count_stream])
+    erdos.connect(PullOp, erdos.OperatorConfig(address="172.17.0.11"),
+                  count_stream])
+    
     erdos.run()
 
 

--- a/python/examples/multimachine_pipeline.py
+++ b/python/examples/multimachine_pipeline.py
@@ -1,0 +1,67 @@
+"""Every second, sends the message count to 2 receivers.
+One receiver processes messages using a callback,
+one uses the blocking read() call.
+"""
+
+import erdos
+import time
+
+
+class SendOp(erdos.Operator):
+    def __init__(self, write_stream):
+        self.write_stream = write_stream
+
+    @staticmethod
+    def connect():
+        return [erdos.WriteStream()]
+
+    def run(self):
+        count = 0
+        while True:
+            msg = erdos.Message(erdos.Timestamp(coordinates=[count]), count)
+            print("SendOp: sending {msg}".format(msg=msg))
+            self.write_stream.send(msg)
+
+            count += 1
+            time.sleep(1)
+
+
+class CallbackOp(erdos.Operator):
+    def __init__(self, read_stream):
+        print("initializing  op")
+        read_stream.add_callback(CallbackOp.callback)
+
+    @staticmethod
+    def callback(msg):
+        print("CallbackOp: received {msg}".format(msg=msg))
+
+    @staticmethod
+    def connect(read_streams):
+        return []
+
+
+class PullOp(erdos.Operator):
+    def __init__(self, read_stream):
+        self.read_stream = read_stream
+
+    @staticmethod
+    def connect(read_streams):
+        return []
+
+    def run(self):
+        while True:
+            data = self.read_stream.read()
+            print("PullOp: received {data}".format(data=data))
+
+
+def main():
+    """Creates and runs the dataflow graph."""
+    (count_stream, ) = erdos.connect(SendOp, erdos.OperatorConfig(addr="172.17.0.9"), [])
+    erdos.connect(CallbackOp, erdos.OperatorConfig(addr="172.17.0.10"), [count_stream])
+    erdos.connect(PullOp, erdos.OperatorConfig(addr="172.17.0.11"), [count_stream])
+
+    erdos.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/multimachine_pipeline.py
+++ b/python/examples/multimachine_pipeline.py
@@ -57,8 +57,8 @@ class PullOp(erdos.Operator):
 def main():
     """Creates and runs the dataflow graph."""
     (count_stream, ) = erdos.connect(SendOp,
-                                     erdos.OperatorConfig(address=
-                                                          "172.17.0.9"), [])
+                                     erdos.
+                                     OperatorConfig(address="172.17.0.9"), [])
     erdos.connect(CallbackOp,
                   erdos.OperatorConfig(address="172.17.0.10"), [count_stream])
     erdos.connect(PullOp,

--- a/python/examples/multimachine_pipeline.py
+++ b/python/examples/multimachine_pipeline.py
@@ -56,9 +56,13 @@ class PullOp(erdos.Operator):
 
 def main():
     """Creates and runs the dataflow graph."""
-    (count_stream, ) = erdos.connect(SendOp, erdos.OperatorConfig(addr="172.17.0.9"), [])
-    erdos.connect(CallbackOp, erdos.OperatorConfig(addr="172.17.0.10"), [count_stream])
-    erdos.connect(PullOp, erdos.OperatorConfig(addr="172.17.0.11"), [count_stream])
+    (count_stream, ) = erdos.connect(SendOp,
+                                     erdos.OperatorConfig(address=
+                                                          "172.17.0.9"), [])
+    erdos.connect(CallbackOp,
+                  erdos.OperatorConfig(address="172.17.0.10"), [count_stream])
+    erdos.connect(PullOp,
+                  erdos.OperatorConfig(address="172.17.0.11"), [count_stream])
 
     erdos.run()
 

--- a/python/examples/multimachine_pipeline.py
+++ b/python/examples/multimachine_pipeline.py
@@ -61,8 +61,8 @@ def main():
     erdos.connect(CallbackOp, erdos.OperatorConfig(address="172.17.0.10"),
                   [count_stream])
     erdos.connect(PullOp, erdos.OperatorConfig(address="172.17.0.11"),
-                  count_stream])
-    
+                  [count_stream])
+
     erdos.run()
 
 


### PR DESCRIPTION
Adds support for multimachine operators. Operators can now be configured with IP addresses and ports for the machines on which they should run.

### Changes

* The `OperatorConfig` class in operator.py now takes in an optional `addr` attribute that defines the address of the machine on which the operator should run.
* The `connect` method and `run_async` method in __ init __.py now keep track of the addresses on which any operators run via two new global variables, node_addrs and num_procs. They use these addresses to set up the networking to connect these operators.
* The file multimachine_pipeline.py provides an example use case for multimachine operators.