### PR TITLE
Run IngestStreams and ExtractStreams on Node 0

### DIFF
--- a/src/dataflow/graph/graph.rs
+++ b/src/dataflow/graph/graph.rs
@@ -123,19 +123,18 @@ impl Graph {
         for<'a> D: Data + Deserialize<'a>,
     {
         let stream_id = extract_stream.id();
-        let node_id = extract_stream.node_id();
         // Add stream to driver
         let driver = self
             .drivers
-            .entry(extract_stream.node_id())
-            .or_insert_with(|| DriverMetadata::new(node_id));
+            .entry(0)
+            .or_insert_with(|| DriverMetadata::new(0));
         driver.add_extract_stream(stream_id, setup_hook);
         // Add channel to stream
         if let Some(stream_metadata) = self.streams.get_mut(&stream_id) {
             let channel = Channel::Unscheduled(ChannelMetadata::new(
                 stream_id,
                 stream_metadata.source(),
-                Vertex::Driver(node_id),
+                Vertex::Driver(0),
             ));
             stream_metadata.add_channel(channel);
         } else {

--- a/src/dataflow/graph/graph.rs
+++ b/src/dataflow/graph/graph.rs
@@ -103,15 +103,14 @@ impl Graph {
         for<'a> D: Data + Deserialize<'a>,
     {
         let stream_id = ingest_stream.id();
-        let node_id = ingest_stream.node_id();
         // Add stream to driver
         let driver = self
             .drivers
-            .entry(ingest_stream.node_id())
-            .or_insert_with(|| DriverMetadata::new(node_id));
+            .entry(0)
+            .or_insert_with(|| DriverMetadata::new(0));
         driver.add_ingest_stream(stream_id, setup_hook);
         // Add stream to graph
-        let mut stream_metadata = StreamMetadata::new::<D>(stream_id, Vertex::Driver(node_id));
+        let mut stream_metadata = StreamMetadata::new::<D>(stream_id, Vertex::Driver(0));
         self.add_channels(&mut stream_metadata);
         self.streams.insert(stream_id, stream_metadata);
     }

--- a/src/dataflow/stream/extract_stream.rs
+++ b/src/dataflow/stream/extract_stream.rs
@@ -9,7 +9,6 @@ use serde::Deserialize;
 
 use crate::{
     dataflow::{graph::default_graph, Data, Message},
-    node::NodeId,
     scheduler::channel_manager::ChannelManager,
 };
 
@@ -73,8 +72,6 @@ where
     id: StreamId,
     /// The name of the stream (String representation of the ID, if no name provided)
     name: String,
-    /// The ID of the Node where the stream runs.
-    node_id: NodeId,
     /// The ReadStream associated with the ExtractStream.
     read_stream_option: Option<ReadStream<D>>,
     // Used to circumvent requiring Send to transfer ReadStream across threads
@@ -88,41 +85,37 @@ where
     /// Returns a new instance of the [`ExtractStream`]
     ///
     /// # Arguments
-    /// * `node_id`: The ID of the Node where the driver is running (typically, 0).
     /// * `read_stream`: The [`ReadStream`] returned by an
     /// [`Operator`](crate::dataflow::operator::Operator) to extract the messages from.
-    pub fn new(node_id: NodeId, read_stream: &Stream<D>) -> Self {
+    pub fn new(read_stream: &Stream<D>) -> Self {
         slog::debug!(
             crate::TERMINAL_LOGGER,
-            "Initializing an ExtractStream on the node {} with the ReadStream {} (ID: {})",
-            node_id,
+            "Initializing an ExtractStream with the ReadStream {} (ID: {})",
             read_stream.name(),
             read_stream.id(),
         );
-        ExtractStream::new_internal(node_id, read_stream, None)
+        ExtractStream::new_internal(read_stream, None)
     }
 
     /// Returns a new instance of the [`ExtractStream`]
     ///
     /// # Arguments
-    /// * `node_id`: The ID of the Node where the driver is running (typically, 0).
     /// * `read_stream`: The [`ReadStream`] returned by an
     /// [`Operator`](crate::dataflow::operator::Operator) to extract the messages from.
     /// * `name`: The name to be given to the stream.
-    pub fn new_with_name(node_id: NodeId, read_stream: &Stream<D>, name: &str) -> Self {
+    pub fn new_with_name(read_stream: &Stream<D>, name: &str) -> Self {
         slog::debug!(
             crate::TERMINAL_LOGGER,
-            "Initializing an ExtractStream {} on the node {} with the ReadStream {} (ID: {})",
+            "Initializing an ExtractStream {} with the ReadStream {} (ID: {})",
             name,
-            node_id,
             read_stream.name(),
             read_stream.id(),
         );
-        ExtractStream::new_internal(node_id, read_stream, Some(name.to_string()))
+        ExtractStream::new_internal(read_stream, Some(name.to_string()))
     }
 
     /// Creates the appropriate channels for the [`ExtractStream`] and adds it to the dataflow.
-    fn new_internal(node_id: NodeId, read_stream: &Stream<D>, name: Option<String>) -> Self {
+    fn new_internal(read_stream: &Stream<D>, name: Option<String>) -> Self {
         // Generate an ID, and use it as the name if no name was provided.
         let id = read_stream.id();
         let stream_name = match name {
@@ -134,7 +127,6 @@ where
         let extract_stream = Self {
             id,
             name: stream_name,
-            node_id,
             read_stream_option: None,
             channel_manager_option: Arc::new(Mutex::new(None)),
         };
@@ -150,11 +142,6 @@ where
 
         default_graph::add_extract_stream(&extract_stream, setup_hook);
         extract_stream
-    }
-
-    /// Get the ID of the node where the stream originated from. (Typically 0 for driver nodes.)
-    pub fn node_id(&self) -> NodeId {
-        self.node_id
     }
 
     /// Returns `true` if a top watermark message was sent or the [`ExtractStream`] failed to set

--- a/src/dataflow/stream/extract_stream.rs
+++ b/src/dataflow/stream/extract_stream.rs
@@ -40,8 +40,8 @@ use super::{
 //  #     .name("MapOperator")
 /// #     .arg(|data: &u32| -> u64 { (data * 2) as u64 });
 /// #
-/// // Create an IngestStream which runs on node 0.
-/// let mut ingest_stream = IngestStream::new(0); // or IngestStream::new_with_name(0, "driver")
+/// // Create an IngestStream.
+/// let mut ingest_stream = IngestStream::new(); // or IngestStream::new_with_name("driver")
 ///
 /// // Create an ExtractStream from the ReadStream of the MapOperator.
 /// let output_read_stream = connect_1_write!(MapOperator<u32, u64>, map_config, ingest_stream);

--- a/src/dataflow/stream/ingest_stream.rs
+++ b/src/dataflow/stream/ingest_stream.rs
@@ -34,7 +34,7 @@ use super::{errors::WriteStreamError, StreamId, StreamT, WriteStream, WriteStrea
 /// #     .arg(|data: &u32| -> u64 { (data * 2) as u64 });
 /// #
 /// // Create an IngestStream. The driver is assigned an ID of 0.
-/// let mut ingest_stream = IngestStream::new(0); // or IngestStream::new_with_name(0, "driver")
+/// let mut ingest_stream = IngestStream::new(); // or IngestStream::new_with_name("driver")
 /// let output_read_stream = connect_1_write!(MapOperator<u32, u64>, map_config, ingest_stream);
 ///
 /// // Send data on the IngestStream.

--- a/src/dataflow/stream/ingest_stream.rs
+++ b/src/dataflow/stream/ingest_stream.rs
@@ -66,11 +66,7 @@ where
     // constructors of different types of streams.
     /// Returns a new instance of the [`IngestStream`].
     pub fn new() -> Self {
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "Initializing an IngestStream on the node {}",
-            0,
-        );
+        slog::debug!(crate::TERMINAL_LOGGER, "Initializing an IngestStream");
         let id = StreamId::new_deterministic();
         IngestStream::new_internal(id, id.to_string())
     }

--- a/src/dataflow/stream/ingest_stream.rs
+++ b/src/dataflow/stream/ingest_stream.rs
@@ -62,8 +62,6 @@ impl<D> IngestStream<D>
 where
     for<'a> D: Data + Deserialize<'a>,
 {
-    // TODO (Sukrit) :: Why does this constructor require the NodeID? Inconsistency between
-    // constructors of different types of streams.
     /// Returns a new instance of the [`IngestStream`].
     pub fn new() -> Self {
         slog::debug!(crate::TERMINAL_LOGGER, "Initializing an IngestStream");


### PR DESCRIPTION
Modifies IngestStreams and ExtractStreams to run on node 0, which is a first step towards providing a single driver for ERDOS programs.

As a temporary solution, the dataflow graph places ingest and extract streams on node 0. I'll improve this abstraction in a follow-up PR in which I'm planning to refactor the dataflow graph.