### PR TITLE
[Bugfix] Destroy operator when run finishes

### DIFF
--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -237,16 +237,16 @@ impl OperatorExecutor {
                 .unwrap();
             // Handle errors?
             future::join_all(event_runner_handles).await;
+        }
 
-            if self.all_streams_closed() {
-                slog::debug!(
-                    crate::TERMINAL_LOGGER,
-                    "Node {}: destroying operator {}",
-                    self.config.node_id,
-                    name,
-                );
-                self.operator.destroy();
-            }
+        if self.all_streams_closed() {
+            slog::debug!(
+                crate::TERMINAL_LOGGER,
+                "Node {}: destroying operator {}",
+                self.config.node_id,
+                name,
+            );
+            self.operator.destroy();
         }
     }
 


### PR DESCRIPTION
Fixes a bug in operators with no input streams where `destroy()` would not be invoked after `run()` finishes.

Note: although `destroy()` will be invoked, top watermarks are *not* automatically sent on output streams.