### PR TITLE
[LINQ] Replace MapOperator with FlatMapOperator, and add flat_map to API.

### DIFF
--- a/erdos/src/dataflow/operators/concat.rs
+++ b/erdos/src/dataflow/operators/concat.rs
@@ -56,10 +56,11 @@ where
     fn on_watermark(&mut self, _ctx: &mut TwoInOneOutContext<(), D>) {}
 }
 
-/// Convenience trait for merging the contents of two streams.
+/// Extension trait for merging the contents of two streams.
 ///
-/// Names the [`ConcatOperator`] using the names of the two merged streams,
-/// in the format `concat-{left_stream_name}-{right_stream_name}`.
+/// Names the [`ConcatOperator`] using the names of the two merged streams.
+///
+/// # Example
 /// ```
 /// # use erdos::dataflow::{stream::{IngestStream, Stream}, operator::OperatorConfig, operators::Concat};
 /// # let left_stream: IngestStream<usize> = IngestStream::new();

--- a/erdos/src/dataflow/operators/map.rs
+++ b/erdos/src/dataflow/operators/map.rs
@@ -140,7 +140,7 @@ where
         F: 'static + Fn(&D1) -> I + Send + Sync + Clone,
         I: 'static + IntoIterator<Item = D2>,
     {
-        let op_name = format!("FlatMapOp_{}", self.name());
+        let op_name = format!("FlatMapOp_{}", self.id());
 
         crate::connect_one_in_one_out(
             move || -> FlatMapOperator<D1, _> { FlatMapOperator::new(flat_map_fn.clone()) },

--- a/erdos/src/dataflow/operators/map.rs
+++ b/erdos/src/dataflow/operators/map.rs
@@ -10,77 +10,90 @@ use crate::dataflow::{
     Data,
 };
 
-/// Maps an incoming stream of type D1 to a stream of type D2 using the provided
+/// Maps an incoming stream of type D to a stream of type `I::Item` using the provided
 /// function.
 ///
 /// # Example
-/// The below example shows how to use a MapOperator to double an incoming stream of usize
+/// The below example shows how to use a [`FlatMapOperator`] to double an incoming stream of usize
 /// messages, and return them.
 ///
-/// ```
-/// # use erdos::dataflow::{stream::IngestStream, operator::{OperatorConfig}, operators::{MapOperator}};
+/// ```F
+/// # use erdos::dataflow::{stream::IngestStream, operator::{OperatorConfig}, operators::{FlatMapOperator}};
 /// # let source_stream = IngestStream::new();
 /// let map_stream = erdos::connect_one_in_one_out(
-///     || -> MapOperator<usize, usize> { MapOperator::new(|a: &usize| -> usize { 2 * a }) },
+///     || -> FlatMapOperator<usize, usize, _> { MapOperator::new(|a: &usize| -> Vec<usize> { vec![2 * a] }) },
 ///     || {},
-///     OperatorConfig::new().name("MapOperator"),
+///     OperatorConfig::new().name("FlatMapOperator"),
 ///     &source_stream,
 /// );
 /// ```
-pub struct MapOperator<D1, D2>
+pub struct FlatMapOperator<D, I>
 where
-    D1: Data + for<'a> Deserialize<'a>,
-    D2: Data + for<'a> Deserialize<'a>,
+    D: Data + for<'a> Deserialize<'a>,
+    I: IntoIterator,
+    I::Item: Data + for<'a> Deserialize<'a>,
 {
-    map_function: Arc<dyn Fn(&D1) -> D2 + Send + Sync>,
+    flat_map_fn: Arc<dyn Fn(&D) -> I + Send + Sync>,
 }
 
-impl<D1, D2> MapOperator<D1, D2>
+impl<D, I> FlatMapOperator<D, I>
 where
-    D1: Data + for<'a> Deserialize<'a>,
-    D2: Data + for<'a> Deserialize<'a>,
+    D: Data + for<'a> Deserialize<'a>,
+    I: IntoIterator,
+    I::Item: Data + for<'a> Deserialize<'a>,
 {
-    pub fn new<F>(map_function: F) -> Self
+    pub fn new<F>(flat_map_fn: F) -> Self
     where
-        F: 'static + Fn(&D1) -> D2 + Send + Sync,
+        F: 'static + Fn(&D) -> I + Send + Sync,
     {
         Self {
-            map_function: Arc::new(map_function),
+            flat_map_fn: Arc::new(flat_map_fn),
         }
     }
 }
 
-impl<D1, D2> OneInOneOut<(), D1, D2> for MapOperator<D1, D2>
+impl<D, I> OneInOneOut<(), D, I::Item> for FlatMapOperator<D, I>
 where
-    D1: Data + for<'a> Deserialize<'a>,
-    D2: Data + for<'a> Deserialize<'a>,
+    D: Data + for<'a> Deserialize<'a>,
+    I: IntoIterator,
+    I::Item: Data + for<'a> Deserialize<'a>,
 {
-    fn on_data(&mut self, ctx: &mut OneInOneOutContext<(), D2>, data: &D1) {
-        let timestamp = ctx.get_timestamp().clone();
-        ctx.get_write_stream()
-            .send(Message::new_message(timestamp, (self.map_function)(data)))
-            .unwrap();
-        tracing::debug!(
-            "{} @ {:?}: received {:?} and sent {:?}",
-            ctx.get_operator_config().get_name(),
-            ctx.get_timestamp(),
-            data,
-            (self.map_function)(data)
-        );
+    fn on_data(&mut self, ctx: &mut OneInOneOutContext<(), I::Item>, data: &D) {
+        tracing::info!("on data");
+        for item in (self.flat_map_fn)(data).into_iter() {
+            tracing::debug!(
+                "{} @ {:?}: received {:?} and sending {:?}",
+                ctx.get_operator_config().get_name(),
+                ctx.get_timestamp(),
+                data,
+                item,
+            );
+
+            let timestamp = ctx.get_timestamp().clone();
+            let msg = Message::new_message(timestamp, item);
+            ctx.get_write_stream().send(msg).unwrap();
+        }
     }
 
-    fn on_watermark(&mut self, _ctx: &mut OneInOneOutContext<(), D2>) {}
+    fn on_watermark(&mut self, _ctx: &mut OneInOneOutContext<(), I::Item>) {
+        tracing::info!("{}: got watermark", _ctx.get_operator_config().get_name());
+    }
 }
 
 // Extension Trait for MapOperator
-pub trait Map<D1, D2>
+pub trait Map<D, D2>
 where
-    D1: Data + for<'a> Deserialize<'a>,
+    D: Data + for<'a> Deserialize<'a>,
     D2: Data + for<'a> Deserialize<'a>,
 {
     fn map<F>(&self, map_fn: F) -> Stream<D2>
     where
-        F: 'static + Fn(&D1) -> D2 + Send + Sync + Clone;
+        F: 'static + Fn(&D) -> D2 + Send + Sync + Clone;
+
+    fn flat_map<F, I>(&self, flat_map_fn: F) -> Stream<D2>
+    where
+        F: 'static + Fn(&D) -> I + Send + Sync + Clone,
+        I: 'static + IntoIterator<Item = D2>;
 }
 
 impl<D1, D2> Map<D1, D2> for Stream<D1>
@@ -95,7 +108,25 @@ where
         let op_name = format!("MapOp_{}", self.id());
 
         crate::connect_one_in_one_out(
-            move || -> MapOperator<D1, D2> { MapOperator::new(map_fn.clone()) },
+            move || -> FlatMapOperator<D1, _> {
+                let map_fn = map_fn.clone();
+                FlatMapOperator::new(move |x| std::iter::once(map_fn(x)))
+            },
+            || {},
+            OperatorConfig::new().name(&op_name),
+            self,
+        )
+    }
+
+    fn flat_map<F, I>(&self, flat_map_fn: F) -> Stream<D2>
+    where
+        F: 'static + Fn(&D1) -> I + Send + Sync + Clone,
+        I: 'static + IntoIterator<Item = D2>,
+    {
+        let op_name = format!("MapOp_{}", self.id());
+
+        crate::connect_one_in_one_out(
+            move || -> FlatMapOperator<D1, _> { FlatMapOperator::new(flat_map_fn.clone()) },
             || {},
             OperatorConfig::new().name(&op_name),
             self,

--- a/erdos/src/dataflow/operators/map.rs
+++ b/erdos/src/dataflow/operators/map.rs
@@ -61,9 +61,8 @@ where
     I::Item: Data + for<'a> Deserialize<'a>,
 {
     fn on_data(&mut self, ctx: &mut OneInOneOutContext<(), I::Item>, data: &D) {
-        tracing::info!("on data");
         for item in (self.flat_map_fn)(data).into_iter() {
-            tracing::debug!(
+            tracing::trace!(
                 "{} @ {:?}: received {:?} and sending {:?}",
                 ctx.get_operator_config().get_name(),
                 ctx.get_timestamp(),
@@ -77,9 +76,7 @@ where
         }
     }
 
-    fn on_watermark(&mut self, _ctx: &mut OneInOneOutContext<(), I::Item>) {
-        tracing::info!("{}: got watermark", _ctx.get_operator_config().get_name());
-    }
+    fn on_watermark(&mut self, _ctx: &mut OneInOneOutContext<(), I::Item>) {}
 }
 
 /// Extension trait for mapping a stream of type `D1` to a stream of type `D2`.

--- a/erdos/src/dataflow/operators/mod.rs
+++ b/erdos/src/dataflow/operators/mod.rs
@@ -15,5 +15,5 @@ mod split;
 // pub use crate::dataflow::operators::join_operator::JoinOperator;
 pub use concat::{Concat, ConcatOperator};
 pub use filter::{Filter, FilterOperator};
-pub use map::{Map, MapOperator};
+pub use map::{FlatMapOperator, Map};
 pub use split::{Split, SplitOperator};

--- a/erdos/src/dataflow/stream/extract_stream.rs
+++ b/erdos/src/dataflow/stream/extract_stream.rs
@@ -32,8 +32,8 @@ use super::{
 /// and retrieve the processed values through an [`ExtractStream`].
 /// ```no_run
 /// # use erdos::dataflow::{
-/// #    stream::{IngestStream, ExtractStream},
-/// #    operators::MapOperator,
+/// #    stream::{IngestStream, ExtractStream, Stream},
+/// #    operators::FlatMapOperator,
 /// #    OperatorConfig, Message, Timestamp
 /// # };
 /// # use erdos::*;
@@ -45,13 +45,14 @@ use super::{
 /// // Create an IngestStream.
 /// let mut ingest_stream = IngestStream::new();
 ///
-/// // Create an ExtractStream from the ReadStream of the MapOperator.
-/// let operator_stream = erdos::connect_one_in_one_out(
-///     || { MapOperator::new(|data: &u32| -> u64 { (2 * data) as u64 }) },
+/// // Create an ExtractStream from the ReadStream of the FlatMapOperator.
+/// let output_stream = erdos::connect_one_in_one_out(
+///     || FlatMapOperator::new(|x: &usize| { std::iter::once(2 * x) }),
 ///     || {},
 ///     OperatorConfig::new().name("MapOperator"),
-///     &ingest_stream);
-/// let mut extract_stream = ExtractStream::new(&operator_stream);
+///     &ingest_stream,
+/// );
+/// let mut extract_stream = ExtractStream::new(&output_stream);
 ///
 /// node.run_async();
 ///
@@ -62,7 +63,7 @@ use super::{
 ///
 /// // Retrieve mapped values using an ExtractStream.
 /// for i in 1..10 {
-///     let message: Message<u64> = extract_stream.read().unwrap();
+///     let message = extract_stream.read().unwrap();
 ///     assert_eq!(*message.data().unwrap(), 2 * i);
 /// }
 /// ```

--- a/erdos/src/dataflow/stream/ingest_stream.rs
+++ b/erdos/src/dataflow/stream/ingest_stream.rs
@@ -28,8 +28,8 @@ use super::{errors::SendError, StreamId, WriteStream, WriteStreamT};
 /// [`ExtractStream`](crate::dataflow::stream::ExtractStream).
 /// ```no_run
 /// # use erdos::dataflow::{
-/// #    stream::{IngestStream, ExtractStream},
-/// #    operators::MapOperator,
+/// #    stream::{IngestStream, ExtractStream, Stream},
+/// #    operators::FlatMapOperator,
 /// #    OperatorConfig, Message, Timestamp
 /// # };
 /// # use erdos::*;
@@ -41,13 +41,14 @@ use super::{errors::SendError, StreamId, WriteStream, WriteStreamT};
 /// // Create an IngestStream.
 /// let mut ingest_stream = IngestStream::new();
 ///
-/// // Create an ExtractStream from the ReadStream of the MapOperator.
-/// let operator_stream = erdos::connect_one_in_one_out(
-///     || { MapOperator::new(|data: &u32| -> u64 { (2 * data) as u64 }) },
+/// // Create an ExtractStream from the ReadStream of the FlatMapOperator.
+/// let output_stream = erdos::connect_one_in_one_out(
+///     || FlatMapOperator::new(|x: &usize| { std::iter::once(2 * x) }),
 ///     || {},
 ///     OperatorConfig::new().name("MapOperator"),
-///     &ingest_stream);
-/// let mut extract_stream = ExtractStream::new(&operator_stream);
+///     &ingest_stream,
+/// );
+/// let mut extract_stream = ExtractStream::new(&output_stream);
 ///
 /// node.run_async();
 ///
@@ -58,7 +59,7 @@ use super::{errors::SendError, StreamId, WriteStream, WriteStreamT};
 ///
 /// // Retrieve mapped values using an ExtractStream.
 /// for i in 1..10 {
-///     let message: Message<u64> = extract_stream.read().unwrap();
+///     let message = extract_stream.read().unwrap();
 ///     assert_eq!(*message.data().unwrap(), 2 * i);
 /// }
 /// ```

--- a/erdos/src/dataflow/stream/loop_stream.rs
+++ b/erdos/src/dataflow/stream/loop_stream.rs
@@ -10,10 +10,10 @@ use super::{Stream, StreamId};
 ///
 /// # Example
 /// ```
-/// # use erdos::dataflow::{stream::LoopStream, operator::{OperatorConfig}, operators::{MapOperator}};
+/// # use erdos::dataflow::{stream::LoopStream, operator::{OperatorConfig}, operators::{FlatMapOperator}};
 /// let loop_stream = LoopStream::new();
 /// let output_stream = erdos::connect_one_in_one_out(
-///     || -> MapOperator<usize, usize> { MapOperator::new(|a: &usize| -> usize { 2 * a }) },
+///     || FlatMapOperator::new(|x: &usize| { std::iter::once(2 * x) }),
 ///     || {},
 ///     OperatorConfig::new().name("MapOperator"),
 ///     &loop_stream,

--- a/examples/full_pipeline.rs
+++ b/examples/full_pipeline.rs
@@ -387,9 +387,11 @@ fn main() {
         &source_stream,
     );
 
-    let map_config = OperatorConfig::new().name("MapOperator");
+    let map_config = OperatorConfig::new().name("FlatMapOperator");
     let map_stream = erdos::connect_one_in_one_out(
-        || -> MapOperator<usize, usize> { MapOperator::new(|a: &usize| -> usize { 2 * a }) },
+        || -> FlatMapOperator<usize, _> {
+            FlatMapOperator::new(|a: &usize| std::iter::once(2 * a))
+        },
         || {},
         map_config,
         &square_stream,

--- a/examples/full_pipeline.rs
+++ b/examples/full_pipeline.rs
@@ -390,7 +390,7 @@ fn main() {
     let map_config = OperatorConfig::new().name("FlatMapOperator");
     let map_stream = erdos::connect_one_in_one_out(
         || -> FlatMapOperator<usize, _> {
-            FlatMapOperator::new(|a: &usize| std::iter::once(2 * a))
+            FlatMapOperator::new(|x: &usize| std::iter::once(2 * x))
         },
         || {},
         map_config,
@@ -399,7 +399,7 @@ fn main() {
 
     let filter_config = OperatorConfig::new().name("FilterOperator");
     let filter_stream = erdos::connect_one_in_one_out(
-        || -> FilterOperator<usize> { FilterOperator::new(|a: &usize| -> bool { a > &10 }) },
+        || -> FilterOperator<usize> { FilterOperator::new(|x: &usize| -> bool { *x > 10 }) },
         || {},
         filter_config,
         &map_stream,
@@ -407,7 +407,7 @@ fn main() {
 
     let split_config = OperatorConfig::new().name("SplitOperator");
     let (split_stream_less_50, split_stream_greater_50) = erdos::connect_one_in_two_out(
-        || -> SplitOperator<usize> { SplitOperator::new(|a: &usize| -> bool { a < &50 }) },
+        || -> SplitOperator<usize> { SplitOperator::new(|x: &usize| -> bool { *x < 50 }) },
         || {},
         split_config,
         &filter_stream,

--- a/examples/linq.rs
+++ b/examples/linq.rs
@@ -106,9 +106,9 @@ fn main() {
     let source_stream = erdos::connect_source(SourceOperator::new, || {}, source_config);
 
     let (split_stream_less_50, split_stream_greater_50) = source_stream
-        .map(|a: &usize| -> usize { 2 * a })
-        .filter(|a: &usize| -> bool { a > &10 })
-        .split(|a: &usize| -> bool { a < &50 });
+        .map(|x: &usize| -> usize { 2 * x })
+        .filter(|x: &usize| -> bool { x > &10 })
+        .split(|x: &usize| -> bool { x < &50 });
 
     let left_sink_config = OperatorConfig::new().name("LeftSinkOperator");
     erdos::connect_sink(


### PR DESCRIPTION
- Replaces `MapOperator` with a more general `FlatMapOperator`.
- Updates documentation.
- Fixes examples and tests.