### PR TITLE
Switch logging to tracing from slog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ futures = "0.3.5"
 futures-delay-queue = "0.4.2"
 futures-intrusive = "0.4"  # Required for futures-delay-queue
 futures-util = "0.3.5"
-lazy_static = "1.4.0"
 petgraph = "0.5.0"
 pyo3 = { version = "0.14.3", optional = true }
 rand = "0.3"
 serde = { version = "1.0.115", features = ["derive"] }
-slog = "2.4.2"
-slog-term = "2.4.2"
+tracing = "0.1.29"
+tracing-appender = "0.2.0"
+tracing-subscriber = "0.3.1"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.7", features = ["codec"] }
 tokio-serde-bincode = "0.2.1"

--- a/src/communication/control_message_handler.rs
+++ b/src/communication/control_message_handler.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use slog::{self, Logger};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use crate::node::NodeId;
@@ -9,8 +8,6 @@ use super::{CommunicationError, ControlMessage};
 
 // TODO: update `channels_to_nodes` for fault tolerance in case nodes to go down.
 pub struct ControlMessageHandler {
-    /// Logger for error messages.
-    logger: Logger,
     /// Sender to clone so other tasks can send messages to `self.rx`.
     tx: UnboundedSender<ControlMessage>,
     /// Receiver for all `ControlMessage`s
@@ -24,10 +21,9 @@ pub struct ControlMessageHandler {
 
 #[allow(dead_code)]
 impl ControlMessageHandler {
-    pub fn new(logger: Logger) -> Self {
+    pub fn new() -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
         Self {
-            logger,
             tx,
             rx,
             channels_to_control_senders: HashMap::new(),
@@ -44,8 +40,7 @@ impl ControlMessageHandler {
         tx: UnboundedSender<ControlMessage>,
     ) {
         if let Some(_) = self.channels_to_control_senders.insert(node_id, tx) {
-            slog::error!(
-                self.logger,
+            tracing::error!(
                 "ControlMessageHandler: overwrote channel to control sender for node {}",
                 node_id
             );
@@ -79,8 +74,7 @@ impl ControlMessageHandler {
         tx: UnboundedSender<ControlMessage>,
     ) {
         if let Some(_) = self.channels_to_control_receivers.insert(node_id, tx) {
-            slog::error!(
-                self.logger,
+            tracing::error!(
                 "ControlMessageHandler: overwrote channel to control receiver for node {}",
                 node_id
             );
@@ -114,8 +108,7 @@ impl ControlMessageHandler {
         tx: UnboundedSender<ControlMessage>,
     ) {
         if let Some(_) = self.channels_to_data_senders.insert(node_id, tx) {
-            slog::error!(
-                self.logger,
+            tracing::error!(
                 "ControlMessageHandler: overwrote channel to data sender for node {}",
                 node_id
             );
@@ -149,8 +142,7 @@ impl ControlMessageHandler {
         tx: UnboundedSender<ControlMessage>,
     ) {
         if let Some(_) = self.channels_to_data_receivers.insert(node_id, tx) {
-            slog::error!(
-                self.logger,
+            tracing::error!(
                 "ControlMessageHandler: overwrote channel to data receiver for node {}",
                 node_id
             );

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -13,8 +13,6 @@ pub struct Configuration {
     pub data_addresses: Vec<SocketAddr>,
     /// Mapping between node indices and control socket addresses.
     pub control_addresses: Vec<SocketAddr>,
-    /// System-level logger.
-    pub logger: slog::Logger,
     /// DOT file to export dataflow graph.
     pub graph_filename: Option<String>,
 }
@@ -33,7 +31,6 @@ impl Configuration {
             num_worker_threads,
             data_addresses,
             control_addresses,
-            logger: crate::get_terminal_logger(),
             graph_filename,
         }
     }
@@ -81,7 +78,6 @@ impl Configuration {
             num_worker_threads: num_threads,
             data_addresses,
             control_addresses,
-            logger: crate::get_terminal_logger(),
             graph_filename,
         }
     }

--- a/src/dataflow/deadlines.rs
+++ b/src/dataflow/deadlines.rs
@@ -117,8 +117,7 @@ where
         condition_context: &ConditionContext,
         current_timestamp: &Timestamp,
     ) -> bool {
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
+        tracing::debug!(
             "Executed default start condition for the streams {:?} and the \
             timestamp: {:?} with the context: {:?}",
             stream_ids,
@@ -140,8 +139,7 @@ where
         condition_context: &ConditionContext,
         current_timestamp: &Timestamp,
     ) -> bool {
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
+        tracing::debug!(
             "Executed default end condition for the streams {:?} and the \
             timestamp: {:?} with the context: {:?}",
             stream_ids,

--- a/src/dataflow/operators/filter_operator.rs
+++ b/src/dataflow/operators/filter_operator.rs
@@ -53,8 +53,7 @@ where
             ctx.get_write_stream()
                 .send(Message::new_message(timestamp, data.clone()))
                 .unwrap();
-            slog::debug!(
-                crate::TERMINAL_LOGGER,
+            tracing::debug!(
                 "{} @ {:?}: received {:?} and sent it",
                 ctx.get_operator_config().get_name(),
                 ctx.get_timestamp(),

--- a/src/dataflow/operators/map_operator.rs
+++ b/src/dataflow/operators/map_operator.rs
@@ -53,8 +53,7 @@ where
         ctx.get_write_stream()
             .send(Message::new_message(timestamp, (self.map_function)(data)))
             .unwrap();
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
+        tracing::debug!(
             "{} @ {:?}: received {:?} and sent {:?}",
             ctx.get_operator_config().get_name(),
             ctx.get_timestamp(),

--- a/src/dataflow/operators/split_operator.rs
+++ b/src/dataflow/operators/split_operator.rs
@@ -62,8 +62,7 @@ where
         write_stream
             .send(Message::new_message(timestamp, data.clone()))
             .unwrap();
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
+        tracing::debug!(
             "{} @ {:?}: received {:?} and sent to {} stream",
             ctx.get_operator_config().get_name(),
             ctx.get_timestamp(),

--- a/src/dataflow/stream/extract_stream.rs
+++ b/src/dataflow/stream/extract_stream.rs
@@ -88,8 +88,7 @@ where
     /// * `stream`: The [`Stream`] returned by an [operator](crate::dataflow::operator)
     /// from which to extract messages.
     pub fn new(stream: &Stream<D>) -> Self {
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
+        tracing::debug!(
             "Initializing an ExtractStream with the ReadStream {} (ID: {})",
             stream.name(),
             stream.id(),
@@ -139,8 +138,7 @@ where
                         self.read_stream_option.replace(read_stream);
                         return result;
                     }
-                    Err(msg) => slog::error!(
-                        crate::TERMINAL_LOGGER,
+                    Err(msg) => tracing::error!(
                         "ExtractStream {} (ID: {}): error getting endpoint from \
                         channel manager \"{}\"",
                         self.name(),

--- a/src/dataflow/stream/ingest_stream.rs
+++ b/src/dataflow/stream/ingest_stream.rs
@@ -78,7 +78,7 @@ where
 {
     /// Returns a new instance of the [`IngestStream`].
     pub fn new() -> Self {
-        slog::debug!(crate::TERMINAL_LOGGER, "Initializing an IngestStream");
+        tracing::debug!("Initializing an IngestStream");
         let id = StreamId::new_deterministic();
         let ingest_stream = Self {
             id,
@@ -117,8 +117,7 @@ where
                 thread::sleep(Duration::from_millis(100));
             }
         } else {
-            slog::warn!(
-                crate::TERMINAL_LOGGER,
+            tracing::warn!(
                 "Trying to send messages on a closed IngestStream {} (ID: {})",
                 default_graph::get_stream_name(&self.id()),
                 self.id(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,8 +121,6 @@
 
 // Re-exports of libraries used in macros.
 #[doc(hidden)]
-pub use ::slog;
-#[doc(hidden)]
 pub use ::tokio;
 
 // Libraries used in this file.
@@ -130,11 +128,8 @@ use std::{cell::RefCell, fmt};
 
 use abomonation_derive::Abomonation;
 use clap::{self, App, Arg};
-use lazy_static::lazy_static;
 use rand::{Rng, SeedableRng, StdRng};
 use serde::{Deserialize, Serialize};
-use slog::{Drain, Logger};
-use slog_term::{self, term_full};
 use uuid;
 
 // Private submodules
@@ -212,16 +207,6 @@ pub fn reset() {
         *rng.borrow_mut() = StdRng::from_seed(&[1913, 03, 26]);
     });
     dataflow::graph::default_graph::set(dataflow::graph::AbstractGraph::new());
-}
-
-lazy_static! {
-    static ref TERMINAL_LOGGER: Logger =
-        Logger::root(std::sync::Mutex::new(term_full()).fuse(), slog::o!());
-}
-
-/// Returns a logger that prints messages to the console.
-pub fn get_terminal_logger() -> slog::Logger {
-    TERMINAL_LOGGER.clone()
 }
 
 /// Defines command line arguments for running a multi-node ERDOS application.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,4 +247,12 @@ pub fn new_app(name: &str) -> clap::App {
                 .default_value("")
                 .help("Exports the dataflow graph as a DOT file to the provided filename"),
         )
+        .arg(
+            Arg::with_name("verbose")
+                .short("v")
+                .long("verbose")
+                .multiple(true)
+                .takes_value(false)
+                .help("Sets the level of verbosity"),
+        )
 }

--- a/src/node/lattice.rs
+++ b/src/node/lattice.rs
@@ -353,8 +353,7 @@ impl ExecutionLattice {
         }
 
         if forest.node_count() > 100 {
-            slog::warn!(
-                crate::TERMINAL_LOGGER,
+            tracing::warn!(
                 "{} operator events queued in lattice. Increase number of operator executors or \
                 decrease incoming message frequency to reduce load.",
                 forest.node_count()

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashSet, sync::Arc, thread};
 
 use futures_util::stream::StreamExt;
-use slog;
 use tokio::{
     net::TcpStream,
     runtime::Builder,
@@ -60,7 +59,6 @@ impl Node {
     /// Creates a new node.
     pub fn new(config: Configuration) -> Self {
         let id = config.index;
-        let logger = config.logger.clone();
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
         Self {
             config,
@@ -68,7 +66,7 @@ impl Node {
             job_graph: None,
             channels_to_receivers: Arc::new(Mutex::new(ChannelsToReceivers::new())),
             channels_to_senders: Arc::new(Mutex::new(ChannelsToSenders::new())),
-            control_handler: ControlMessageHandler::new(logger),
+            control_handler: ControlMessageHandler::new(),
             initialized: Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new())),
             shutdown_tx,
             shutdown_rx: Some(shutdown_rx),
@@ -79,7 +77,7 @@ impl Node {
     ///
     /// The method never returns.
     pub fn run(&mut self) {
-        slog::debug!(self.config.logger, "Node {}: running", self.id);
+        tracing::debug!("Node {}: running", self.id);
         // Set the dataflow graph if it hasn't been set already.
         if self.job_graph.is_none() {
             let mut abstract_graph = default_graph::clone();
@@ -93,7 +91,7 @@ impl Node {
             .build()
             .unwrap();
         runtime.block_on(self.async_run());
-        slog::debug!(self.config.logger, "Node {}: finished running", self.id);
+        tracing::debug!("Node {}: finished running", self.id);
     }
 
     /// Runs an ERDOS node in a seperate OS thread.
@@ -128,7 +126,7 @@ impl Node {
         *started = true;
         cvar.notify_all();
 
-        slog::debug!(self.config.logger, "Node {}: done initializing.", self.id);
+        tracing::debug!("Node {}: done initializing.", self.id);
     }
 
     /// Splits a vector of TCPStreams into `DataSender`s and `DataReceiver`s.
@@ -252,11 +250,7 @@ impl Node {
     }
 
     async fn broadcast_local_operators_initialized(&mut self) -> Result<(), String> {
-        slog::debug!(
-            self.config.logger,
-            "Node {}: initialized all operators on this node.",
-            self.id
-        );
+        tracing::debug!("Node {}: initialized all operators on this node.", self.id);
         self.control_handler
             .broadcast_to_nodes(ControlMessage::AllOperatorsInitializedOnNode(self.id))
             .map_err(|e| format!("Error broadcasting control message: {:?}", e))
@@ -307,11 +301,7 @@ impl Node {
         // Execute operators scheduled on the current node.
         let channel_manager = Arc::new(std::sync::Mutex::new(channel_manager));
         let num_operators = job_graph.get_operators().len();
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "There are {} operators total",
-            num_operators
-        );
+        tracing::debug!("There are {} operators total", num_operators);
         let local_operators: Vec<_> = job_graph
             .get_operators()
             .into_iter()
@@ -319,11 +309,7 @@ impl Node {
             .collect();
 
         let num_local_operators = local_operators.len();
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "{} local operators",
-            num_local_operators
-        );
+        tracing::debug!("{} local operators", num_local_operators);
 
         // TODO: choose a better value.
         let num_event_runners = std::cmp::max(
@@ -343,12 +329,7 @@ impl Node {
                 .name
                 .clone()
                 .unwrap_or_else(|| format!("{}", operator_info.id));
-            slog::debug!(
-                self.config.logger,
-                "Node {}: starting operator {}",
-                self.id,
-                name
-            );
+            tracing::debug!("Node {}: starting operator {}", self.id, name);
             let channel_manager_copy = Arc::clone(&channel_manager);
             // Launch the operator as a separate async task.
             let operator_executor = (operator_info.runner)(channel_manager_copy);
@@ -379,20 +360,11 @@ impl Node {
     async fn async_run(&mut self) {
         // Assign values used later to avoid lifetime errors.
         let num_nodes = self.config.data_addresses.len();
-        let logger = self.config.logger.clone();
         // Create TCPStreams between all node pairs.
-        let control_streams = communication::create_tcp_streams(
-            self.config.control_addresses.clone(),
-            self.id,
-            &self.config.logger,
-        )
-        .await;
-        let data_streams = communication::create_tcp_streams(
-            self.config.data_addresses.clone(),
-            self.id,
-            &self.config.logger,
-        )
-        .await;
+        let control_streams =
+            communication::create_tcp_streams(self.config.control_addresses.clone(), self.id).await;
+        let data_streams =
+            communication::create_tcp_streams(self.config.data_addresses.clone(), self.id).await;
         let (control_senders, control_receivers) =
             self.split_control_streams(control_streams).await;
         let (senders, receivers) = self.split_data_streams(data_streams).await;
@@ -416,33 +388,32 @@ impl Node {
                 control_senders_fut,
                 control_recvs_fut
             ) {
-                slog::error!(
-                    logger,
+                tracing::error!(
                     "Non-fatal network communication error; this should not happen! {:?}",
                     e
                 );
             }
             tokio::select! {
-                Err(e) = ops_fut => slog::error!(
-                    logger,
+                Err(e) = ops_fut => tracing::error!(
+
                     "Error running operators on node {:?}: {:?}", self.id, e
                 ),
-                _ = shutdown_fut => slog::debug!(logger, "Node {}: shutting down", self.id),
+                _ = shutdown_fut => tracing::debug!("Node {}: shutting down", self.id),
             }
         } else {
             tokio::select! {
-                Err(e) = senders_fut => slog::error!(logger, "Error with data senders: {:?}", e),
-                Err(e) = recvs_fut => slog::error!(logger, "Error with data receivers: {:?}", e),
-                Err(e) = control_senders_fut => slog::error!(logger, "Error with control senders: {:?}", e),
-                Err(e) = control_recvs_fut => slog::error!(
-                    self.config.logger,
+                Err(e) = senders_fut => tracing::error!("Error with data senders: {:?}", e),
+                Err(e) = recvs_fut => tracing::error!("Error with data receivers: {:?}", e),
+                Err(e) = control_senders_fut => tracing::error!("Error with control senders: {:?}", e),
+                Err(e) = control_recvs_fut => tracing::error!(
+
                     "Error with control receivers: {:?}", e
                 ),
-                Err(e) = ops_fut => slog::error!(
-                    logger,
+                Err(e) = ops_fut => tracing::error!(
+
                     "Error running operators on node {:?}: {:?}", self.id, e
                 ),
-                _ = shutdown_fut => slog::debug!(logger, "Node {}: shutting down", self.id),
+                _ = shutdown_fut => tracing::debug!("Node {}: shutting down", self.id),
             }
         }
     }

--- a/src/node/operator_executors/mod.rs
+++ b/src/node/operator_executors/mod.rs
@@ -226,8 +226,7 @@ where
             tokio::task::block_in_place(|| self.processor.execute_setup(&mut read_stream));
 
         // Execute the `run` method.
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
+        tracing::debug!(
             "Node {}: Running Operator {}",
             self.config.node_id,
             self.config.get_name()
@@ -256,8 +255,8 @@ where
                             }
                         }
                         Err(e) => {
-                            slog::error!(
-                                crate::TERMINAL_LOGGER,
+                            tracing::error!(
+
                                 "OneInExecutor {}: Error receiving notifications {:?}",
                                 self.operator_id(),
                                 e
@@ -358,8 +357,7 @@ where
         });
 
         // Execute the `run` method.
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
+        tracing::debug!(
             "Node {}: Running Operator {}",
             self.config.node_id,
             self.config.get_name()
@@ -390,8 +388,8 @@ where
                             }
                         }
                         Err(e) => {
-                            slog::error!(
-                                crate::TERMINAL_LOGGER,
+                            tracing::error!(
+
                                 "TwoInExecutor {}: Error receiving notifications {:?}",
                                 self.operator_id(),
                                 e
@@ -484,8 +482,7 @@ impl OperatorExecutorHelper {
                 let event_duration = event.duration;
                 let deadline_id = event.id;
                 let queue_key: DelayHandle = self.deadline_queue.insert(event, event_duration);
-                slog::debug!(
-                    crate::TERMINAL_LOGGER,
+                tracing::debug!(
                     "Installed a deadline handler for the Deadline {} with the DelayHandle: {:?}",
                     deadline_id,
                     queue_key,
@@ -531,15 +528,15 @@ impl OperatorExecutorHelper {
                     // Remove the key from the hashmap and clear the state in the ConditionContext.
                     match self.deadline_to_key_map.remove(&deadline_event.id) {
                         None => {
-                            slog::warn!(
-                                crate::TERMINAL_LOGGER,
+                            tracing::warn!(
+
                                 "Could not find a key corresponding to the Deadline ID: {}",
                                 deadline_event.id,
                             );
                         }
                         Some(key) => {
-                            slog::debug!(
-                                crate::TERMINAL_LOGGER,
+                            tracing::debug!(
+
                                 "Finished invoking the deadline handler for the DelayHandle: {:?} \
                                 corresponding to the Deadline ID: {}",
                                 key,
@@ -654,15 +651,15 @@ impl OperatorExecutorHelper {
                     // Remove the key from the hashmap and clear the state in the ConditionContext.
                     match self.deadline_to_key_map.remove(&deadline_event.id) {
                         None => {
-                            slog::warn!(
-                                crate::TERMINAL_LOGGER,
+                            tracing::warn!(
+
                                 "Could not find a key corresponding to the Deadline ID: {}",
                                 deadline_event.id,
                             );
                         }
                         Some(key) => {
-                            slog::debug!(
-                                crate::TERMINAL_LOGGER,
+                            tracing::debug!(
+
                                 "Finished invoking the deadline handler for the DelayHandle: {:?} \
                                 corresponding to the Deadline ID: {}",
                                 key,

--- a/src/node/operator_executors/source_executor.rs
+++ b/src/node/operator_executors/source_executor.rs
@@ -62,8 +62,7 @@ where
     ) {
         self.helper.synchronize().await;
 
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
+        tracing::debug!(
             "Node {}: running operator {}",
             self.config.node_id,
             self.config.get_name()

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -56,12 +56,7 @@ fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
             .node(node_id)
             .flow_watermarks(flow_watermarks);
         config.id = OperatorId::new_deterministic();
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "Assigning ID {} to {}.",
-            config.id,
-            name,
-        );
+        tracing::debug!("Assigning ID {} to {}.", config.id, name,);
         let config_copy = config.clone();
 
         // Arc objects to pass to the executor.
@@ -110,12 +105,7 @@ fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
             .node(node_id)
             .flow_watermarks(flow_watermarks);
         config.id = OperatorId::new_deterministic();
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "Assigning ID {} to {}.",
-            config.id,
-            name,
-        );
+        tracing::debug!("Assigning ID {} to {}.", config.id, name,);
         let config_copy = config.clone();
 
         // Arc objects to pass to the constructor.
@@ -164,12 +154,7 @@ fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
             .node(node_id)
             .flow_watermarks(flow_watermarks);
         config.id = OperatorId::new_deterministic();
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "Assigning ID {} to {}.",
-            config.id,
-            name,
-        );
+        tracing::debug!("Assigning ID {} to {}.", config.id, name,);
         let config_copy = config.clone();
 
         // Arc objects to pass to the executor.
@@ -219,12 +204,7 @@ fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
             .node(node_id)
             .flow_watermarks(flow_watermarks);
         config.id = OperatorId::new_deterministic();
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "Assigning ID {} to {}",
-            config.id,
-            name,
-        );
+        tracing::debug!("Assigning ID {} to {}", config.id, name,);
         let config_copy = config.clone();
 
         // Arc objects to pass to the executor.
@@ -278,12 +258,7 @@ fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
             .node(node_id)
             .flow_watermarks(flow_watermarks);
         config.id = OperatorId::new_deterministic();
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "Assigning ID {} to {}.",
-            config.id,
-            name,
-        );
+        tracing::debug!("Assigning ID {} to {}.", config.id, name,);
         let config_copy = config.clone();
 
         // Arc objects to pass to the executor.

--- a/src/python/py_operators/py_one_in_one_out.rs
+++ b/src/python/py_operators/py_one_in_one_out.rs
@@ -28,11 +28,7 @@ impl PyOneInOneOut {
         config: OperatorConfig,
     ) -> Self {
         // Instantiate the Operator in Python.
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "Instantiating the operator {:?}",
-            config.name
-        );
+        tracing::debug!("Instantiating the operator {:?}", config.name);
 
         let py_operator_config_clone = Arc::clone(&py_operator_config);
         let py_operator = super::construct_operator(

--- a/src/python/py_operators/py_one_in_two_out.rs
+++ b/src/python/py_operators/py_one_in_two_out.rs
@@ -30,11 +30,7 @@ impl PyOneInTwoOut {
         config: OperatorConfig,
     ) -> Self {
         // Instantiate the Operator in Python.
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "Instantiating the operator {:?}",
-            config.name
-        );
+        tracing::debug!("Instantiating the operator {:?}", config.name);
 
         let py_operator_config_clone = Arc::clone(&py_operator_config);
         let py_operator = super::construct_operator(

--- a/src/python/py_operators/py_sink.rs
+++ b/src/python/py_operators/py_sink.rs
@@ -24,11 +24,7 @@ impl PySink {
         config: OperatorConfig,
     ) -> Self {
         // Instantiate the operator in Python.
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "Instantiating the operator {:?}",
-            config.name
-        );
+        tracing::debug!("Instantiating the operator {:?}", config.name);
 
         let py_operator_config_clone = Arc::clone(&py_operator_config);
         let py_operator = super::construct_operator(

--- a/src/python/py_operators/py_source.rs
+++ b/src/python/py_operators/py_source.rs
@@ -22,11 +22,7 @@ impl PySource {
         config: OperatorConfig,
     ) -> Self {
         // Instantiate the Operator in Python.
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "Instantiating the operator {:?}",
-            config.name
-        );
+        tracing::debug!("Instantiating the operator {:?}", config.name);
 
         let py_operator = super::construct_operator(
             py_operator_type,

--- a/src/python/py_operators/py_two_in_one_out.rs
+++ b/src/python/py_operators/py_two_in_one_out.rs
@@ -28,11 +28,7 @@ impl PyTwoInOneOut {
         config: OperatorConfig,
     ) -> Self {
         // Instantiate the Operator in Python.
-        slog::debug!(
-            crate::TERMINAL_LOGGER,
-            "Instantiating the operator {:?}",
-            config.name
-        );
+        tracing::debug!("Instantiating the operator {:?}", config.name);
 
         let py_operator_config_clone = Arc::clone(&py_operator_config);
         let py_operator = super::construct_operator(

--- a/tests/inter_thread_test.rs
+++ b/tests/inter_thread_test.rs
@@ -104,14 +104,14 @@ impl DestroyOperator {
 
     pub fn msg_callback(_t: &Timestamp, data: &usize) {
         let logger = erdos::get_terminal_logger();
-        slog::debug!(logger, "DestroyOperator: received {}", data);
+        tracing::debug!("DestroyOperator: received {}", data);
     }
 }
 
 impl Operator for DestroyOperator {
     fn destroy(&mut self) {
         let logger = erdos::get_terminal_logger();
-        slog::debug!(logger, "DestroyOperator: called destroy()");
+        tracing::debug!("DestroyOperator: called destroy()");
     }
 }
 
@@ -139,7 +139,7 @@ impl TwoStreamDestroyOperator {
 impl Operator for TwoStreamDestroyOperator {
     fn destroy(&mut self) {
         let logger = erdos::get_terminal_logger();
-        slog::debug!(logger, "TwoStreamDestroyOperator: called destroy()");
+        tracing::debug!("TwoStreamDestroyOperator: called destroy()");
     }
 }
 
@@ -233,10 +233,10 @@ fn test_ingest_extract() {
 
     for count in 0..5 {
         let msg = Message::new_message(Timestamp::Time(vec![count as u64]), count);
-        slog::debug!(logger, "Ingest stream: sending {:?}", msg);
+        tracing::debug!("Ingest stream: sending {:?}", msg);
         ingest_stream.send(msg).unwrap();
         let result = extract_stream.read();
-        slog::debug!(logger, "Received {:?}", result);
+        tracing::debug!("Received {:?}", result);
     }
 }
 
@@ -254,18 +254,18 @@ fn test_destroy() {
     let logger = erdos::get_terminal_logger();
 
     let msg = Message::new_message(Timestamp::Time(vec![0]), 0);
-    slog::debug!(logger, "IngestStream: sending {:?}", msg);
+    tracing::debug!("IngestStream: sending {:?}", msg);
     ingest_stream.send(msg).unwrap();
 
     let received_msg = extract_stream.read().unwrap();
-    slog::debug!(logger, "ExtractStream: received {:?}", received_msg);
+    tracing::debug!("ExtractStream: received {:?}", received_msg);
 
     let msg = Message::new_watermark(Timestamp::Top);
-    slog::debug!(logger, "IngestStream: sending {:?}", msg);
+    tracing::debug!("IngestStream: sending {:?}", msg);
     ingest_stream.send(msg).unwrap();
 
     let received_msg = extract_stream.read().unwrap();
-    slog::debug!(logger, "ExtractStream: received {:?}", received_msg);
+    tracing::debug!("ExtractStream: received {:?}", received_msg);
 
     // Check that the stream is closed.
     let msg = Message::new_message(Timestamp::Time(vec![0]), 0);


### PR DESCRIPTION
Switches logging to [tracing](https://github.com/tokio-rs/tracing) from [slog](https://github.com/slog-rs/slog).

## Additional Changes
- More customization for logging via the Node configuration and command line interfaces.
- Rename `num_worker_threads` to `num_threads` to distinguish from the worker tasks.

## Advantages of tracing
- Supports [spans](https://docs.rs/tracing/0.1.29/tracing/#spans) for monitoring the progress/duration code contexts. I've found this useful for concurrent debugging.
- Tracing integrates with Tokio and provides support for async contexts.
- Don't need to pass a logger when recording events.
- Support for additional logging interfaces (e.g. writing to file, integrating with [OpenTelemetry](https://github.com/tokio-rs/tracing/tree/master/tracing-opentelemetry)).
- Easy to add additional information such as current OS thread.

## Advantages of slog
- Slightly better measured performance
   - 1.3 us/event for slog with slog-async-drain vs. 3 us/event for tracing with tracing-appender.
   - In these measurements, the slog's asynchronous logger dropped most events.
- Users can instantiate that are independent of ERDOS.