### PR TITLE
Rewrite IntTimestamp to enum.

### DIFF
--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -6,12 +6,14 @@ pub mod connect;
 pub mod graph;
 pub mod message;
 pub mod operator;
+pub mod time;
 // pub mod operators;
 pub mod state;
 pub mod stream;
 
 // Public exports
-pub use message::{Data, Message, Timestamp, TimestampedData};
+pub use message::{Data, Message, TimestampedData};
+pub use time::Timestamp;
 pub use operator::OperatorConfig;
 pub use state::State;
 pub use stream::{LoopStream, Stream, ReadStream, StreamT, WriteStream};
@@ -39,7 +41,7 @@ mod tests {
         });
 
         // Generate events from message
-        let msg = Message::new_message(Timestamp::new(vec![1]), String::from("msg 1"));
+        let msg = Message::new_message(Timestamp::Time(vec![1]), String::from("msg 1"));
         let irs: Rc<RefCell<InternalReadStream<String>>> = (&rs).into();
         let mut events = irs.borrow().make_events(Arc::new(msg));
         assert!(events.len() == 1);
@@ -66,8 +68,8 @@ mod tests {
         });
 
         // Generate events from message
-        let msg = Message::new_message(Timestamp::new(vec![1]), String::from("msg 1"));
-        let watermark_msg = Message::new_watermark(Timestamp::new(vec![2]));
+        let msg = Message::new_message(Timestamp::Time(vec![1]), String::from("msg 1"));
+        let watermark_msg = Message::new_watermark(Timestamp::Time(vec![2]));
         // Non-watermark messages should not create events
         let events = irs.borrow().make_events(Arc::new(msg));
         assert!(events.is_empty());
@@ -103,7 +105,7 @@ mod tests {
         });
 
         // Generate events from message
-        let msg = Message::new_message(Timestamp::new(vec![1]), 42);
+        let msg = Message::new_message(Timestamp::Time(vec![1]), 42);
         let mut events = irs.borrow().make_events(Arc::new(msg));
         assert!(events.len() == 1);
 
@@ -129,8 +131,8 @@ mod tests {
         });
 
         // Generate events from message
-        let msg = Message::new_message(Timestamp::new(vec![1]), 1);
-        let watermark_msg = Message::new_watermark(Timestamp::new(vec![2]));
+        let msg = Message::new_message(Timestamp::Time(vec![1]), 1);
+        let watermark_msg = Message::new_watermark(Timestamp::Time(vec![2]));
         // Non-watermark messages should not create events
         let events = irs.borrow().make_events(Arc::new(msg));
         assert!(events.is_empty());
