### PR TITLE
Fix doctests for ROS operators.

### DIFF
--- a/erdos/src/dataflow/operators/ros/from_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/from_ros_operator.rs
@@ -34,12 +34,6 @@ use std::sync::{Arc, Mutex};
 /// #             pub data: Vec<u8>,
 /// #         }
 /// #
-/// #         impl Image {
-/// #             fn new() -> Self {
-/// #                 Self { data: vec![] }
-/// #             }
-/// #         }
-/// #
 /// #         impl rosrust::Message for Image {
 /// #             fn msg_definition() -> String { String::new() }
 /// #             fn md5sum() -> String { String::new() }
@@ -48,7 +42,7 @@ use std::sync::{Arc, Mutex};
 /// #
 /// #         impl rosrust::RosMsg for Image {
 /// #             fn encode<W: io::Write>(&self, mut w: W) -> io::Result<()> { Ok(()) }
-/// #             fn decode<R: io::Read>(mut r: R) -> io::Result<Self> { Ok(Self::new()) }
+/// #             fn decode<R: io::Read>(mut r: R) -> io::Result<Self> { Ok(Default::default()) }
 /// #         }
 /// #     }
 /// # };

--- a/erdos/src/dataflow/operators/ros/from_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/from_ros_operator.rs
@@ -19,9 +19,41 @@ use std::sync::{Arc, Mutex};
 /// which takes a [`rosrust_msg::sensor_msgs::Image`] and returns an ERDOS message containing
 /// [`Vec<u8>`] a vector of bytes.
 ///
-/// ```
-/// fn ros_image_to_bytes(input: &rosrust_msg::sensor_msgs::Image) -> Vector<Message<Vec<u8>>> {
-///     vec![Message::new_message(Timestamp::Time(vec![0 as u64]), input.data)]
+/// ```no_run
+/// # use erdos::{
+/// #     dataflow::{Message, operators::ros::FromRosOperator, Timestamp},
+/// #     OperatorConfig,
+/// # };
+/// #
+/// # pub mod rosrust_msg {
+/// #     pub mod sensor_msgs {
+/// #         use std::io;
+/// #
+/// #         #[derive(Debug, Clone, PartialEq, Default)]
+/// #         pub struct Image {
+/// #             pub data: Vec<u8>,
+/// #         }
+/// # 
+/// #         impl Image {
+/// #             fn new() -> Self { 
+/// #                 Self { data: vec![] }
+/// #             }
+/// #         }
+/// #
+/// #         impl rosrust::Message for Image {
+/// #             fn msg_definition() -> String { String::new() }
+/// #             fn md5sum() -> String { String::new() }
+/// #             fn msg_type() -> String { String::new() }
+/// #         }
+/// #
+/// #         impl rosrust::RosMsg for Image {
+/// #             fn encode<W: io::Write>(&self, mut w: W) -> io::Result<()> { Ok(()) }
+/// #             fn decode<R: io::Read>(mut r: R) -> io::Result<Self> { Ok(Self::new()) }
+/// #         }
+/// #     }
+/// # };
+/// fn ros_image_to_bytes(input: &rosrust_msg::sensor_msgs::Image) -> Vec<Message<Vec<u8>>> {
+///     vec![Message::new_message(Timestamp::Time(vec![0 as u64]), input.data.clone())]
 /// }
 ///
 /// let ros_source_config = OperatorConfig::new().name("FromRosImage");

--- a/erdos/src/dataflow/operators/ros/from_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/from_ros_operator.rs
@@ -33,9 +33,9 @@ use std::sync::{Arc, Mutex};
 /// #         pub struct Image {
 /// #             pub data: Vec<u8>,
 /// #         }
-/// # 
+/// #
 /// #         impl Image {
-/// #             fn new() -> Self { 
+/// #             fn new() -> Self {
 /// #                 Self { data: vec![] }
 /// #             }
 /// #         }

--- a/erdos/src/dataflow/operators/ros/from_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/from_ros_operator.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex};
 /// which takes a [`rosrust_msg::sensor_msgs::Image`] and returns an ERDOS message containing
 /// [`Vec<u8>`] a vector of bytes.
 ///
-/// ```no_run
+/// ```
 /// # use erdos::{
 /// #     dataflow::{Message, operators::ros::FromRosOperator, Timestamp},
 /// #     OperatorConfig,

--- a/erdos/src/dataflow/operators/ros/to_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/to_ros_operator.rs
@@ -29,9 +29,9 @@ use std::sync::Arc;
 /// #         pub struct Int32 {
 /// #             pub data: i32,
 /// #         }
-/// # 
+/// #
 /// #         impl Int32 {
-/// #             fn new() -> Self { 
+/// #             fn new() -> Self {
 /// #                 Self { data: 0 }
 /// #             }
 /// #         }

--- a/erdos/src/dataflow/operators/ros/to_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/to_ros_operator.rs
@@ -9,23 +9,57 @@ use std::sync::Arc;
 /// the [`rosrust::Message`] trait.
 ///
 /// # Example
-/// The following example shows how to use a [`ToRosOperator`] with a conversion function which takes
-/// a Rust [`i32`] and converts it to a ROS message with [`rosrust_msg::std_msgs::Int32`] data.
+/// The following example shows how to use a [`ToRosOperator`] with a conversion function which
+/// takes a Rust [`i32`] and converts it to a ROS message with [`rosrust_msg::std_msgs::Int32`]
+/// data.
 ///
 /// Assume that `source_stream` is an ERDOS stream sending the correct messages.
 ///
