### PR TITLE
Implement Timestamp deadlines for TwoInMessageProcessor

### DIFF
--- a/src/dataflow/operator.rs
+++ b/src/dataflow/operator.rs
@@ -43,6 +43,8 @@ where
 /// ordered by the timestamp order.
 #[allow(unused_variables)]
 pub trait ParallelSink<S: AppendableStateT<U>, T: Data, U>: Send + Sync {
+    fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
+
     fn run(&mut self, read_stream: &mut ReadStream<T>) {}
 
     fn destroy(&mut self) {}
@@ -66,6 +68,8 @@ pub trait ParallelSink<S: AppendableStateT<U>, T: Data, U>: Send + Sync {
 /// allowed to mutate state in both the message and the watermark callbacks.
 #[allow(unused_variables)]
 pub trait Sink<S: StateT, T: Data>: Send + Sync {
+    fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
+
     fn run(&mut self, read_stream: &mut ReadStream<T>) {}
 
     fn destroy(&mut self) {}
@@ -98,6 +102,8 @@ where
     T: Data + for<'a> Deserialize<'a>,
     U: Data + for<'a> Deserialize<'a>,
 {
+    fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
+
     fn run(&mut self, read_stream: &mut ReadStream<T>, write_stream: &mut WriteStream<U>) {}
 
     fn destroy(&mut self) {}
@@ -161,6 +167,8 @@ where
     U: Data + for<'a> Deserialize<'a>,
     V: Data + for<'a> Deserialize<'a>,
 {
+    fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
+
     fn run(
         &mut self,
         left_read_stream: &mut ReadStream<T>,
@@ -198,6 +206,8 @@ where
     U: Data + for<'a> Deserialize<'a>,
     V: Data + for<'a> Deserialize<'a>,
 {
+    fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
+
     fn run(
         &mut self,
         left_read_stream: &mut ReadStream<T>,
@@ -239,6 +249,8 @@ where
     U: Data + for<'a> Deserialize<'a>,
     V: Data + for<'a> Deserialize<'a>,
 {
+    fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
+
     fn run(
         &mut self,
         read_stream: &mut ReadStream<T>,
@@ -274,6 +286,8 @@ where
     U: Data + for<'a> Deserialize<'a>,
     V: Data + for<'a> Deserialize<'a>,
 {
+    fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
+
     fn run(
         &mut self,
         read_stream: &mut ReadStream<T>,

--- a/src/node/operator_executors/mod.rs
+++ b/src/node/operator_executors/mod.rs
@@ -79,9 +79,7 @@ where
 {
     /// Executes the `setup` method inside the operator.
     // TODO (Sukrit): Stopgap to prevent compilation errors. Remove once deadline API is decided.
-    fn execute_setup(&mut self, _read_stream: &mut ReadStream<T>) -> SetupContext<S> {
-        SetupContext::new(Vec::new(), Vec::new())
-    }
+    fn execute_setup(&mut self, read_stream: &mut ReadStream<T>) -> SetupContext<S>;
 
     /// Executes the `run` method inside the operator.
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>);
@@ -199,7 +197,6 @@ where
         let mut read_stream: ReadStream<T> = self.read_stream.take().unwrap();
         let mut setup_context =
             tokio::task::block_in_place(|| self.processor.execute_setup(&mut read_stream));
-        // TODO (Sukrit): Implement deadlines and `setup` method for the operators.
 
         // Execute the `run` method.
         slog::debug!(

--- a/src/node/operator_executors/mod.rs
+++ b/src/node/operator_executors/mod.rs
@@ -78,7 +78,6 @@ where
     T: Data + for<'a> Deserialize<'a>,
 {
     /// Executes the `setup` method inside the operator.
-    // TODO (Sukrit): Stopgap to prevent compilation errors. Remove once deadline API is decided.
     fn execute_setup(&mut self, read_stream: &mut ReadStream<T>) -> SetupContext<S>;
 
     /// Executes the `run` method inside the operator.
@@ -97,7 +96,7 @@ where
     fn arm_deadlines(
         &self,
         setup_context: &mut SetupContext<S>,
-        read_stream_id: StreamId,
+        read_stream_ids: Vec<StreamId>,
         condition_context: &ConditionContext,
         timestamp: Timestamp,
     ) -> Vec<DeadlineEvent>;
@@ -123,16 +122,23 @@ where
 /// streams. This trait is used by the executors to invoke the callback corresponding to the event
 /// occurring in the system. (T is the datatype of the first stream, and U is the datatype of the
 /// second stream)
-pub trait TwoInMessageProcessorT<T, U>: Send + Sync
+pub trait TwoInMessageProcessorT<S, T, U>: Send + Sync
 where
     T: Data + for<'a> Deserialize<'a>,
     U: Data + for<'a> Deserialize<'a>,
 {
+    /// Executes the `setup` method inside the operator.
+    fn execute_setup(
+        &mut self,
+        left_read_stream: &mut ReadStream<T>,
+        right_read_stream: &mut ReadStream<U>,
+    ) -> SetupContext<S>;
+
     /// Executes the `run` method inside the operator.
     fn execute_run(
         &mut self,
-        _left_read_stream: &mut ReadStream<T>,
-        _right_read_stream: &mut ReadStream<U>,
+        left_read_stream: &mut ReadStream<T>,
+        right_read_stream: &mut ReadStream<U>,
     );
 
     /// Executes the `destroy` method inside the operator.
@@ -147,8 +153,29 @@ where
     /// Generates an OperatorEvent for a watermark callback.
     fn watermark_cb_event(&mut self, timestamp: &Timestamp) -> OperatorEvent;
 
+    /// Generates a DeadlineEvent for arming a deadline.
+    fn arm_deadlines(
+        &self,
+        setup_context: &mut SetupContext<S>,
+        read_stream_ids: Vec<StreamId>,
+        condition_context: &ConditionContext,
+        timestamp: Timestamp,
+    ) -> Vec<DeadlineEvent>;
+
+    /// Disarms a deadline by returning true if the given deadline should be disarmed, or false
+    /// otherwise.
+    fn disarm_deadline(&self, deadline_event: &DeadlineEvent) -> bool;
+
     /// Cleans up the write streams and any other data owned by the executor.
     fn cleanup(&mut self) {}
+
+    /// Invokes the handler for the given DeadlineId in case of a missed deadline.
+    fn invoke_handler(
+        &self,
+        setup_context: &mut SetupContext<S>,
+        deadline_id: DeadlineId,
+        timestamp: Timestamp,
+    );
 }
 
 /* ***********************************************************************************************
@@ -280,26 +307,26 @@ where
 }
 
 /// Executor that executes operators that process messages on two read streams of type T and U.
-pub struct TwoInExecutor<T, U>
+pub struct TwoInExecutor<S, T, U>
 where
     T: Data + for<'a> Deserialize<'a>,
     U: Data + for<'a> Deserialize<'a>,
 {
     config: OperatorConfig,
-    processor: Box<dyn TwoInMessageProcessorT<T, U>>,
+    processor: Box<dyn TwoInMessageProcessorT<S, T, U>>,
     helper: OperatorExecutorHelper,
     left_read_stream: Option<ReadStream<T>>,
     right_read_stream: Option<ReadStream<U>>,
 }
 
-impl<T, U> TwoInExecutor<T, U>
+impl<S, T, U> TwoInExecutor<S, T, U>
 where
     T: Data + for<'a> Deserialize<'a>,
     U: Data + for<'a> Deserialize<'a>,
 {
     pub fn new(
         config: OperatorConfig,
-        processor: Box<dyn TwoInMessageProcessorT<T, U>>,
+        processor: Box<dyn TwoInMessageProcessorT<S, T, U>>,
         left_read_stream: ReadStream<T>,
         right_read_stream: ReadStream<U>,
     ) -> Self {
@@ -325,7 +352,10 @@ where
         // Run the `setup` method.
         let mut left_read_stream: ReadStream<T> = self.left_read_stream.take().unwrap();
         let mut right_read_stream: ReadStream<U> = self.right_read_stream.take().unwrap();
-        // TODO (Sukrit): Implement deadlines and the `setup` method for the operators.
+        let mut setup_context = tokio::task::block_in_place(|| {
+            self.processor
+                .execute_setup(&mut left_read_stream, &mut right_read_stream)
+        });
 
         // Execute the `run` method.
         slog::debug!(
@@ -345,6 +375,7 @@ where
             right_read_stream,
             &mut (*self.processor),
             &channel_to_event_runners,
+            &mut setup_context,
         );
 
         // Shutdown.
@@ -383,7 +414,7 @@ where
     }
 }
 
-impl<T, U> OperatorExecutorT for TwoInExecutor<T, U>
+impl<S, T, U> OperatorExecutorT for TwoInExecutor<S, T, U>
 where
     T: Data + for<'a> Deserialize<'a>,
     U: Data + for<'a> Deserialize<'a>,
@@ -474,7 +505,7 @@ impl OperatorExecutorHelper {
     ) where
         T: Data + for<'a> Deserialize<'a>,
     {
-        // Create a ConditionContext for the stream.
+        // Create a ConditionContext for the deadline evaluation.
         let mut condition_context = ConditionContext::new();
         loop {
             tokio::select! {
@@ -565,7 +596,7 @@ impl OperatorExecutorHelper {
                     // Arm deadlines and install them into the executor.
                     let deadline_events = message_processor.arm_deadlines(
                         setup_context,
-                        read_stream.id(),
+                        vec![read_stream.id()],
                         &condition_context,
                         msg.timestamp().clone()
                     );
@@ -581,33 +612,103 @@ impl OperatorExecutorHelper {
         }
     }
 
-    pub(crate) async fn process_two_streams<T, U>(
-        &self,
+    pub(crate) async fn process_two_streams<S, T, U>(
+        &mut self,
         mut left_read_stream: ReadStream<T>,
         mut right_read_stream: ReadStream<U>,
-        message_processor: &mut dyn TwoInMessageProcessorT<T, U>,
+        message_processor: &mut dyn TwoInMessageProcessorT<S, T, U>,
         notifier_tx: &tokio::sync::broadcast::Sender<EventNotification>,
+        setup_context: &mut SetupContext<S>,
     ) where
         T: Data + for<'a> Deserialize<'a>,
         U: Data + for<'a> Deserialize<'a>,
     {
+        // Create a ConditionContext for the deadline evaluation.
+        let mut condition_context = ConditionContext::new();
+
+        // Manage minimum watermarks across the two streams.
         let mut left_watermark = Timestamp::Bottom;
         let mut right_watermark = Timestamp::Bottom;
         let mut min_watermark = cmp::min(&left_watermark, &right_watermark).clone();
         loop {
-            let events = tokio::select! {
+            tokio::select! {
+                // DelayQueue returns `None` if the queue is empty. This means that if there are no
+                // deadlines installed, the queue will always be ready and return `None` thus
+                // wasting resources. We can potentially fix this by inserting a Deadline for the
+                // future and maintaining it so that the queue is not empty.
+                Some(deadline_event) = self.deadline_queue_rx.receive() => {
+                    // Missed a deadline. Check if the end condition is satisfied and invoke the
+                    // handler if not so.
+                    // TODO (Sukrit): The handler is invoked in the thread of the OperatorExecutor.
+                    // This may be an issue for long-running handlers since they block the
+                    // processing of future messages. We can spawn these as a separate task.
+                    if !message_processor.disarm_deadline(&deadline_event) {
+                        // Invoke the handler.
+                        message_processor.invoke_handler(
+                            setup_context,
+                            deadline_event.id,
+                            deadline_event.timestamp.clone(),
+                        );
+                    }
+
+                    // Remove the key from the hashmap and clear the state in the ConditionContext.
+                    match self.deadline_to_key_map.remove(&deadline_event.id) {
+                        None => {
+                            slog::warn!(
+                                crate::TERMINAL_LOGGER,
+                                "Could not find a key corresponding to the Deadline ID: {}",
+                                deadline_event.id,
+                            );
+                        }
+                        Some(key) => {
+                            slog::debug!(
+                                crate::TERMINAL_LOGGER,
+                                "Finished invoking the deadline handler for the DelayHandle: {:?} \
+                                corresponding to the Deadline ID: {}",
+                                key,
+                                deadline_event.id,
+                            );
+                        }
+                    }
+
+                    // Clean the state.
+                    for stream_id in deadline_event.read_stream_ids {
+                        condition_context.clear_state(stream_id, deadline_event.timestamp.clone());
+                    }
+                },
+                // If there is a message on the left ReadStream, then increment the message counts
+                // for the given timestamp, evaluate the start and end condition and install /
+                // disarm deadlines accordingly.
+                // TODO(Sukrit): The start and end conditions are evaluated in the thread of the
+                // OperatorExecutor, and can be moved to a separate task if they become a
+                // bottleneck.
                 Ok(left_msg) = left_read_stream.async_read() => {
-                    match left_msg.data() {
+                    let events = match left_msg.data() {
                         // Data message
                         Some(_) => {
-                            // Stateless callback.
+                            // Increment message count.
+                            condition_context.increment_msg_count(
+                                left_read_stream.id(),
+                                left_msg.timestamp().clone(),
+                            );
+
+                            // Create an OperatorEvent for the callback.
                             let msg_ref = Arc::clone(&left_msg);
                             let data_event = message_processor.left_message_cb_event(msg_ref);
 
                             vec![data_event]
-                        }
+                        },
+
                         // Watermark
                         None => {
+                            // Update watermark status.
+                            condition_context.notify_watermark_arrival(
+                                left_read_stream.id(),
+                                left_msg.timestamp().clone(),
+                            );
+
+                            // Create an OperatorEvent if this message increments the minimum
+                            // watermark across the two streams.
                             left_watermark = left_msg.timestamp().clone();
                             let advance_watermark = cmp::min(
                                 &left_watermark,
@@ -621,20 +722,56 @@ impl OperatorExecutorHelper {
                                 Vec::new()
                             }
                         }
-                    }
-                }
+                    };
+
+                    // Arm deadlines and install them into the executor.
+                    let deadline_events = message_processor.arm_deadlines(
+                        setup_context,
+                        vec![left_read_stream.id(), right_read_stream.id()],
+                        &condition_context,
+                        left_msg.timestamp().clone()
+                    );
+                    self.manage_deadlines(deadline_events);
+
+                    // Add the events to the lattice.
+                    self.lattice.add_events(events).await;
+                    notifier_tx
+                        .send(EventNotification::AddedEvents(self.operator_id))
+                        .unwrap();
+                },
+                // If there is a message on the right ReadStream, then increment the message counts
+                // for the given timestamp, evaluate the start and end condition and install /
+                // disarm deadlines accordingly.
+                // TODO(Sukrit): The start and end conditions are evaluated in the thread of the
+                // OperatorExecutor, and can be moved to a separate task if they become a
+                // bottleneck.
                 Ok(right_msg) = right_read_stream.async_read() => {
-                    match right_msg.data() {
+                    let events = match right_msg.data() {
                         // Data message
                         Some(_) => {
-                            // Stateless callback.
+                            // Increment message counts.
+                            condition_context.increment_msg_count(
+                                right_read_stream.id(),
+                                right_msg.timestamp().clone(),
+                            );
+
+                            // Create an OperatorEvent for the callback.
                             let msg_ref = Arc::clone(&right_msg);
                             let data_event = message_processor.right_message_cb_event(msg_ref);
 
                             vec![data_event]
-                        }
+                        },
+
                         // Watermark
                         None => {
+                            // Update watermark status.
+                            condition_context.notify_watermark_arrival(
+                                right_read_stream.id(),
+                                right_msg.timestamp().clone(),
+                            );
+
+                            // Create an OperatorEvent if this message increments the minimum
+                            // watermark across the two streams.
                             right_watermark = right_msg.timestamp().clone();
                             let advance_watermark = cmp::min(
                                 &left_watermark,
@@ -648,14 +785,25 @@ impl OperatorExecutorHelper {
                                 Vec::new()
                             }
                         }
-                    }
+                    };
+
+                    // Arm deadlines and install them into the executor.
+                    let deadline_events = message_processor.arm_deadlines(
+                        setup_context,
+                        vec![left_read_stream.id(), right_read_stream.id()],
+                        &condition_context,
+                        right_msg.timestamp().clone()
+                    );
+                    self.manage_deadlines(deadline_events);
+
+                    // Add the events to the lattice.
+                    self.lattice.add_events(events).await;
+                    notifier_tx
+                        .send(EventNotification::AddedEvents(self.operator_id))
+                        .unwrap();
                 }
                 else => break,
             };
-            self.lattice.add_events(events).await;
-            notifier_tx
-                .send(EventNotification::AddedEvents(self.operator_id))
-                .unwrap();
         }
     }
 }

--- a/src/node/operator_executors/one_in_one_out_executor.rs
+++ b/src/node/operator_executors/one_in_one_out_executor.rs
@@ -196,7 +196,7 @@ where
     fn arm_deadlines(
         &self,
         setup_context: &mut SetupContext<S>,
-        read_stream_id: StreamId,
+        read_stream_ids: Vec<StreamId>,
         condition_context: &ConditionContext,
         timestamp: Timestamp,
     ) -> Vec<DeadlineEvent> {
@@ -205,12 +205,8 @@ where
         for deadline in setup_context.get_deadlines() {
             if deadline
                 .get_constrained_read_stream_ids()
-                .contains(&read_stream_id)
-                && deadline.invoke_start_condition(
-                    vec![read_stream_id],
-                    condition_context,
-                    &timestamp,
-                )
+                .is_superset(&read_stream_ids.iter().cloned().collect())
+                && deadline.invoke_start_condition(&read_stream_ids, condition_context, &timestamp)
             {
                 // Compute the deadline for the timestamp.
                 let deadline_duration = deadline.calculate_deadline(&state, &timestamp);
@@ -232,7 +228,7 @@ where
         if deadline_event.write_stream_ids.contains(&write_stream_id) {
             // Invoke the end condition function on the statistics from the WriteStream.
             return (deadline_event.end_condition)(
-                vec![write_stream_id],
+                &vec![write_stream_id],
                 &self.write_stream.get_condition_context(),
                 &deadline_event.timestamp,
             );
@@ -431,7 +427,7 @@ where
     fn arm_deadlines(
         &self,
         setup_context: &mut SetupContext<S>,
-        read_stream_id: StreamId,
+        read_stream_ids: Vec<StreamId>,
         condition_context: &ConditionContext,
         timestamp: Timestamp,
     ) -> Vec<DeadlineEvent> {
@@ -440,12 +436,8 @@ where
         for deadline in setup_context.get_deadlines() {
             if deadline
                 .get_constrained_read_stream_ids()
-                .contains(&read_stream_id)
-                && deadline.invoke_start_condition(
-                    vec![read_stream_id],
-                    condition_context,
-                    &timestamp,
-                )
+                .is_superset(&read_stream_ids.iter().cloned().collect())
+                && deadline.invoke_start_condition(&read_stream_ids, condition_context, &timestamp)
             {
                 // Compute the deadline for the timestamp.
                 let deadline_duration =
@@ -468,7 +460,7 @@ where
         if deadline_event.write_stream_ids.contains(&write_stream_id) {
             // Invoke the end condition function on the statistics from the WriteStream.
             return (deadline_event.end_condition)(
-                vec![write_stream_id],
+                &vec![write_stream_id],
                 &self.write_stream.get_condition_context(),
                 &deadline_event.timestamp,
             );

--- a/src/node/operator_executors/one_in_one_out_executor.rs
+++ b/src/node/operator_executors/one_in_one_out_executor.rs
@@ -79,6 +79,15 @@ where
     U: Data + for<'a> Deserialize<'a>,
     V: 'static + Send + Sync,
 {
+    fn execute_setup(&mut self, read_stream: &mut ReadStream<T>) -> SetupContext<S> {
+        let mut setup_context =
+            SetupContext::new(vec![read_stream.id()], vec![self.write_stream.id()]);
+        Arc::get_mut(&mut self.operator)
+            .unwrap()
+            .setup(&mut setup_context);
+        setup_context
+    }
+
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>) {
         Arc::get_mut(&mut self.operator)
             .unwrap()

--- a/src/node/operator_executors/one_in_two_out_executor.rs
+++ b/src/node/operator_executors/one_in_two_out_executor.rs
@@ -233,7 +233,7 @@ where
     fn arm_deadlines(
         &self,
         setup_context: &mut SetupContext<S>,
-        read_stream_id: StreamId,
+        read_stream_ids: Vec<StreamId>,
         condition_context: &ConditionContext,
         timestamp: Timestamp,
     ) -> Vec<DeadlineEvent> {
@@ -242,12 +242,8 @@ where
         for deadline in setup_context.get_deadlines() {
             if deadline
                 .get_constrained_read_stream_ids()
-                .contains(&read_stream_id)
-                && deadline.invoke_start_condition(
-                    vec![read_stream_id],
-                    condition_context,
-                    &timestamp,
-                )
+                .is_superset(&read_stream_ids.iter().cloned().collect())
+                && deadline.invoke_start_condition(&read_stream_ids, condition_context, &timestamp)
             {
                 // Compute the deadline for the timestamp.
                 let deadline_duration = deadline.calculate_deadline(&state, &timestamp);
@@ -276,7 +272,7 @@ where
         {
             // Invoke the end condition function on the statistics from the WriteStream.
             return (deadline_event.end_condition)(
-                vec![left_write_stream_id, right_write_stream_id],
+                &vec![left_write_stream_id, right_write_stream_id],
                 &(self
                     .left_write_stream
                     .get_condition_context()
@@ -509,7 +505,7 @@ where
     fn arm_deadlines(
         &self,
         setup_context: &mut SetupContext<S>,
-        read_stream_id: StreamId,
+        read_stream_ids: Vec<StreamId>,
         condition_context: &ConditionContext,
         timestamp: Timestamp,
     ) -> Vec<DeadlineEvent> {
@@ -518,12 +514,8 @@ where
         for deadline in setup_context.get_deadlines() {
             if deadline
                 .get_constrained_read_stream_ids()
-                .contains(&read_stream_id)
-                && deadline.invoke_start_condition(
-                    vec![read_stream_id],
-                    condition_context,
-                    &timestamp,
-                )
+                .is_superset(&read_stream_ids.iter().cloned().collect())
+                && deadline.invoke_start_condition(&read_stream_ids, condition_context, &timestamp)
             {
                 // Compute the deadline for the timestamp.
                 let deadline_duration =
@@ -553,7 +545,7 @@ where
         {
             // Invoke the end condition function on the statistics from the WriteStream.
             return (deadline_event.end_condition)(
-                vec![left_write_stream_id, right_write_stream_id],
+                &vec![left_write_stream_id, right_write_stream_id],
                 &(self
                     .left_write_stream
                     .get_condition_context()

--- a/src/node/operator_executors/one_in_two_out_executor.rs
+++ b/src/node/operator_executors/one_in_two_out_executor.rs
@@ -86,6 +86,17 @@ where
     V: Data + for<'a> Deserialize<'a>,
     W: 'static + Send + Sync,
 {
+    fn execute_setup(&mut self, read_stream: &mut ReadStream<T>) -> SetupContext<S> {
+        let mut setup_context = SetupContext::new(
+            vec![read_stream.id()],
+            vec![self.left_write_stream.id(), self.right_write_stream.id()],
+        );
+        Arc::get_mut(&mut self.operator)
+            .unwrap()
+            .setup(&mut setup_context);
+        setup_context
+    }
+
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>) {
         Arc::get_mut(&mut self.operator).unwrap().run(
             read_stream,
@@ -345,6 +356,15 @@ where
     U: Data + for<'a> Deserialize<'a>,
     V: Data + for<'a> Deserialize<'a>,
 {
+    fn execute_setup(&mut self, read_stream: &mut ReadStream<T>) -> SetupContext<S> {
+        let mut setup_context = SetupContext::new(
+            vec![read_stream.id()],
+            vec![self.left_write_stream.id(), self.right_write_stream.id()],
+        );
+        self.operator.lock().unwrap().setup(&mut setup_context);
+        setup_context
+    }
+
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>) {
         self.operator.lock().unwrap().run(
             read_stream,

--- a/src/node/operator_executors/sink_executor.rs
+++ b/src/node/operator_executors/sink_executor.rs
@@ -10,7 +10,7 @@ use crate::{
         context::{ParallelSinkContext, SetupContext, SinkContext},
         deadlines::{ConditionContext, DeadlineEvent, DeadlineId},
         operator::{OperatorConfig, ParallelSink, Sink},
-        stream::StreamId,
+        stream::{StreamId, StreamT},
         AppendableStateT, Data, Message, ReadStream, StateT, Timestamp,
     },
     node::{
@@ -71,6 +71,14 @@ where
     T: Data + for<'a> Deserialize<'a>,
     U: 'static + Send + Sync,
 {
+    fn execute_setup(&mut self, read_stream: &mut ReadStream<T>) -> SetupContext<S> {
+        let mut setup_context = SetupContext::new(vec![read_stream.id()], vec![]);
+        Arc::get_mut(&mut self.operator)
+            .unwrap()
+            .setup(&mut setup_context);
+        setup_context
+    }
+
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>) {
         Arc::get_mut(&mut self.operator).unwrap().run(read_stream);
     }
@@ -220,6 +228,12 @@ where
     S: StateT,
     T: Data + for<'a> Deserialize<'a>,
 {
+    fn execute_setup(&mut self, read_stream: &mut ReadStream<T>) -> SetupContext<S> {
+        let mut setup_context = SetupContext::new(vec![read_stream.id()], vec![]);
+        self.operator.lock().unwrap().setup(&mut setup_context);
+        setup_context
+    }
+
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>) {
         self.operator.lock().unwrap().run(read_stream);
     }

--- a/src/node/operator_executors/sink_executor.rs
+++ b/src/node/operator_executors/sink_executor.rs
@@ -137,7 +137,7 @@ where
     fn arm_deadlines(
         &self,
         setup_context: &mut SetupContext<S>,
-        read_stream_id: StreamId,
+        read_stream_ids: Vec<StreamId>,
         condition_context: &ConditionContext,
         timestamp: Timestamp,
     ) -> Vec<DeadlineEvent> {
@@ -146,12 +146,8 @@ where
         for deadline in setup_context.get_deadlines() {
             if deadline
                 .get_constrained_read_stream_ids()
-                .contains(&read_stream_id)
-                && deadline.invoke_start_condition(
-                    vec![read_stream_id],
-                    condition_context,
-                    &timestamp,
-                )
+                .is_superset(&read_stream_ids.iter().cloned().collect())
+                && deadline.invoke_start_condition(&read_stream_ids, condition_context, &timestamp)
             {
                 // Compute the deadline for the timestamp.
                 let deadline_duration = deadline.calculate_deadline(&state, &timestamp);
@@ -295,7 +291,7 @@ where
     fn arm_deadlines(
         &self,
         setup_context: &mut SetupContext<S>,
-        read_stream_id: StreamId,
+        read_stream_ids: Vec<StreamId>,
         condition_context: &ConditionContext,
         timestamp: Timestamp,
     ) -> Vec<DeadlineEvent> {
@@ -304,12 +300,8 @@ where
         for deadline in setup_context.get_deadlines() {
             if deadline
                 .get_constrained_read_stream_ids()
-                .contains(&read_stream_id)
-                && deadline.invoke_start_condition(
-                    vec![read_stream_id],
-                    condition_context,
-                    &timestamp,
-                )
+                .is_superset(&read_stream_ids.iter().cloned().collect())
+                && deadline.invoke_start_condition(&read_stream_ids, condition_context, &timestamp)
             {
                 // Compute the deadline for the timestamp.
                 let deadline_duration =


### PR DESCRIPTION
- Invokes `setup` for all operator types.
- Implements timestamp deadlines for the `TwoInMessageProcessorT`.
- Cleans up redundant code.