### PR TITLE
Add OperatorConfig to operator run method

### DIFF
--- a/erdos/src/dataflow/operator.rs
+++ b/erdos/src/dataflow/operator.rs
@@ -20,7 +20,7 @@ where
     S: State,
     T: Data + for<'a> Deserialize<'a>,
 {
-    fn run(&mut self, write_stream: &mut WriteStream<T>) {}
+    fn run(&mut self, config: &OperatorConfig, write_stream: &mut WriteStream<T>) {}
 
     fn destroy(&mut self) {}
 }
@@ -45,7 +45,7 @@ where
 pub trait ParallelSink<S: AppendableStateT<U>, T: Data, U>: Send + Sync {
     fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
 
-    fn run(&mut self, read_stream: &mut ReadStream<T>) {}
+    fn run(&mut self, config: &OperatorConfig, read_stream: &mut ReadStream<T>) {}
 
     fn destroy(&mut self) {}
 
@@ -70,7 +70,7 @@ pub trait ParallelSink<S: AppendableStateT<U>, T: Data, U>: Send + Sync {
 pub trait Sink<S: StateT, T: Data>: Send + Sync {
     fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
 
-    fn run(&mut self, read_stream: &mut ReadStream<T>) {}
+    fn run(&mut self, config: &OperatorConfig, read_stream: &mut ReadStream<T>) {}
 
     fn destroy(&mut self) {}
 
@@ -104,7 +104,7 @@ where
 {
     fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
 
-    fn run(&mut self, read_stream: &mut ReadStream<T>, write_stream: &mut WriteStream<U>) {}
+    fn run(&mut self, config: &OperatorConfig, read_stream: &mut ReadStream<T>, write_stream: &mut WriteStream<U>) {}
 
     fn destroy(&mut self) {}
 
@@ -134,7 +134,7 @@ where
 {
     fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
 
-    fn run(&mut self, read_stream: &mut ReadStream<T>, write_stream: &mut WriteStream<U>) {}
+    fn run(&mut self, config: &OperatorConfig, read_stream: &mut ReadStream<T>, write_stream: &mut WriteStream<U>) {}
 
     fn destroy(&mut self) {}
 
@@ -171,6 +171,7 @@ where
 
     fn run(
         &mut self,
+        config: &OperatorConfig,
         left_read_stream: &mut ReadStream<T>,
         right_read_stream: &mut ReadStream<U>,
         write_stream: &mut WriteStream<V>,
@@ -210,6 +211,7 @@ where
 
     fn run(
         &mut self,
+        config: &OperatorConfig,
         left_read_stream: &mut ReadStream<T>,
         right_read_stream: &mut ReadStream<U>,
         write_stream: &mut WriteStream<V>,
@@ -253,6 +255,7 @@ where
 
     fn run(
         &mut self,
+        config: &OperatorConfig,
         read_stream: &mut ReadStream<T>,
         left_write_stream: &mut WriteStream<U>,
         right_write_stream: &mut WriteStream<V>,
@@ -290,6 +293,7 @@ where
 
     fn run(
         &mut self,
+        config: &OperatorConfig,
         read_stream: &mut ReadStream<T>,
         left_write_stream: &mut WriteStream<U>,
         right_write_stream: &mut WriteStream<V>,

--- a/erdos/src/dataflow/operator.rs
+++ b/erdos/src/dataflow/operator.rs
@@ -104,7 +104,13 @@ where
 {
     fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
 
-    fn run(&mut self, config: &OperatorConfig, read_stream: &mut ReadStream<T>, write_stream: &mut WriteStream<U>) {}
+    fn run(
+        &mut self,
+        config: &OperatorConfig,
+        read_stream: &mut ReadStream<T>,
+        write_stream: &mut WriteStream<U>,
+    ) {
+    }
 
     fn destroy(&mut self) {}
 
@@ -134,7 +140,13 @@ where
 {
     fn setup(&mut self, setup_context: &mut SetupContext<S>) {}
 
-    fn run(&mut self, config: &OperatorConfig, read_stream: &mut ReadStream<T>, write_stream: &mut WriteStream<U>) {}
+    fn run(
+        &mut self,
+        config: &OperatorConfig,
+        read_stream: &mut ReadStream<T>,
+        write_stream: &mut WriteStream<U>,
+    ) {
+    }
 
     fn destroy(&mut self) {}
 

--- a/erdos/src/dataflow/operators/ros/from_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/from_ros_operator.rs
@@ -1,5 +1,5 @@
 use crate::dataflow::{
-    operator::{Source, OperatorConfig},
+    operator::{OperatorConfig, Source},
     operators::ros::*,
     stream::{WriteStream, WriteStreamT},
     Data, Message,
@@ -72,7 +72,11 @@ where
                 let erdos_msg_vec = (from_ros_msg)(&ros_msg);
 
                 for erdos_msg in erdos_msg_vec.into_iter() {
-                    tracing::trace!("{}: Received and Converted {:?}", config_clone.get_name(), erdos_msg,);
+                    tracing::trace!(
+                        "{}: Received and Converted {:?}",
+                        config_clone.get_name(),
+                        erdos_msg,
+                    );
                     // Sends converted message on ERDOS stream.
                     write_stream_clone.lock().unwrap().send(erdos_msg).unwrap();
                 }

--- a/erdos/src/dataflow/operators/ros/from_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/from_ros_operator.rs
@@ -62,9 +62,9 @@ impl<T: rosrust::Message, U> Source<(), U> for FromRosOperator<T, U>
 where
     U: Data + for<'a> Deserialize<'a>,
 {
-    fn run(&mut self, context: &OperatorConfig, write_stream: &mut WriteStream<U>) {
+    fn run(&mut self, config: &OperatorConfig, write_stream: &mut WriteStream<U>) {
         let from_ros_msg = self.from_ros_msg.clone();
-        let context_clone = context.clone();
+        let config_clone = config.clone();
         let write_stream_clone = Arc::new(Mutex::new(write_stream.clone()));
 
         let _subscriber_raii =
@@ -72,7 +72,7 @@ where
                 let erdos_msg_vec = (from_ros_msg)(&ros_msg);
 
                 for erdos_msg in erdos_msg_vec.into_iter() {
-                    tracing::trace!("{}: Received and Converted {:?}", context_clone.get_name(), erdos_msg,);
+                    tracing::trace!("{}: Received and Converted {:?}", config_clone.get_name(), erdos_msg,);
                     // Sends converted message on ERDOS stream.
                     write_stream_clone.lock().unwrap().send(erdos_msg).unwrap();
                 }

--- a/erdos/src/dataflow/operators/ros/from_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/from_ros_operator.rs
@@ -1,5 +1,5 @@
 use crate::dataflow::{
-    operator::Source,
+    operator::{Source, OperatorConfig},
     operators::ros::*,
     stream::{WriteStream, WriteStreamT},
     Data, Message,
@@ -62,8 +62,9 @@ impl<T: rosrust::Message, U> Source<(), U> for FromRosOperator<T, U>
 where
     U: Data + for<'a> Deserialize<'a>,
 {
-    fn run(&mut self, write_stream: &mut WriteStream<U>) {
+    fn run(&mut self, context: &OperatorConfig, write_stream: &mut WriteStream<U>) {
         let from_ros_msg = self.from_ros_msg.clone();
+        let context_clone = context.clone();
         let write_stream_clone = Arc::new(Mutex::new(write_stream.clone()));
 
         let _subscriber_raii =
@@ -71,7 +72,7 @@ where
                 let erdos_msg_vec = (from_ros_msg)(&ros_msg);
 
                 for erdos_msg in erdos_msg_vec.into_iter() {
-                    tracing::trace!("FromRosOperator: Received and Converted {:?}", erdos_msg,);
+                    tracing::trace!("{}: Received and Converted {:?}", context_clone.get_name(), erdos_msg,);
                     // Sends converted message on ERDOS stream.
                     write_stream_clone.lock().unwrap().send(erdos_msg).unwrap();
                 }

--- a/erdos/src/node/operator_executors/one_in_one_out_executor.rs
+++ b/erdos/src/node/operator_executors/one_in_one_out_executor.rs
@@ -89,9 +89,11 @@ where
     }
 
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>) {
-        Arc::get_mut(&mut self.operator)
-            .unwrap()
-            .run(&self.config, read_stream, &mut self.write_stream);
+        Arc::get_mut(&mut self.operator).unwrap().run(
+            &self.config,
+            read_stream,
+            &mut self.write_stream,
+        );
     }
 
     fn execute_destroy(&mut self) {

--- a/erdos/src/node/operator_executors/one_in_one_out_executor.rs
+++ b/erdos/src/node/operator_executors/one_in_one_out_executor.rs
@@ -91,7 +91,7 @@ where
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>) {
         Arc::get_mut(&mut self.operator)
             .unwrap()
-            .run(read_stream, &mut self.write_stream);
+            .run(&self.config, read_stream, &mut self.write_stream);
     }
 
     fn execute_destroy(&mut self) {
@@ -309,7 +309,7 @@ where
         self.operator
             .lock()
             .unwrap()
-            .run(read_stream, &mut self.write_stream);
+            .run(&self.config, read_stream, &mut self.write_stream);
     }
 
     fn execute_destroy(&mut self) {

--- a/erdos/src/node/operator_executors/one_in_two_out_executor.rs
+++ b/erdos/src/node/operator_executors/one_in_two_out_executor.rs
@@ -99,6 +99,7 @@ where
 
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>) {
         Arc::get_mut(&mut self.operator).unwrap().run(
+            &self.config,
             read_stream,
             &mut self.left_write_stream,
             &mut self.right_write_stream,
@@ -363,6 +364,7 @@ where
 
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>) {
         self.operator.lock().unwrap().run(
+            &self.config,
             read_stream,
             &mut self.left_write_stream,
             &mut self.right_write_stream,

--- a/erdos/src/node/operator_executors/sink_executor.rs
+++ b/erdos/src/node/operator_executors/sink_executor.rs
@@ -80,7 +80,9 @@ where
     }
 
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>) {
-        Arc::get_mut(&mut self.operator).unwrap().run(&self.config, read_stream);
+        Arc::get_mut(&mut self.operator)
+            .unwrap()
+            .run(&self.config, read_stream);
     }
 
     fn execute_destroy(&mut self) {

--- a/erdos/src/node/operator_executors/sink_executor.rs
+++ b/erdos/src/node/operator_executors/sink_executor.rs
@@ -80,7 +80,7 @@ where
     }
 
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>) {
-        Arc::get_mut(&mut self.operator).unwrap().run(read_stream);
+        Arc::get_mut(&mut self.operator).unwrap().run(&self.config, read_stream);
     }
 
     fn execute_destroy(&mut self) {
@@ -231,7 +231,7 @@ where
     }
 
     fn execute_run(&mut self, read_stream: &mut ReadStream<T>) {
-        self.operator.lock().unwrap().run(read_stream);
+        self.operator.lock().unwrap().run(&self.config, read_stream);
     }
 
     fn execute_destroy(&mut self) {

--- a/erdos/src/node/operator_executors/source_executor.rs
+++ b/erdos/src/node/operator_executors/source_executor.rs
@@ -68,7 +68,7 @@ where
             self.config.get_name()
         );
 
-        tokio::task::block_in_place(|| self.operator.run(&mut self.write_stream));
+        tokio::task::block_in_place(|| self.operator.run(&self.config, &mut self.write_stream));
         tokio::task::block_in_place(|| self.operator.destroy());
 
         // Close the stream.

--- a/erdos/src/node/operator_executors/two_in_one_out_executor.rs
+++ b/erdos/src/node/operator_executors/two_in_one_out_executor.rs
@@ -106,6 +106,7 @@ where
         right_read_stream: &mut ReadStream<U>,
     ) {
         Arc::get_mut(&mut self.operator).unwrap().run(
+            &self.config,
             left_read_stream,
             right_read_stream,
             &mut self.write_stream,
@@ -365,6 +366,7 @@ where
         right_read_stream: &mut ReadStream<U>,
     ) {
         self.operator.lock().unwrap().run(
+            &self.config,
             left_read_stream,
             right_read_stream,
             &mut self.write_stream,

--- a/examples/erdos_to_ros.rs
+++ b/examples/erdos_to_ros.rs
@@ -23,8 +23,8 @@ impl SourceOperator {
 
 // This Source operator repeatedly sends String messages.
 impl Source<(), String> for SourceOperator {
-    fn run(&mut self, context: &OperatorConfig, write_stream: &mut WriteStream<String>) {
-        tracing::info!("Running {}", context.get_name());
+    fn run(&mut self, config: &OperatorConfig, write_stream: &mut WriteStream<String>) {
+        tracing::info!("Running {}", config.get_name());
         for t in 0..10 {
             let timestamp = Timestamp::Time(vec![t as u64]);
             write_stream

--- a/examples/erdos_to_ros.rs
+++ b/examples/erdos_to_ros.rs
@@ -23,8 +23,8 @@ impl SourceOperator {
 
 // This Source operator repeatedly sends String messages.
 impl Source<(), String> for SourceOperator {
-    fn run(&mut self, write_stream: &mut WriteStream<String>) {
-        tracing::info!("Running Source Operator");
+    fn run(&mut self, context: &OperatorConfig, write_stream: &mut WriteStream<String>) {
+        tracing::info!("Running {}", context.get_name());
         for t in 0..10 {
             let timestamp = Timestamp::Time(vec![t as u64]);
             write_stream

--- a/examples/full_pipeline.rs
+++ b/examples/full_pipeline.rs
@@ -21,8 +21,8 @@ impl SourceOperator {
 }
 
 impl Source<(), usize> for SourceOperator {
-    fn run(&mut self, context: &OperatorConfig, write_stream: &mut WriteStream<usize>) {
-        tracing::info!("Running {}", context.get_name());
+    fn run(&mut self, config: &OperatorConfig, write_stream: &mut WriteStream<usize>) {
+        tracing::info!("Running {}", config.get_name());
         for t in 0..10 {
             let timestamp = Timestamp::Time(vec![t as u64]);
             write_stream

--- a/examples/full_pipeline.rs
+++ b/examples/full_pipeline.rs
@@ -21,8 +21,8 @@ impl SourceOperator {
 }
 
 impl Source<(), usize> for SourceOperator {
-    fn run(&mut self, write_stream: &mut WriteStream<usize>) {
-        tracing::info!("Running Source Operator");
+    fn run(&mut self, context: &OperatorConfig, write_stream: &mut WriteStream<usize>) {
+        tracing::info!("Running {}", context.get_name());
         for t in 0..10 {
             let timestamp = Timestamp::Time(vec![t as u64]);
             write_stream

--- a/python/src/py_operators/py_one_in_one_out.rs
+++ b/python/src/py_operators/py_one_in_one_out.rs
@@ -48,7 +48,7 @@ impl PyOneInOneOut {
 impl OneInOneOut<(), Vec<u8>, Vec<u8>> for PyOneInOneOut {
     fn run(
         &mut self,
-        config: &OperatorConfig,
+        _config: &OperatorConfig,
         read_stream: &mut ReadStream<Vec<u8>>,
         write_stream: &mut WriteStream<Vec<u8>>,
     ) {

--- a/python/src/py_operators/py_one_in_one_out.rs
+++ b/python/src/py_operators/py_one_in_one_out.rs
@@ -48,6 +48,7 @@ impl PyOneInOneOut {
 impl OneInOneOut<(), Vec<u8>, Vec<u8>> for PyOneInOneOut {
     fn run(
         &mut self,
+        config: &OperatorConfig,
         read_stream: &mut ReadStream<Vec<u8>>,
         write_stream: &mut WriteStream<Vec<u8>>,
     ) {

--- a/python/src/py_operators/py_one_in_two_out.rs
+++ b/python/src/py_operators/py_one_in_two_out.rs
@@ -52,7 +52,7 @@ impl PyOneInTwoOut {
 impl OneInTwoOut<(), Vec<u8>, Vec<u8>, Vec<u8>> for PyOneInTwoOut {
     fn run(
         &mut self,
-        config: &OperatorConfig,
+        _config: &OperatorConfig,
         read_stream: &mut ReadStream<Vec<u8>>,
         left_write_stream: &mut WriteStream<Vec<u8>>,
         right_write_stream: &mut WriteStream<Vec<u8>>,

--- a/python/src/py_operators/py_one_in_two_out.rs
+++ b/python/src/py_operators/py_one_in_two_out.rs
@@ -52,6 +52,7 @@ impl PyOneInTwoOut {
 impl OneInTwoOut<(), Vec<u8>, Vec<u8>, Vec<u8>> for PyOneInTwoOut {
     fn run(
         &mut self,
+        config: &OperatorConfig,
         read_stream: &mut ReadStream<Vec<u8>>,
         left_write_stream: &mut WriteStream<Vec<u8>>,
         right_write_stream: &mut WriteStream<Vec<u8>>,

--- a/python/src/py_operators/py_sink.rs
+++ b/python/src/py_operators/py_sink.rs
@@ -42,7 +42,7 @@ impl PySink {
 }
 
 impl Sink<(), Vec<u8>> for PySink {
-    fn run(&mut self, read_stream: &mut ReadStream<Vec<u8>>) {
+    fn run(&mut self, config: &OperatorConfig, read_stream: &mut ReadStream<Vec<u8>>) {
         // Note on the unsafe execution: To conform to the Operator API that passes a mutable
         // reference to the `run` method of an operator, we convert the reference to a raw pointer
         // and create another object that points to the same memory location as the original

--- a/python/src/py_operators/py_sink.rs
+++ b/python/src/py_operators/py_sink.rs
@@ -42,7 +42,7 @@ impl PySink {
 }
 
 impl Sink<(), Vec<u8>> for PySink {
-    fn run(&mut self, config: &OperatorConfig, read_stream: &mut ReadStream<Vec<u8>>) {
+    fn run(&mut self, _config: &OperatorConfig, read_stream: &mut ReadStream<Vec<u8>>) {
         // Note on the unsafe execution: To conform to the Operator API that passes a mutable
         // reference to the `run` method of an operator, we convert the reference to a raw pointer
         // and create another object that points to the same memory location as the original

--- a/python/src/py_operators/py_source.rs
+++ b/python/src/py_operators/py_source.rs
@@ -36,7 +36,7 @@ impl PySource {
 }
 
 impl Source<(), Vec<u8>> for PySource {
-    fn run(&mut self, config: &OperatorConfig, write_stream: &mut WriteStream<Vec<u8>>) {
+    fn run(&mut self, _config: &OperatorConfig, write_stream: &mut WriteStream<Vec<u8>>) {
         // Create the Python version of the WriteStream.
         let write_stream_clone = write_stream.clone();
         let write_stream_id = write_stream.id();

--- a/python/src/py_operators/py_source.rs
+++ b/python/src/py_operators/py_source.rs
@@ -36,7 +36,7 @@ impl PySource {
 }
 
 impl Source<(), Vec<u8>> for PySource {
-    fn run(&mut self, write_stream: &mut WriteStream<Vec<u8>>) {
+    fn run(&mut self, config: &OperatorConfig, write_stream: &mut WriteStream<Vec<u8>>) {
         // Create the Python version of the WriteStream.
         let write_stream_clone = write_stream.clone();
         let write_stream_id = write_stream.id();

--- a/python/src/py_operators/py_two_in_one_out.rs
+++ b/python/src/py_operators/py_two_in_one_out.rs
@@ -48,6 +48,7 @@ impl PyTwoInOneOut {
 impl TwoInOneOut<(), Vec<u8>, Vec<u8>, Vec<u8>> for PyTwoInOneOut {
     fn run(
         &mut self,
+        config: &OperatorConfig,
         left_read_stream: &mut ReadStream<Vec<u8>>,
         right_read_stream: &mut ReadStream<Vec<u8>>,
         write_stream: &mut WriteStream<Vec<u8>>,

--- a/python/src/py_operators/py_two_in_one_out.rs
+++ b/python/src/py_operators/py_two_in_one_out.rs
@@ -48,7 +48,7 @@ impl PyTwoInOneOut {
 impl TwoInOneOut<(), Vec<u8>, Vec<u8>, Vec<u8>> for PyTwoInOneOut {
     fn run(
         &mut self,
-        config: &OperatorConfig,
+        _config: &OperatorConfig,
         left_read_stream: &mut ReadStream<Vec<u8>>,
         right_read_stream: &mut ReadStream<Vec<u8>>,
         write_stream: &mut WriteStream<Vec<u8>>,


### PR DESCRIPTION
* Adds a `config: &OperatorConfig` to all operators
* Updated examples and ros operators
* `config` is currently unused in the Python interface (Rust warnings)