### PR TITLE
[BUG] Fix pyo3 build issue in MacOS (#195)

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -5,8 +5,14 @@ edition = "2018"
 
 [dependencies]
 erdos = { path = "../erdos" }
-pyo3 = { version = "0.15.1", features = ["extension-module"] }
 tracing = "0.1.29"
+
+[dependencies.pyo3]
+version = "0.15.1"
+
+[features]
+extension-module = ["pyo3/extension-module"]
+default = ["extension-module"]
 
 [lib]
 name = "erdos_python"


### PR DESCRIPTION
Fixes #195 on x86-64 Mac. Run with `cargo build --no-default-features`. 

@objorkman: Can you test on the M1?