### PR TITLE
[Bug] Fix error when streams have no destination operators

### DIFF
--- a/src/dataflow/graph/job_graph.rs
+++ b/src/dataflow/graph/job_graph.rs
@@ -26,7 +26,7 @@ impl JobGraph {
 
         // Initialize stream destination vectors.
         // Necessary because the JobGraph assumes that each stream
-        // has a source and a destination vector (may be empty).
+        // has a destination vector (may be empty).
         for s in streams.iter() {
             stream_destinations.insert(s.id(), Vec::new());
         }


### PR DESCRIPTION
Previously, the `JobGraph` assumed that each stream would have a destination operator. This PR fixes this assumption, and improves error messages.