### PR TITLE
Introduce MessageProcessorT and OperatorExecutorHelper abstractions.

### DIFF
--- a/src/dataflow/operator.rs
+++ b/src/dataflow/operator.rs
@@ -36,7 +36,7 @@ where
  * Sink: receives data with type T                                           *
  *****************************************************************************/
 
-pub trait Sink<S: State, T: Data>: Send {
+pub trait Sink<S: State, T: Data>: Send + Sync {
     fn run(&mut self, read_stream: &mut ReadStream<T>) {}
 
     fn destroy(&mut self) {}

--- a/src/dataflow/operator.rs
+++ b/src/dataflow/operator.rs
@@ -143,7 +143,7 @@ pub struct StatefulTwoInOneOutContext<S: State, U: Data> {
  * OneInTwoOut: receives T, sends U, sends V                                 *
  *****************************************************************************/
 
-pub trait OneInTwoOut<S: State, T: Data, U: Data, V: Data>: Send {
+pub trait OneInTwoOut<S: State, T: Data, U: Data, V: Data>: Send + Sync {
     fn run(
         &mut self,
         read_stream: &mut ReadStream<T>,

--- a/src/dataflow/operator.rs
+++ b/src/dataflow/operator.rs
@@ -99,7 +99,7 @@ where
  * TwoInOneOut: receives T, receives U, sends V                              *
  *****************************************************************************/
 
-pub trait TwoInOneOut<S, T, U, V>: Send
+pub trait TwoInOneOut<S, T, U, V>: Send + Sync
 where
     S: State,
     T: Data + for<'a> Deserialize<'a>,

--- a/src/dataflow/operator.rs
+++ b/src/dataflow/operator.rs
@@ -62,7 +62,7 @@ pub struct StatefulSinkContext<S: State> {
  * OneInOneOut: receives T, sends U                                          *
  *****************************************************************************/
 
-pub trait OneInOneOut<S, T, U>: Send
+pub trait OneInOneOut<S, T, U>: Send + Sync
 where
     S: State,
     T: Data + for<'a> Deserialize<'a>,

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -741,7 +741,7 @@ where
                         // Watermark
                         None => {
                             right_watermark = right_msg.timestamp().clone();
-                            let advance_watermark = cmp::min(&right_watermark, &right_watermark) > &min_watermark;
+                            let advance_watermark = cmp::min(&left_watermark, &right_watermark) > &min_watermark;
                             if advance_watermark {
                                 min_watermark = right_watermark.clone();
 

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -3,6 +3,7 @@ use std::{
     cmp,
     collections::{HashMap, HashSet},
     future::Future,
+    marker::PhantomData,
     pin::Pin,
     rc::Rc,
     sync::{
@@ -71,6 +72,108 @@ pub trait OperatorExecutorT: Send {
     fn execute<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = ()> + 'a + Send>>;
 }
 
+pub trait MessageProcessorT<T>: Send + Sync
+where
+    T: Data + for<'a> Deserialize<'a>,
+{
+    // Generates an OperatorEvent for a stateless callback.
+    fn stateless_cb_event(&self, msg: Arc<Message<T>>) -> OperatorEvent;
+
+    // Generates an OperatorEvent for a stateful callback.
+    fn stateful_cb_event(&self, msg: Arc<Message<T>>) -> OperatorEvent;
+
+    // Generates an OperatorEvent for a watermark callback.
+    fn watermark_cb_event(&self, timestamp: &Timestamp) -> OperatorEvent;
+}
+
+pub struct OperatorExecutorHelper<T> {
+    lattice: Arc<ExecutionLattice>,
+    event_runner_handles: Option<Vec<tokio::task::JoinHandle<()>>>,
+    phantom: PhantomData<T>,
+}
+
+impl<T> OperatorExecutorHelper<T>
+where
+    T: Data + for<'a> Deserialize<'a>,
+{
+    fn new() -> Self {
+        OperatorExecutorHelper {
+            lattice: Arc::new(ExecutionLattice::new()),
+            event_runner_handles: None,
+            phantom: PhantomData,
+        }
+    }
+
+    async fn synchronize(&self) {
+        // TODO: replace this with a synchronization step
+        // that ensures all operators are ready to run.
+        tokio::time::delay_for(Duration::from_secs(1)).await;
+    }
+
+    fn setup(
+        &mut self,
+        num_event_runners: usize,
+    ) -> tokio::sync::watch::Sender<EventRunnerMessage> {
+        // Set up the event runner.
+        let (notifier_tx, notifier_rx) = watch::channel(EventRunnerMessage::AddedEvents);
+        self.event_runner_handles = Some(Vec::with_capacity(num_event_runners));
+        for _ in 0..num_event_runners {
+            let event_runner_fut =
+                tokio::task::spawn(event_runner(Arc::clone(&self.lattice), notifier_rx.clone()));
+            self.event_runner_handles
+                .as_mut()
+                .unwrap()
+                .push(event_runner_fut);
+        }
+        notifier_tx
+    }
+
+    async fn process_messages(
+        &self,
+        mut read_stream: ReadStream<T>,
+        message_processor: &dyn MessageProcessorT<T>,
+        notifier_tx: &tokio::sync::watch::Sender<EventRunnerMessage>,
+    ) {
+        while let Ok(msg) = read_stream.async_read().await {
+            // TODO: optimize so that stateful callbacks not invoked if not needed.
+            let events = match msg.data() {
+                // Data message
+                Some(_) => {
+                    // Stateless callback.
+                    let msg_ref = Arc::clone(&msg);
+                    let stateless_data_event = message_processor.stateless_cb_event(msg_ref);
+
+                    // Stateful callback
+                    let msg_ref = Arc::clone(&msg);
+                    let stateful_data_event = message_processor.stateful_cb_event(msg_ref);
+                    vec![stateless_data_event, stateful_data_event]
+                }
+                // Watermark
+                None => {
+                    let watermark_event = message_processor.watermark_cb_event(msg.timestamp());
+                    vec![watermark_event]
+                }
+            };
+
+            self.lattice.add_events(events).await;
+            notifier_tx
+                .broadcast(EventRunnerMessage::AddedEvents)
+                .unwrap();
+        }
+    }
+
+    async fn teardown(&mut self, notifier_tx: &tokio::sync::watch::Sender<EventRunnerMessage>) {
+        // Wait for event runners to finish.
+        notifier_tx
+            .broadcast(EventRunnerMessage::DestroyOperator)
+            .unwrap();
+
+        // Handle errors?
+        let event_runner_handles = self.event_runner_handles.take().unwrap();
+        future::join_all(event_runner_handles).await;
+    }
+}
+
 pub struct SourceExecutor<O, S, T>
 where
     O: Source<S, T>,
@@ -81,6 +184,7 @@ where
     operator: O,
     state: S,
     write_stream: WriteStream<T>,
+    helper: OperatorExecutorHelper<T>,
 }
 
 impl<O, S, T> SourceExecutor<O, S, T>
@@ -100,13 +204,12 @@ where
             operator: operator_fn(),
             state: state_fn(),
             write_stream,
+            helper: OperatorExecutorHelper::new(),
         }
     }
 
     pub async fn execute(&mut self) {
-        // TODO: replace this with a synchronization step
-        // that ensures all operators are ready to run.
-        tokio::time::delay_for(Duration::from_secs(1)).await;
+        self.helper.synchronize().await;
 
         slog::debug!(
             crate::TERMINAL_LOGGER,
@@ -147,7 +250,9 @@ where
     config: OperatorConfig,
     operator: O,
     state: Arc<Mutex<S>>,
-    read_stream: ReadStream<T>,
+    read_stream: Option<ReadStream<T>>,
+    helper: OperatorExecutorHelper<T>,
+    read_ids: HashSet<StreamId>,
 }
 
 impl<O, S, T> SinkExecutor<O, S, T>
@@ -166,14 +271,14 @@ where
             config,
             operator: operator_fn(),
             state: Arc::new(Mutex::new(state_fn())),
-            read_stream,
+            read_ids: vec![read_stream.id()].into_iter().collect(),
+            read_stream: Some(read_stream),
+            helper: OperatorExecutorHelper::new(),
         }
     }
 
     pub async fn execute(&mut self) {
-        // TODO: replace this with a synchronization step
-        // that ensures all operators are ready to run.
-        tokio::time::delay_for(Duration::from_secs(1)).await;
+        self.helper.synchronize().await;
 
         slog::debug!(
             crate::TERMINAL_LOGGER,
@@ -182,87 +287,16 @@ where
             self.config.get_name()
         );
 
-        tokio::task::block_in_place(|| self.operator.run(&mut self.read_stream));
+        tokio::task::block_in_place(|| self.operator.run(self.read_stream.as_mut().unwrap()));
 
-        // Set up lattice and event runners.
-        let lattice = Arc::new(ExecutionLattice::new());
-        let (notifier_tx, notifier_rx) = watch::channel(EventRunnerMessage::AddedEvents);
-        let mut event_runner_handles = Vec::new();
-        for _ in 0..self.config.num_event_runners {
-            let event_runner_fut =
-                tokio::task::spawn(event_runner(Arc::clone(&lattice), notifier_rx.clone()));
-            event_runner_handles.push(event_runner_fut);
-        }
+        let notifier_tx = self.helper.setup(self.config.num_event_runners);
 
-        // Get messages and insert events into lattice.
-        let mut read_ids = HashSet::new();
-        read_ids.insert(self.read_stream.id());
-        while let Ok(msg) = self.read_stream.async_read().await {
-            // TODO: optimize so that stateful callbacks not invoked if not needed.
-            let events = match msg.data() {
-                // Data message
-                Some(_) => {
-                    // Stateless callback.
-                    let msg_ref = Arc::clone(&msg);
-                    let mut ctx = SinkContext {
-                        timestamp: msg.timestamp().clone(),
-                    };
-                    let data_event = OperatorEvent::new(
-                        msg.timestamp().clone(),
-                        false,
-                        0,
-                        HashSet::new(), // Used to manage state in lattice, should be cleaned up.
-                        HashSet::new(), // Used to manage state in lattice, should be cleaned up.
-                        move || O::on_data(&mut ctx, msg_ref.data().unwrap()),
-                    );
+        let read_stream: ReadStream<T> = self.read_stream.take().unwrap();
+        self.helper
+            .process_messages(read_stream, &(*self), &notifier_tx)
+            .await;
 
-                    // Stateful callback
-                    let msg_ref = Arc::clone(&msg);
-                    let mut ctx = StatefulSinkContext {
-                        timestamp: msg.timestamp().clone(),
-                        state: Arc::clone(&self.state),
-                    };
-                    let stateful_data_event = OperatorEvent::new(
-                        msg.timestamp().clone(),
-                        false,
-                        0,
-                        read_ids.clone(),
-                        HashSet::new(),
-                        move || O::on_data_stateful(&mut ctx, msg_ref.data().unwrap()),
-                    );
-
-                    vec![data_event, stateful_data_event]
-                }
-                // Watermark
-                None => {
-                    let mut ctx = StatefulSinkContext {
-                        timestamp: msg.timestamp().clone(),
-                        state: Arc::clone(&self.state),
-                    };
-                    let watermark_event = OperatorEvent::new(
-                        msg.timestamp().clone(),
-                        true,
-                        0,
-                        read_ids.clone(),
-                        HashSet::new(),
-                        move || O::on_watermark(&mut ctx),
-                    );
-                    vec![watermark_event]
-                }
-            };
-
-            lattice.add_events(events).await;
-            notifier_tx
-                .broadcast(EventRunnerMessage::AddedEvents)
-                .unwrap();
-        }
-
-        // Wait for event runners to finish.
-        notifier_tx
-            .broadcast(EventRunnerMessage::DestroyOperator)
-            .unwrap();
-        // Handle errors?
-        future::join_all(event_runner_handles).await;
+        self.helper.teardown(&notifier_tx).await;
 
         tokio::task::block_in_place(|| self.operator.destroy());
     }
@@ -276,6 +310,59 @@ where
 {
     fn execute<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = ()> + 'a + Send>> {
         Box::pin(self.execute())
+    }
+}
+
+impl<O, S, T> MessageProcessorT<T> for SinkExecutor<O, S, T>
+where
+    O: Sink<S, T>,
+    S: State,
+    T: Data + for<'a> Deserialize<'a>,
+{
+    fn stateless_cb_event(&self, msg: Arc<Message<T>>) -> OperatorEvent {
+        let mut ctx = SinkContext {
+            timestamp: msg.timestamp().clone(),
+        };
+        OperatorEvent::new(
+            msg.timestamp().clone(),
+            false,
+            0,
+            HashSet::new(),
+            HashSet::new(),
+            move || O::on_data(&mut ctx, msg.data().unwrap()),
+        )
+    }
+
+    // Generates an OperatorEvent for a stateful callback.
+    fn stateful_cb_event(&self, msg: Arc<Message<T>>) -> OperatorEvent {
+        let mut ctx = StatefulSinkContext {
+            timestamp: msg.timestamp().clone(),
+            state: Arc::clone(&self.state),
+        };
+        OperatorEvent::new(
+            msg.timestamp().clone(),
+            false,
+            0,
+            self.read_ids.clone(),
+            HashSet::new(),
+            move || O::on_data_stateful(&mut ctx, msg.data().unwrap()),
+        )
+    }
+
+    // Generates an OperatorEvent for a watermark callback.
+    fn watermark_cb_event(&self, timestamp: &Timestamp) -> OperatorEvent {
+        let mut ctx = StatefulSinkContext {
+            timestamp: timestamp.clone(),
+            state: Arc::clone(&self.state),
+        };
+        OperatorEvent::new(
+            timestamp.clone(),
+            true,
+            0,
+            self.read_ids.clone(),
+            HashSet::new(),
+            move || O::on_watermark(&mut ctx),
+        )
     }
 }
 

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -72,7 +72,7 @@ pub trait OperatorExecutorT: Send {
     fn execute<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = ()> + 'a + Send>>;
 }
 
-pub trait MessageProcessorT<T>: Send + Sync
+pub trait OneInMessageProcessorT<T>: Send + Sync
 where
     T: Data + for<'a> Deserialize<'a>,
 {
@@ -131,7 +131,7 @@ where
     async fn process_messages(
         &self,
         mut read_stream: ReadStream<T>,
-        message_processor: &dyn MessageProcessorT<T>,
+        message_processor: &dyn OneInMessageProcessorT<T>,
         notifier_tx: &tokio::sync::watch::Sender<EventRunnerMessage>,
     ) {
         while let Ok(msg) = read_stream.async_read().await {
@@ -313,7 +313,7 @@ where
     }
 }
 
-impl<O, S, T> MessageProcessorT<T> for SinkExecutor<O, S, T>
+impl<O, S, T> OneInMessageProcessorT<T> for SinkExecutor<O, S, T>
 where
     O: Sink<S, T>,
     S: State,
@@ -456,7 +456,7 @@ where
     }
 }
 
-impl<O, S, T, U> MessageProcessorT<T> for OneInOneOutExecutor<O, S, T, U>
+impl<O, S, T, U> OneInMessageProcessorT<T> for OneInOneOutExecutor<O, S, T, U>
 where
     O: OneInOneOut<S, T, U>,
     S: State,
@@ -926,7 +926,7 @@ where
     }
 }
 
-impl<O, S, T, U, V> MessageProcessorT<T> for OneInTwoOutExecutor<O, S, T, U, V>
+impl<O, S, T, U, V> OneInMessageProcessorT<T> for OneInTwoOutExecutor<O, S, T, U, V>
 where
     O: OneInTwoOut<S, T, U, V>,
     S: State,

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -376,8 +376,11 @@ where
     config: OperatorConfig,
     operator: O,
     state: Arc<Mutex<S>>,
-    read_stream: ReadStream<T>,
+    read_stream: Option<ReadStream<T>>,
     write_stream: WriteStream<U>,
+    helper: OperatorExecutorHelper<T>,
+    read_ids: HashSet<StreamId>,
+    write_ids: HashSet<StreamId>,
 }
 
 impl<O, S, T, U> OneInOneOutExecutor<O, S, T, U>
@@ -398,15 +401,16 @@ where
             config,
             operator: operator_fn(),
             state: Arc::new(Mutex::new(state_fn())),
-            read_stream,
+            read_ids: vec![read_stream.id()].into_iter().collect(),
+            write_ids: vec![write_stream.id()].into_iter().collect(),
+            read_stream: Some(read_stream),
             write_stream,
+            helper: OperatorExecutorHelper::new(),
         }
     }
 
     pub async fn execute(&mut self) {
-        // TODO: replace this with a synchronization step
-        // that ensures all operators are ready to run.
-        tokio::time::delay_for(Duration::from_secs(1)).await;
+        self.helper.synchronize().await;
 
         slog::debug!(
             crate::TERMINAL_LOGGER,
@@ -417,113 +421,17 @@ where
 
         tokio::task::block_in_place(|| {
             self.operator
-                .run(&mut self.read_stream, &mut self.write_stream)
+                .run(self.read_stream.as_mut().unwrap(), &mut self.write_stream)
         });
 
-        // Set up lattice and event runners.
-        let lattice = Arc::new(ExecutionLattice::new());
-        let (notifier_tx, notifier_rx) = watch::channel(EventRunnerMessage::AddedEvents);
-        let mut event_runner_handles = Vec::new();
-        for _ in 0..self.config.num_event_runners {
-            let event_runner_fut =
-                tokio::task::spawn(event_runner(Arc::clone(&lattice), notifier_rx.clone()));
-            event_runner_handles.push(event_runner_fut);
-        }
+        let notifier_tx = self.helper.setup(self.config.num_event_runners);
 
-        // Get messages and insert events into lattice.
-        let mut read_ids = HashSet::new();
-        read_ids.insert(self.read_stream.id());
-        let mut write_ids = HashSet::new();
-        write_ids.insert(self.write_stream.id());
-        while let Ok(msg) = self.read_stream.async_read().await {
-            // TODO: optimize so that stateful callbacks not invoked if not needed.
-            let events = match msg.data() {
-                // Data message
-                Some(_) => {
-                    // Stateless callback.
-                    let msg_ref = Arc::clone(&msg);
-                    let mut ctx = OneInOneOutContext {
-                        timestamp: msg.timestamp().clone(),
-                        write_stream: self.write_stream.clone(),
-                    };
-                    let data_event = OperatorEvent::new(
-                        msg.timestamp().clone(),
-                        false,
-                        0,
-                        HashSet::new(), // Used to manage state in lattice, should be cleaned up.
-                        HashSet::new(), // Used to manage state in lattice, should be cleaned up.
-                        move || O::on_data(&mut ctx, msg_ref.data().unwrap()),
-                    );
+        let read_stream: ReadStream<T> = self.read_stream.take().unwrap();
+        self.helper
+            .process_messages(read_stream, &(*self), &notifier_tx)
+            .await;
 
-                    // Stateful callback
-                    let msg_ref = Arc::clone(&msg);
-                    let mut ctx = StatefulOneInOneOutContext {
-                        timestamp: msg.timestamp().clone(),
-                        write_stream: self.write_stream.clone(),
-                        state: Arc::clone(&self.state),
-                    };
-                    let stateful_data_event = OperatorEvent::new(
-                        msg.timestamp().clone(),
-                        false,
-                        0,
-                        read_ids.clone(),
-                        write_ids.clone(),
-                        move || O::on_data_stateful(&mut ctx, msg_ref.data().unwrap()),
-                    );
-
-                    vec![data_event, stateful_data_event]
-                }
-                // Watermark
-                None => {
-                    let mut ctx = StatefulOneInOneOutContext {
-                        timestamp: msg.timestamp().clone(),
-                        write_stream: self.write_stream.clone(),
-                        state: Arc::clone(&self.state),
-                    };
-                    let watermark_event = OperatorEvent::new(
-                        msg.timestamp().clone(),
-                        true,
-                        0,
-                        read_ids.clone(),
-                        write_ids.clone(),
-                        move || O::on_watermark(&mut ctx),
-                    );
-
-                    if self.config.flow_watermarks {
-                        let timestamp = msg.timestamp().clone();
-                        let mut write_stream_copy = self.write_stream.clone();
-                        let flow_watermark_event = OperatorEvent::new(
-                            msg.timestamp().clone(),
-                            true,
-                            127,
-                            read_ids.clone(),
-                            write_ids.clone(),
-                            move || {
-                                write_stream_copy
-                                    .send(Message::new_watermark(timestamp))
-                                    .ok();
-                            },
-                        );
-                        vec![watermark_event, flow_watermark_event]
-                    } else {
-                        vec![watermark_event]
-                    }
-                }
-            };
-
-            lattice.add_events(events).await;
-            notifier_tx
-                .broadcast(EventRunnerMessage::AddedEvents)
-                .unwrap();
-        }
-
-        // Wait for event runners to finish.
-        notifier_tx
-            .broadcast(EventRunnerMessage::DestroyOperator)
-            .unwrap();
-        // Handle errors?
-        future::join_all(event_runner_handles).await;
-
+        self.helper.teardown(&notifier_tx).await;
         tokio::task::block_in_place(|| self.operator.destroy());
 
         // Close the stream.
@@ -545,6 +453,83 @@ where
 {
     fn execute<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = ()> + 'a + Send>> {
         Box::pin(self.execute())
+    }
+}
+
+impl<O, S, T, U> MessageProcessorT<T> for OneInOneOutExecutor<O, S, T, U>
+where
+    O: OneInOneOut<S, T, U>,
+    S: State,
+    T: Data + for<'a> Deserialize<'a>,
+    U: Data + for<'a> Deserialize<'a>,
+{
+    fn stateless_cb_event(&self, msg: Arc<Message<T>>) -> OperatorEvent {
+        let mut ctx = OneInOneOutContext {
+            timestamp: msg.timestamp().clone(),
+            write_stream: self.write_stream.clone(),
+        };
+        OperatorEvent::new(
+            msg.timestamp().clone(),
+            false,
+            0,
+            HashSet::new(),
+            HashSet::new(),
+            move || O::on_data(&mut ctx, msg.data().unwrap()),
+        )
+    }
+
+    // Generates an OperatorEvent for a stateful callback.
+    fn stateful_cb_event(&self, msg: Arc<Message<T>>) -> OperatorEvent {
+        let mut ctx = StatefulOneInOneOutContext {
+            timestamp: msg.timestamp().clone(),
+            write_stream: self.write_stream.clone(),
+            state: Arc::clone(&self.state),
+        };
+        OperatorEvent::new(
+            msg.timestamp().clone(),
+            false,
+            0,
+            self.read_ids.clone(),
+            self.write_ids.clone(),
+            move || O::on_data_stateful(&mut ctx, msg.data().unwrap()),
+        )
+    }
+
+    // Generates an OperatorEvent for a watermark callback.
+    fn watermark_cb_event(&self, timestamp: &Timestamp) -> OperatorEvent {
+        let mut ctx = StatefulOneInOneOutContext {
+            timestamp: timestamp.clone(),
+            write_stream: self.write_stream.clone(),
+            state: Arc::clone(&self.state),
+        };
+        if self.config.flow_watermarks {
+            let mut write_stream_copy = self.write_stream.clone();
+            let timestamp_copy = timestamp.clone();
+            OperatorEvent::new(
+                timestamp.clone(),
+                true,
+                0,
+                self.read_ids.clone(),
+                self.write_ids.clone(),
+                move || {
+                    O::on_watermark(&mut ctx);
+                    write_stream_copy
+                        .send(Message::new_watermark(timestamp_copy))
+                        .ok();
+                },
+            )
+        } else {
+            OperatorEvent::new(
+                timestamp.clone(),
+                true,
+                0,
+                self.read_ids.clone(),
+                self.write_ids.clone(),
+                move || {
+                    O::on_watermark(&mut ctx);
+                },
+            )
+        }
     }
 }
 

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -144,7 +144,7 @@ impl OperatorExecutorHelper {
         notifier_tx
     }
 
-    async fn process_messages<T>(
+    async fn process_stream<T>(
         &self,
         mut read_stream: ReadStream<T>,
         message_processor: &dyn OneInMessageProcessorT<T>,
@@ -387,7 +387,7 @@ where
 
         let read_stream: ReadStream<T> = self.read_stream.take().unwrap();
         self.helper
-            .process_messages(read_stream, &(*self), &notifier_tx)
+            .process_stream(read_stream, &(*self), &notifier_tx)
             .await;
 
         self.helper.teardown(&notifier_tx).await;
@@ -522,7 +522,7 @@ where
 
         let read_stream: ReadStream<T> = self.read_stream.take().unwrap();
         self.helper
-            .process_messages(read_stream, &(*self), &notifier_tx)
+            .process_stream(read_stream, &(*self), &notifier_tx)
             .await;
 
         self.helper.teardown(&notifier_tx).await;
@@ -699,7 +699,9 @@ where
 
         let left_read_stream: ReadStream<T> = self.left_read_stream.take().unwrap();
         let right_read_stream: ReadStream<U> = self.right_read_stream.take().unwrap();
-        self.helper.process_two_streams(left_read_stream, right_read_stream, &(*self), &notifier_tx).await;
+        self.helper
+            .process_two_streams(left_read_stream, right_read_stream, &(*self), &notifier_tx)
+            .await;
 
         self.helper.teardown(&notifier_tx).await;
         tokio::task::block_in_place(|| self.operator.destroy());
@@ -909,7 +911,7 @@ where
 
         let read_stream: ReadStream<T> = self.read_stream.take().unwrap();
         self.helper
-            .process_messages(read_stream, &(*self), &notifier_tx)
+            .process_stream(read_stream, &(*self), &notifier_tx)
             .await;
 
         self.helper.teardown(&notifier_tx).await;


### PR DESCRIPTION
PR to track the deduplication of the `OperatorExecutor` code. Changes are as follows:

- Require the operator traits to be both `Send` and `Sync`.
- Introduce `MessageProcessorT` trait that must be implemented by each executor and provides a way to create new `OperatorEvent`s for stateless and stateful message callbacks along with watermark callbacks.
- Introduce `OperatorExecutorHelper` struct that performs the common tasks of synchronization of the operators, creation of channels, processing of messages and teardown. It invokes the abstractions provided by the `MessageProcessorT` trait to generate events for the lattice. 

Curent status:

- Moved `SourceOperator` and `SinkOperator` to the new abstractions.