-/// ```
+/// ```no_run
+/// # use erdos::{
+/// #     dataflow::{Message, operators::ros::ToRosOperator, stream::IngestStream},
+/// #     OperatorConfig
+/// # };
+/// #
+/// # pub mod rosrust_msg {
+/// #     pub mod std_msgs {
+/// #         use std::io;
+/// #
+/// #         #[derive(Debug, Clone, PartialEq, Default)]
+/// #         pub struct Int32 {
+/// #             pub data: i32,
+/// #         }
+/// # 
+/// #         impl Int32 {
+/// #             fn new() -> Self { 
+/// #                 Self { data: 0 }
+/// #             }
+/// #         }
+/// #
+/// #         impl rosrust::Message for Int32 {
+/// #             fn msg_definition() -> String { String::new() }
+/// #             fn md5sum() -> String { String::new() }
+/// #             fn msg_type() -> String { String::new() }
+/// #         }
+/// #
+/// #         impl rosrust::RosMsg for Int32 {
+/// #             fn encode<W: io::Write>(&self, mut w: W) -> io::Result<()> { Ok(()) }
+/// #             fn decode<R: io::Read>(mut r: R) -> io::Result<Self> { Ok(Self::new()) }
+/// #         }
+/// #     }
+/// # };
 /// fn erdos_int_to_ros_int(input: &Message<i32>) -> Vec<rosrust_msg::std_msgs::Int32> {
 ///     match input.data() {
 ///         Some(x) => {
 ///             vec![rosrust_msg::std_msgs::Int32 {
-///                 data: x,
+///                 data: *x,
 ///             }]
 ///         }
 ///         None => vec![],
 ///     }
 /// }
 ///
+/// # let source_stream = IngestStream::new();
 /// let ros_sink_config = OperatorConfig::new().name("ToRosInt32");
 /// erdos::connect_sink(
 ///     move || -> ToRosOperator<i32, rosrust_msg::std_msgs::Int32> {
@@ -59,7 +93,8 @@ where
         }
     }
 
-    // Converts ERDOS message using conversion function and publishes all messages in returned vector
+    // Converts ERDOS message using conversion function and publishes all messages in
+    // returned vector
     fn convert_and_publish(&mut self, ctx: &mut SinkContext<()>, erdos_msg: &Message<T>) {
         let ros_msg_vec = (self.to_ros_msg)(erdos_msg);
 

--- a/erdos/src/dataflow/operators/ros/to_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/to_ros_operator.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 ///
 /// Assume that `source_stream` is an ERDOS stream sending the correct messages.
 ///
-/// ```no_run
+/// ```
 /// # use erdos::{
 /// #     dataflow::{Message, operators::ros::ToRosOperator, stream::IngestStream},
 /// #     OperatorConfig

--- a/erdos/src/dataflow/operators/ros/to_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/to_ros_operator.rs
@@ -30,12 +30,6 @@ use std::sync::Arc;
 /// #             pub data: i32,
 /// #         }
 /// #
-/// #         impl Int32 {
-/// #             fn new() -> Self {
-/// #                 Self { data: 0 }
-/// #             }
-/// #         }
-/// #
 /// #         impl rosrust::Message for Int32 {
 /// #             fn msg_definition() -> String { String::new() }
 /// #             fn md5sum() -> String { String::new() }
@@ -44,7 +38,7 @@ use std::sync::Arc;
 /// #
 /// #         impl rosrust::RosMsg for Int32 {
 /// #             fn encode<W: io::Write>(&self, mut w: W) -> io::Result<()> { Ok(()) }
-/// #             fn decode<R: io::Read>(mut r: R) -> io::Result<Self> { Ok(Self::new()) }
+/// #             fn decode<R: io::Read>(mut r: R) -> io::Result<Self> { Ok(Default::default()) }
 /// #         }
 /// #     }
 /// # };

--- a/erdos/src/dataflow/stream/extract_stream.rs
+++ b/erdos/src/dataflow/stream/extract_stream.rs
@@ -30,7 +30,7 @@ use super::{
 /// The below example shows how to use an [`IngestStream`](crate::dataflow::stream::IngestStream)
 /// to send data to a [`MapOperator`](crate::dataflow::operators::MapOperator),
 /// and retrieve the processed values through an [`ExtractStream`].
-/// ```
+/// ```no_run
 /// # use erdos::dataflow::{
 /// #    stream::{IngestStream, ExtractStream},
 /// #    operators::MapOperator,

--- a/erdos/src/dataflow/stream/ingest_stream.rs
+++ b/erdos/src/dataflow/stream/ingest_stream.rs
@@ -26,7 +26,7 @@ use super::{errors::SendError, StreamId, WriteStream, WriteStreamT};
 /// [`MapOperator`](crate::dataflow::operators::MapOperator),
 /// and retrieve the processed values through an
 /// [`ExtractStream`](crate::dataflow::stream::ExtractStream).
-/// ```
+/// ```no_run
 /// # use erdos::dataflow::{
 /// #    stream::{IngestStream, ExtractStream},
 /// #    operators::MapOperator,


### PR DESCRIPTION
- Mocks `rosrust_msg` library for the ROS doctests.
- Only compiles (and does not run) the tests for `IngestStream` and `ExtractStream` since they run a ROS node.