@@ -164,10 +166,10 @@ mod tests {
         crate::add_watermark_callback!((srs1, srs2), (), (cb));
 
         // Generate events from message
-        let msg1 = Message::new_message(Timestamp::new(vec![1]), 1);
-        let msg2 = Message::new_message(Timestamp::new(vec![1]), 1);
-        let watermark_msg1 = Message::new_watermark(Timestamp::new(vec![2]));
-        let watermark_msg2 = Message::new_watermark(Timestamp::new(vec![2]));
+        let msg1 = Message::new_message(Timestamp::Time(vec![1]), 1);
+        let msg2 = Message::new_message(Timestamp::Time(vec![1]), 1);
+        let watermark_msg1 = Message::new_watermark(Timestamp::Time(vec![2]));
+        let watermark_msg2 = Message::new_watermark(Timestamp::Time(vec![2]));
         // Non-watermark messages should not create events
         let events = irs1.borrow().make_events(Arc::new(msg1));
         assert!(events.is_empty());
@@ -223,12 +225,12 @@ mod tests {
             .add_watermark_callback(cb);
 
         // Generate events from message
-        let msg1 = Message::new_message(Timestamp::new(vec![1]), 1);
-        let msg2 = Message::new_message(Timestamp::new(vec![1]), 1);
-        let msg3 = Message::new_message(Timestamp::new(vec![1]), 1);
-        let watermark_msg1 = Message::new_watermark(Timestamp::new(vec![2]));
-        let watermark_msg2 = Message::new_watermark(Timestamp::new(vec![2]));
-        let watermark_msg3 = Message::new_watermark(Timestamp::new(vec![2]));
+        let msg1 = Message::new_message(Timestamp::Time(vec![1]), 1);
+        let msg2 = Message::new_message(Timestamp::Time(vec![1]), 1);
+        let msg3 = Message::new_message(Timestamp::Time(vec![1]), 1);
+        let watermark_msg1 = Message::new_watermark(Timestamp::Time(vec![2]));
+        let watermark_msg2 = Message::new_watermark(Timestamp::Time(vec![2]));
+        let watermark_msg3 = Message::new_watermark(Timestamp::Time(vec![2]));
         // Non-watermark messages should not create events
         let events = irs1.borrow().make_events(Arc::new(msg1));
         assert!(events.is_empty());
@@ -270,7 +272,7 @@ mod tests {
         rws.borrow_mut().add_watermark_callback(
             |_t: &Timestamp, state: &CounterState, output_stream: &mut WriteStream<usize>| {
                 let msg = TimestampedData {
-                    timestamp: Timestamp::new(vec![1]),
+                    timestamp: Timestamp::Time(vec![1]),
                     data: state.count,
                 };
                 output_stream.send(Message::TimestampedData(msg)).unwrap()
@@ -278,9 +280,9 @@ mod tests {
         );
 
         // Watermark messages should create events
-        let t0 = Timestamp::new(vec![0]);
-        let t1 = Timestamp::new(vec![1]);
-        let t2 = Timestamp::new(vec![2]);
+        let t0 = Timestamp::Time(vec![0]);
+        let t1 = Timestamp::Time(vec![1]);
+        let t2 = Timestamp::Time(vec![2]);
 
         // First watermark should create events
         let events = rws.borrow_mut().receive_watermark(rs.get_id(), t1);
@@ -320,8 +322,8 @@ mod tests {
             tx2.send("watermark callback invoked").unwrap();
         });
         // Generate events from message
-        let msg = Message::new_message(Timestamp::new(vec![1]), String::from(""));
-        let watermark_msg = Message::new_watermark(Timestamp::new(vec![2]));
+        let msg = Message::new_message(Timestamp::Time(vec![1]), String::from(""));
+        let watermark_msg = Message::new_watermark(Timestamp::Time(vec![2]));
         // Non-watermark messages should not create events
         let mut events = irs.borrow().make_events(Arc::new(msg));
         assert!(events.len() == 1);

--- a/src/dataflow/state.rs
+++ b/src/dataflow/state.rs
@@ -397,16 +397,16 @@ mod tests {
         state.set_history_size(2).unwrap();
         assert_eq!(state.history_size(), 2);
         state.set_initial_state(99).unwrap();
-        assert_eq!(Some(&99), state.state_history.get(&Timestamp::bottom()));
+        assert_eq!(Some(&99), state.state_history.get(&Timestamp::Bottom));
         assert!(state.append(3).is_err());
         assert_eq!(
             Some(&Vec::new()),
-            state.message_history.get(&Timestamp::bottom())
+            state.message_history.get(&Timestamp::Bottom)
         );
         assert!(state.get_current_messages().is_err());
-        assert!(state.get_messages(&Timestamp::bottom()).is_err());
+        assert!(state.get_messages(&Timestamp::Bottom).is_err());
         assert!(state.iter_messages().is_err());
-        assert!(state.get_state(&Timestamp::bottom()).is_err());
+        assert!(state.get_state(&Timestamp::Bottom).is_err());
         assert!(state.get_current_state().is_err());
         assert!(state.get_current_state_mut().is_err());
         assert!(state.iter_states().is_err());
@@ -417,18 +417,18 @@ mod tests {
         let mut state: TimeVersionedState<usize, usize> =
             TimeVersionedState::new_with_history_size(1);
         state.access_context = AccessContext::Callback;
-        let current_time = Timestamp::new(vec![1]);
+        let current_time = Timestamp::Time(vec![1]);
         state.set_current_time(current_time.clone());
         assert!(state.set_history_size(2).is_err());
         assert_ne!(state.history_size(), 2);
         assert!(state.set_initial_state(99).is_err());
-        assert_eq!(None, state.state_history.get(&Timestamp::bottom()));
+        assert_eq!(None, state.state_history.get(&Timestamp::Bottom));
         assert!(state.append(3).is_ok());
         assert_eq!(Some(&vec![3]), state.message_history.get(&current_time));
         assert!(state.get_current_messages().is_err());
-        assert!(state.get_messages(&Timestamp::bottom()).is_err());
+        assert!(state.get_messages(&Timestamp::Bottom).is_err());
         assert!(state.iter_messages().is_err());
-        assert!(state.get_state(&Timestamp::bottom()).is_err());
+        assert!(state.get_state(&Timestamp::Bottom).is_err());
         assert!(state.get_current_state().is_err());
         assert!(state.get_current_state_mut().is_err());
         assert!(state.iter_states().is_err());
@@ -438,20 +438,20 @@ mod tests {
     fn test_watermark_callback_access() {
         let mut state: TimeVersionedState<usize, usize> =
             TimeVersionedState::new_with_history_size(1);
-        state.set_current_time(Timestamp::new(vec![1]));
+        state.set_current_time(Timestamp::Time(vec![1]));
         state.access_context = AccessContext::WatermarkCallback;
         assert!(state.set_history_size(2).is_err());
         assert_ne!(state.history_size(), 2);
         assert!(state.set_initial_state(99).is_err());
-        assert_eq!(None, state.state_history.get(&Timestamp::bottom()));
+        assert_eq!(None, state.state_history.get(&Timestamp::Bottom));
         assert!(state.append(3).is_err());
         assert_eq!(
             Ok(Some(&vec![])),
-            state.get_messages(&Timestamp::new(vec![1]))
+            state.get_messages(&Timestamp::Time(vec![1]))
         );
         assert_eq!(Ok(&vec![]), state.get_current_messages());
         assert_eq!(Ok(&mut usize::default()), state.get_current_state_mut());
-        assert_eq!(Ok(None), state.get_state(&Timestamp::bottom()));
+        assert_eq!(Ok(None), state.get_state(&Timestamp::Bottom));
         assert_eq!(Ok(&usize::default()), state.get_current_state());
         assert_eq!(Ok(&mut usize::default()), state.get_current_state_mut());
         assert!(state.iter_states().is_ok());
@@ -471,7 +471,7 @@ mod tests {
         // Add all messages first.
         for i in 1..=5 {
             // Called internally by ERDOS.
-            versioned_state.set_current_time(Timestamp::new(vec![i as u64]));
+            versioned_state.set_current_time(Timestamp::Time(vec![i as u64]));
             // Add message data from simulated callback.
             versioned_state.append(i).unwrap();
             versioned_state.append(i * 2).unwrap();
@@ -481,7 +481,7 @@ mod tests {
         versioned_state.set_access_context(AccessContext::WatermarkCallback);
         // Process messages and create states.
         for i in 1..=5 {
-            let current_time = Timestamp::new(vec![i as u64]);
+            let current_time = Timestamp::Time(vec![i as u64]);
             // Called internally by ERDOS.
             versioned_state.set_current_time(current_time.clone());
             // Check that state is initiated to default.
@@ -508,8 +508,8 @@ mod tests {
             for (j, ((t_msg, msgs), (t_state, state))) in msg_iter.zip(state_iter).enumerate() {
                 let k = i - j;
                 let (expected_t, expected_state, expected_msgs) = match k {
-                    0 => (Timestamp::bottom(), 100, Vec::new()),
-                    x => (Timestamp::new(vec![x as u64]), 6 * x, vec![k, k * 2, k * 3]),
+                    0 => (Timestamp::Bottom, 100, Vec::new()),
+                    x => (Timestamp::Time(vec![x as u64]), 6 * x, vec![k, k * 2, k * 3]),
                 };
                 assert_eq!(t_msg, t_state);
                 assert_eq!(t_msg, &expected_t);
@@ -527,7 +527,7 @@ mod tests {
             );
             // Try to get a future state.
             assert!(versioned_state
-                .get_state(&Timestamp::new(vec![(i + 1) as u64]))
+                .get_state(&Timestamp::Time(vec![(i + 1) as u64]))
                 .unwrap()
                 .is_none());
             // Called internally by ERDOS.
@@ -535,7 +535,7 @@ mod tests {
             if i % 2 == 0 {
                 versioned_state.close_time(&current_time).unwrap();
                 let expected_min_time =
-                    Timestamp::new(vec![(i + 1 - expected_num_states_accessible) as u64]);
+                    Timestamp::Time(vec![(i + 1 - expected_num_states_accessible) as u64]);
                 let gcd_messages: Vec<_> = versioned_state
                     .message_history
                     .range(..expected_min_time.clone())

--- a/src/dataflow/stream/mod.rs
+++ b/src/dataflow/stream/mod.rs
@@ -148,8 +148,8 @@ mod tests {
         let mut ws: WriteStream<usize> =
             WriteStream::from_endpoints(endpoints, StreamId::new_deterministic());
         thread::spawn(move || {
-            let msg1 = Message::TimestampedData(TimestampedData::new(Timestamp::new(vec![0]), 1));
-            let msg2 = Message::TimestampedData(TimestampedData::new(Timestamp::new(vec![0]), 2));
+            let msg1 = Message::TimestampedData(TimestampedData::new(Timestamp::Time(vec![0]), 1));
+            let msg2 = Message::TimestampedData(TimestampedData::new(Timestamp::Time(vec![0]), 2));
             ws.send(msg1).unwrap();
             ws.send(msg2).unwrap();
         });
@@ -183,15 +183,15 @@ mod tests {
         let mut ws: WriteStream<usize> =
             WriteStream::from_endpoints(endpoints, StreamId::new_deterministic());
         thread::spawn(move || {
-            let w1 = Message::Watermark(Timestamp::new(vec![1]));
-            let w2 = Message::Watermark(Timestamp::new(vec![2]));
+            let w1 = Message::Watermark(Timestamp::Time(vec![1]));
+            let w2 = Message::Watermark(Timestamp::Time(vec![2]));
             ws.send(w1).unwrap();
             ws.send(w2).unwrap();
         });
         let w1 = rt.block_on(rx.recv()).unwrap();
         match &*w1 {
             Message::Watermark(t) => {
-                assert_eq!(t.time[0], 1);
+                assert_eq!(*t, Timestamp::Time(vec![1 as u64]));
             }
             _ => {
                 panic!("Unexpected first watermark");
@@ -200,7 +200,7 @@ mod tests {
         let w2 = rt.block_on(rx.recv()).unwrap();
         match &*w2 {
             Message::Watermark(t) => {
-                assert_eq!(t.time[0], 2);
+                assert_eq!(*t, Timestamp::Time(vec![2 as u64]));
             }
             _ => {
                 panic!("Unexpected second watermark");
@@ -215,9 +215,9 @@ mod tests {
         let endpoints = vec![SendEndpoint::InterThread(tx)];
         let mut ws: WriteStream<usize> =
             WriteStream::from_endpoints(endpoints, StreamId::new_deterministic());
-        let w1 = Message::Watermark(Timestamp::new(vec![2]));
+        let w1 = Message::Watermark(Timestamp::Time(vec![2]));
         ws.send(w1).unwrap();
-        let w2 = Message::Watermark(Timestamp::new(vec![1]));
+        let w2 = Message::Watermark(Timestamp::Time(vec![1]));
         match ws.send(w2) {
             Err(_) => Ok(()),
             _ => Err(String::from(
@@ -234,9 +234,9 @@ mod tests {
         let endpoints = vec![SendEndpoint::InterThread(tx)];
         let mut ws: WriteStream<usize> =
             WriteStream::from_endpoints(endpoints, StreamId::new_deterministic());
-        let w1 = Message::Watermark(Timestamp::new(vec![2]));
+        let w1 = Message::Watermark(Timestamp::Time(vec![2]));
         ws.send(w1).unwrap();
-        let msg = Message::TimestampedData(TimestampedData::new(Timestamp::new(vec![1]), 2));
+        let msg = Message::TimestampedData(TimestampedData::new(Timestamp::Time(vec![1]), 2));
         match ws.send(msg) {
             Err(_) => Ok(()),
             _ => Err(String::from(

--- a/src/dataflow/stream/write_stream.rs
+++ b/src/dataflow/stream/write_stream.rs
@@ -88,7 +88,7 @@ impl<D: Data> WriteStream<D> {
             id,
             name: name.to_string(),
             pusher: Some(Pusher::new()),
-            low_watermark: Timestamp::new(vec![0]),
+            low_watermark: Timestamp::Time(vec![0]),
             stream_closed: false,
         }
     }

--- a/src/dataflow/time.rs
+++ b/src/dataflow/time.rs
@@ -1,0 +1,55 @@
+use std::{cmp::Ordering, fmt::Debug};
+
+use abomonation_derive::Abomonation;
+use serde::{Deserialize, Serialize};
+
+// Alias to [`IntTimestamp`] in case more timestamp variants are added.
+pub type Timestamp = IntTimestamp;
+
+/// Information about when an operator released a message.
+#[derive(Debug, Clone, Serialize, Deserialize, Abomonation, PartialEq, Eq, Hash)]
+pub enum IntTimestamp {
+    /// The timestamp used to close the streams. Signifies completion of all data.
+    Top,
+    /// The multi-dimension timestamp conveyed by this instance.
+    Time(Vec<u64>),
+    /// The lowest timestamp that any stream starts with.
+    Bottom,
+}
+
+impl IntTimestamp {
+    pub fn is_top(&self) -> bool {
+        *self == IntTimestamp::Top
+    }
+
+    pub fn is_bottom(&self) -> bool {
+        *self == IntTimestamp::Bottom
+    }
+}
+
+impl Ord for IntTimestamp {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            // Top and Bottom are always equal.
+            (IntTimestamp::Top, IntTimestamp::Top) => Ordering::Equal,
+            (IntTimestamp::Bottom, IntTimestamp::Bottom) => Ordering::Equal,
+
+            // Top is bigger than other timestamps.
+            (IntTimestamp::Top, _) => Ordering::Greater,
+            (_, IntTimestamp::Top) => Ordering::Less,
+
+            // Bottom is less than other timestamps.
+            (_, IntTimestamp::Bottom) => Ordering::Greater,
+            (IntTimestamp::Bottom, _) => Ordering::Less,
+
+            // Time should be compared lexicographically.
+            (IntTimestamp::Time(a), IntTimestamp::Time(b)) => a.cmp(b),
+        }
+    }
+}
+
+impl PartialOrd for IntTimestamp {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ impl Source<(), usize> for SourceOperator {
         let logger = erdos::get_terminal_logger();
         slog::info!(logger, "Running Source Operator");
         for t in 0..10 {
-            let timestamp = Timestamp::new(vec![t as u64]);
+            let timestamp = Timestamp::Time(vec![t as u64]);
             write_stream
                 .send(Message::new_message(timestamp.clone(), t))
                 .unwrap();

--- a/src/node/lattice.rs
+++ b/src/node/lattice.rs
@@ -134,8 +134,8 @@ impl PartialOrd for RunnableEvent {
 ///
 ///     // Add two events of timestamp 1 and 2 to the lattice with empty callbacks.
 ///     events = vec![
-///         OperatorEvent::new(Timestamp::new(vec![1]), true, 0, HashSet::new(), HashSet::new(), || ())
-///         OperatorEvent::new(Timestamp::new(vec![2]), true, 0, HashSet::new(), HashSet::new(), || ())
+///         OperatorEvent::new(Timestamp::Time(vec![1]), true, 0, HashSet::new(), HashSet::new(), || ())
+///         OperatorEvent::new(Timestamp::Time(vec![2]), true, 0, HashSet::new(), HashSet::new(), || ())
 ///     ];
 ///     lattice.add_events(events).await;
 ///
@@ -460,7 +460,7 @@ mod test {
     fn test_leaf_addition() {
         let lattice: ExecutionLattice = ExecutionLattice::new();
         let events = vec![OperatorEvent::new(
-            Timestamp::new(vec![1]),
+            Timestamp::Time(vec![1]),
             false,
             0,
             HashSet::new(),
@@ -472,7 +472,8 @@ mod test {
         // Ensure that the correct event is returned by the lattice.
         let (event, _event_id) = block_on(lattice.get_event()).unwrap();
         assert_eq!(
-            event.timestamp.time[0], 1,
+            event.timestamp,
+            Timestamp::Time(vec![1 as u64]),
             "The wrong event was returned by the lattice."
         );
 
@@ -487,7 +488,7 @@ mod test {
         let lattice: ExecutionLattice = ExecutionLattice::new();
         let events = vec![
             OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 false,
                 0,
                 HashSet::new(),
@@ -495,7 +496,7 @@ mod test {
                 || (),
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 false,
                 0,
                 HashSet::new(),
@@ -508,7 +509,8 @@ mod test {
         // Check the first event is returned correctly by the lattice.
         let (event, _event_id) = block_on(lattice.get_event()).unwrap();
         assert_eq!(
-            event.timestamp.time[0], 1,
+            event.timestamp,
+            Timestamp::Time(vec![1 as u64]),
             "The wrong event was returned by the lattice."
         );
 
@@ -516,7 +518,8 @@ mod test {
         // This shows that they can be executed concurrently.
         let (event_2, _event_id_2) = block_on(lattice.get_event()).unwrap();
         assert_eq!(
-            event_2.timestamp.time[0], 1,
+            event_2.timestamp,
+            Timestamp::Time(vec![1 as u64]),
             "The wrong event was returned by the lattice."
         );
     }
@@ -528,7 +531,7 @@ mod test {
         let lattice: ExecutionLattice = ExecutionLattice::new();
         let events = vec![
             OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 false,
                 0,
                 HashSet::new(),
@@ -536,7 +539,7 @@ mod test {
                 || (),
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 false,
                 0,
                 HashSet::new(),
@@ -544,7 +547,7 @@ mod test {
                 || (),
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 true,
                 0,
                 HashSet::new(),
@@ -556,14 +559,14 @@ mod test {
         // Check that the first event is returned correctly by the lattice.
         let (event, event_id) = block_on(lattice.get_event()).unwrap();
         assert!(
-            event.timestamp.time[0] == 1 && !event.is_watermark_callback,
+            event.timestamp == Timestamp::Time(vec![1 as u64]) && !event.is_watermark_callback,
             "The wrong event was returned by the lattice."
         );
 
         // Check that the first event is returned correctly by the lattice.
         let (event_2, event_id_2) = block_on(lattice.get_event()).unwrap();
         assert!(
-            event_2.timestamp.time[0] == 1 && !event.is_watermark_callback,
+            event_2.timestamp == Timestamp::Time(vec![1 as u64]) && !event.is_watermark_callback,
             "The wrong event was returned by the lattice."
         );
         let no_event = block_on(lattice.get_event());
@@ -580,7 +583,7 @@ mod test {
 
         let (event_3, _event_id_3) = block_on(lattice.get_event()).unwrap();
         assert!(
-            event_3.timestamp.time[0] == 1 && event_3.is_watermark_callback,
+            event_3.timestamp == Timestamp::Time(vec![1 as u64]) && event_3.is_watermark_callback,
             "The wrong event was returned by the lattice."
         );
     }
@@ -592,7 +595,7 @@ mod test {
         let lattice: ExecutionLattice = ExecutionLattice::new();
         let events = vec![
             OperatorEvent::new(
-                Timestamp::new(vec![3]),
+                Timestamp::Time(vec![3]),
                 true,
                 0,
                 HashSet::new(),
@@ -600,7 +603,7 @@ mod test {
                 || (),
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![2]),
+                Timestamp::Time(vec![2]),
                 true,
                 0,
                 HashSet::new(),
@@ -608,7 +611,7 @@ mod test {
                 || (),
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 true,
                 0,
                 HashSet::new(),
@@ -620,7 +623,8 @@ mod test {
 
         let (event, event_id) = block_on(lattice.get_event()).unwrap();
         assert_eq!(
-            event.timestamp.time[0], 1,
+            event.timestamp,
+            Timestamp::Time(vec![1 as u64]),
             "The wrong event was returned by the lattice."
         );
         assert!(
@@ -630,7 +634,8 @@ mod test {
         block_on(lattice.mark_as_completed(event_id));
         let (event_2, event_id_2) = block_on(lattice.get_event()).unwrap();
         assert_eq!(
-            event_2.timestamp.time[0], 2,
+            event_2.timestamp,
+            Timestamp::Time(vec![2 as u64]),
             "The wrong event was returned by the lattice."
         );
         assert!(
@@ -640,7 +645,8 @@ mod test {
         block_on(lattice.mark_as_completed(event_id_2));
         let (event_3, _event_id_3) = block_on(lattice.get_event()).unwrap();
         assert_eq!(
-            event_3.timestamp.time[0], 3,
+            event_3.timestamp,
+            Timestamp::Time(vec![3 as u64]),
             "The wrong event was returned by the lattice."
         );
         assert!(
@@ -655,7 +661,7 @@ mod test {
         let lattice: ExecutionLattice = ExecutionLattice::new();
         let events = vec![
             OperatorEvent::new(
-                Timestamp::new(vec![3]),
+                Timestamp::Time(vec![3]),
                 false,
                 0,
                 HashSet::new(),
@@ -663,7 +669,7 @@ mod test {
                 || (),
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![2]),
+                Timestamp::Time(vec![2]),
                 false,
                 0,
                 HashSet::new(),
@@ -671,7 +677,7 @@ mod test {
                 || (),
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 false,
                 0,
                 HashSet::new(),
@@ -683,17 +689,20 @@ mod test {
 
         let (event, _event_id) = block_on(lattice.get_event()).unwrap();
         assert_eq!(
-            event.timestamp.time[0], 1,
+            event.timestamp,
+            Timestamp::Time(vec![1 as u64]),
             "The wrong event was returned by the lattice."
         );
         let (event_2, _event_id_2) = block_on(lattice.get_event()).unwrap();
         assert_eq!(
-            event_2.timestamp.time[0], 2,
+            event_2.timestamp,
+            Timestamp::Time(vec![2 as u64]),
             "The wrong event was returned by the lattice."
         );
         let (event_3, _event_id_3) = block_on(lattice.get_event()).unwrap();
         assert_eq!(
-            event_3.timestamp.time[0], 3,
+            event_3.timestamp,
+            Timestamp::Time(vec![3 as u64]),
             "The wrong event was returned by the lattice."
         );
     }
@@ -704,7 +713,7 @@ mod test {
         let lattice: ExecutionLattice = ExecutionLattice::new();
         let events = vec![
             OperatorEvent::new(
-                Timestamp::new(vec![3]),
+                Timestamp::Time(vec![3]),
                 true,
                 0,
                 HashSet::new(),
@@ -712,7 +721,7 @@ mod test {
                 || (),
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![2]),
+                Timestamp::Time(vec![2]),
                 true,
                 0,
                 HashSet::new(),
@@ -720,7 +729,7 @@ mod test {
                 || (),
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 true,
                 0,
                 HashSet::new(),
@@ -728,7 +737,7 @@ mod test {
                 || (),
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 false,
                 0,
                 HashSet::new(),
@@ -736,7 +745,7 @@ mod test {
                 || (),
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![2]),
+                Timestamp::Time(vec![2]),
                 false,
                 0,
                 HashSet::new(),
@@ -744,7 +753,7 @@ mod test {
                 || (),
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![3]),
+                Timestamp::Time(vec![3]),
                 false,
                 0,
                 HashSet::new(),
@@ -755,17 +764,17 @@ mod test {
         block_on(lattice.add_events(events));
         let (event, event_id) = block_on(lattice.get_event()).unwrap();
         assert!(
-            event.timestamp.time[0] == 1 && !event.is_watermark_callback,
+            event.timestamp == Timestamp::Time(vec![1 as u64]) && !event.is_watermark_callback,
             "The wrong event was returned by the lattice."
         );
         let (event_2, event_id_2) = block_on(lattice.get_event()).unwrap();
         assert!(
-            event_2.timestamp.time[0] == 2 && !event_2.is_watermark_callback,
+            event_2.timestamp == Timestamp::Time(vec![2 as u64]) && !event_2.is_watermark_callback,
             "The wrong event was returned by the lattice."
         );
         let (event_3, event_id_3) = block_on(lattice.get_event()).unwrap();
         assert!(
-            event_3.timestamp.time[0] == 3 && !event_3.is_watermark_callback,
+            event_3.timestamp == Timestamp::Time(vec![3 as u64]) && !event_3.is_watermark_callback,
             "The wrong event was returned by the lattice."
         );
         assert!(
@@ -775,7 +784,7 @@ mod test {
         block_on(lattice.mark_as_completed(event_id));
         let (event_4, event_id_4) = block_on(lattice.get_event()).unwrap();
         assert!(
-            event_4.timestamp.time[0] == 1 && event_4.is_watermark_callback,
+            event_4.timestamp == Timestamp::Time(vec![1 as u64]) && event_4.is_watermark_callback,
             "The wrong event was returned by the lattice."
         );
         assert!(
@@ -790,7 +799,7 @@ mod test {
         block_on(lattice.mark_as_completed(event_id_2));
         let (event_5, event_id_5) = block_on(lattice.get_event()).unwrap();
         assert!(
-            event_5.timestamp.time[0] == 2 && event_5.is_watermark_callback,
+            event_5.timestamp == Timestamp::Time(vec![2 as u64]) && event_5.is_watermark_callback,
             "The wrong event was returned by the lattice."
         );
         block_on(lattice.mark_as_completed(event_id_3));
@@ -801,7 +810,7 @@ mod test {
         block_on(lattice.mark_as_completed(event_id_5));
         let (event_6, event_id_6) = block_on(lattice.get_event()).unwrap();
         assert!(
-            event_6.timestamp.time[0] == 3 && event_6.is_watermark_callback,
+            event_6.timestamp == Timestamp::Time(vec![3 as u64]) && event_6.is_watermark_callback,
             "The wrong event was returned by the lattice."
         );
         block_on(lattice.mark_as_completed(event_id_6));
@@ -820,7 +829,7 @@ mod test {
         // Add 2 operators that can run concurrently.
         let initial_events = vec![
             OperatorEvent::new(
-                Timestamp::new(vec![0]),
+                Timestamp::Time(vec![0]),
                 false,
                 0,
                 HashSet::new(),
@@ -828,7 +837,7 @@ mod test {
                 || {},
             ),
             OperatorEvent::new(
-                Timestamp::new(vec![0]),
+                Timestamp::Time(vec![0]),
                 false,
                 0,
                 HashSet::new(),
@@ -840,7 +849,7 @@ mod test {
 
         // Generate events A and B where B precedes A.
         let event_a = OperatorEvent::new(
-            Timestamp::new(vec![0]),
+            Timestamp::Time(vec![0]),
             true,
             20,
             HashSet::new(),
@@ -848,7 +857,7 @@ mod test {
             || {},
         );
         let event_b = OperatorEvent::new(
-            Timestamp::new(vec![0]),
+            Timestamp::Time(vec![0]),
             true,
             0,
             HashSet::new(),

--- a/src/node/operator_event.rs
+++ b/src/node/operator_event.rs
@@ -179,7 +179,7 @@ mod test {
     fn test_watermark_event_orderings() {
         {
             let watermark_event_a: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 true,
                 0,
                 HashSet::new(),
@@ -187,7 +187,7 @@ mod test {
                 || (),
             );
             let watermark_event_b: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![2]),
+                Timestamp::Time(vec![2]),
                 true,
                 0,
                 HashSet::new(),
@@ -202,7 +202,7 @@ mod test {
         // Test that priorities should break ties only for otherwise equal watermark callbacks.
         {
             let watermark_event_a: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 true,
                 -1,
                 HashSet::new(),
@@ -210,7 +210,7 @@ mod test {
                 || (),
             );
             let watermark_event_b: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 true,
                 1,
                 HashSet::new(),
@@ -223,7 +223,7 @@ mod test {
             );
 
             let watermark_event_c: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![0]),
+                Timestamp::Time(vec![0]),
                 true,
                 0,
                 HashSet::new(),
@@ -240,7 +240,7 @@ mod test {
             );
 
             let watermark_event_d: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![2]),
+                Timestamp::Time(vec![2]),
                 true,
                 0,
                 HashSet::new(),
@@ -258,7 +258,7 @@ mod test {
 
             // Priority should not affect message events
             let message_event_a: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 false,
                 0,
                 HashSet::new(),
@@ -275,7 +275,7 @@ mod test {
             );
 
             let message_event_b: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![2]),
+                Timestamp::Time(vec![2]),
                 false,
                 0,
                 HashSet::new(),
@@ -298,7 +298,7 @@ mod test {
     #[test]
     fn test_message_event_orderings() {
         let message_event_a: OperatorEvent = OperatorEvent::new(
-            Timestamp::new(vec![1]),
+            Timestamp::Time(vec![1]),
             false,
             0,
             HashSet::new(),
@@ -306,7 +306,7 @@ mod test {
             || (),
         );
         let message_event_b: OperatorEvent = OperatorEvent::new(
-            Timestamp::new(vec![2]),
+            Timestamp::Time(vec![2]),
             false,
             0,
             HashSet::new(),
@@ -325,7 +325,7 @@ mod test {
         // is dependent on the message.
         {
             let message_event_a: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 false,
                 0,
                 HashSet::new(),
@@ -333,7 +333,7 @@ mod test {
                 || (),
             );
             let watermark_event_b: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![2]),
+                Timestamp::Time(vec![2]),
                 true,
                 0,
                 HashSet::new(),
@@ -350,7 +350,7 @@ mod test {
         // watermark.
         {
             let message_event_a: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 false,
                 0,
                 HashSet::new(),
@@ -358,7 +358,7 @@ mod test {
                 || (),
             );
             let watermark_event_b: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 true,
                 0,
                 HashSet::new(),
@@ -375,7 +375,7 @@ mod test {
         // with a watermark of lesser timestamp.
         {
             let message_event_a: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![2]),
+                Timestamp::Time(vec![2]),
                 false,
                 0,
                 HashSet::new(),
@@ -383,7 +383,7 @@ mod test {
                 || (),
             );
             let watermark_event_b: OperatorEvent = OperatorEvent::new(
-                Timestamp::new(vec![1]),
+                Timestamp::Time(vec![1]),
                 true,
                 0,
                 HashSet::new(),
@@ -402,7 +402,7 @@ mod test {
         let mut write_ids = HashSet::new();
         write_ids.insert(Uuid::new_deterministic());
         let event_a = OperatorEvent::new(
-            Timestamp::new(vec![0]),
+            Timestamp::Time(vec![0]),
             true,
             0,
             HashSet::new(),
@@ -411,7 +411,7 @@ mod test {
         );
 
         let event_b = OperatorEvent::new(
-            Timestamp::new(vec![0]),
+            Timestamp::Time(vec![0]),
             true,
             1,
             HashSet::new(),
@@ -423,7 +423,7 @@ mod test {
         let mut read_ids = HashSet::new();
         read_ids.insert(Uuid::new_deterministic());
         let event_c = OperatorEvent::new(
-            Timestamp::new(vec![0]),
+            Timestamp::Time(vec![0]),
             true,
             0,
             read_ids,
@@ -437,7 +437,7 @@ mod test {
 
         let read_ids = write_ids.clone();
         let event_d = OperatorEvent::new(
-            Timestamp::new(vec![0]),
+            Timestamp::Time(vec![0]),
             true,
             0,
             read_ids,

--- a/src/node/operator_executor.rs
+++ b/src/node/operator_executor.rs
@@ -189,8 +189,8 @@ impl OperatorExecutorHelper {
         T: Data + for<'a> Deserialize<'a>,
         U: Data + for<'a> Deserialize<'a>,
     {
-        let mut left_watermark = Timestamp::bottom();
-        let mut right_watermark = Timestamp::bottom();
+        let mut left_watermark = Timestamp::Bottom;
+        let mut right_watermark = Timestamp::Bottom;
         let mut min_watermark = cmp::min(&left_watermark, &right_watermark).clone();
         loop {
             let events = tokio::select! {
@@ -317,7 +317,7 @@ where
         // Close the stream.
         if !self.write_stream.is_closed() {
             self.write_stream
-                .send(Message::new_watermark(Timestamp::top()))
+                .send(Message::new_watermark(Timestamp::Top))
                 .unwrap();
         }
     }
@@ -531,7 +531,7 @@ where
         // TODO: check that the top watermark hasn't already been sent.
         if !self.write_stream.is_closed() {
             self.write_stream
-                .send(Message::new_watermark(Timestamp::top()))
+                .send(Message::new_watermark(Timestamp::Top))
                 .unwrap();
         }
     }
@@ -709,7 +709,7 @@ where
         // TODO: check that the top watermark hasn't already been sent.
         if !self.write_stream.is_closed() {
             self.write_stream
-                .send(Message::new_watermark(Timestamp::top()))
+                .send(Message::new_watermark(Timestamp::Top))
                 .unwrap();
         }
     }
@@ -920,12 +920,12 @@ where
         // TODO: check that the top watermark hasn't already been sent.
         if !self.left_write_stream.is_closed() {
             self.left_write_stream
-                .send(Message::new_watermark(Timestamp::top()))
+                .send(Message::new_watermark(Timestamp::Top))
                 .unwrap();
         }
         if !self.right_write_stream.is_closed() {
             self.right_write_stream
-                .send(Message::new_watermark(Timestamp::top()))
+                .send(Message::new_watermark(Timestamp::Top))
                 .unwrap();
         }
     }

--- a/tests/watermark_test.rs
+++ b/tests/watermark_test.rs
@@ -3,7 +3,7 @@ use erdos::{
         message::*,
         operators::MapOperator,
         stream::{ExtractStream, WriteStreamT},
-        Operator, OperatorConfig, ReadStream, WriteStream,
+        Operator, OperatorConfig, ReadStream, Timestamp, WriteStream,
     },
     node::Node,
     *,


### PR DESCRIPTION
- Changes the `IntTimestamp` structure to `enum` with `Top`, `Bottom` and `Time(vec<u64>)`.