### PR TITLE
[CI] Enable Clippy linting and separate formatting checks.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Check Python imports
         uses: isort/isort-action@master
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,21 +60,16 @@ jobs:
           source /opt/ros/$ROS_DISTRO/setup.bash
           cargo test --verbose --features=ros
 
-  build-python:
-    name: "Python ${{ matrix.python-version }} Build"
+  format-python:
+    name: "Python Formatting"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup python
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Python dependencies
-        run: |
-          python -m pip install maturin toml flake8==3.9.2 flake8-quotes
+          python-version: 3.10
       - name: Check Python imports
         uses: isort/isort-action@master
         with:
@@ -85,8 +80,27 @@ jobs:
           options: "--check --diff --color"
       - name: Check Flake8 compatibility
         run: |
+          python -m pip install flake8==3.9.2 flake8-quotes
           flake8 --inline-quotes="double" ./python/doc/
           flake8 --inline-quotes="double" ./python/
+
+
+  build-python:
+    name: "Python ${{ matrix.python-version }} Build"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+    needs: format-python
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python dependencies
+        run: |
+          python -m pip install maturin
       - name: Install supported Rust nightly
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,8 @@ jobs:
           profile: minimal
           override: true
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v1
+      - name: Cache Rust package builds
+        uses: Swatinem/rust-cache@v1
       - name: Check Rust formatting
         run: cargo fmt -- --check
       - name: Check Clippy linting
@@ -36,7 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: format-rust
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
       - name: Install supported Rust nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -44,7 +46,8 @@ jobs:
           profile: minimal
           override: true
           components: rust-src
-      - uses: Swatinem/rust-cache@v1
+      - name: Cache Rust package builds
+        uses: Swatinem/rust-cache@v1
       - name: Build
         run: cargo build --examples --verbose
       - name: Run tests
@@ -56,7 +59,8 @@ jobs:
     container: ros:noetic
     needs: format-rust
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
       - name: Install curl
         run: apt-get update; apt-get install curl
       - name: Install supported Rust nightly
@@ -66,7 +70,8 @@ jobs:
           profile: minimal
           override: true
           components: rust-src
-      - uses: Swatinem/rust-cache@v1
+      - name: Cache Rust package builds
+        uses: Swatinem/rust-cache@v1
       - name: Build
         shell: bash
         run: |
@@ -110,7 +115,8 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     needs: [format-python, format-rust]
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -122,7 +128,8 @@ jobs:
           profile: minimal
           override: true
           components: rust-src
-      - uses: Swatinem/rust-cache@v1
+      - name: Cache Rust package builds
+        uses: Swatinem/rust-cache@v1
       - name: Build
         run: |
           python -m pip install maturin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,6 @@ jobs:
         run: cargo fmt -- --check
       - name: Check Clippy linting
         run: cargo clippy --all --tests --all-features -- -A clippy::needless_option_as_deref
-
         
   build-rust:
     name: "Rust Build"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Install supported Rust nightly
+      - name: Install Rust ${{ env.rust_toolchain }} 
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.rust_toolchain }}
@@ -38,13 +38,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Install supported Rust nightly
+      - name: Install Rust ${{ env.rust_toolchain }} 
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.rust_toolchain }}
           profile: minimal
           override: true
-          components: rust-src
       - name: Cache Rust package builds
         uses: Swatinem/rust-cache@v1
       - name: Build
@@ -62,13 +61,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Install curl
         run: apt-get update; apt-get install curl
-      - name: Install supported Rust nightly
+      - name: Install Rust ${{ env.rust_toolchain }} 
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.rust_toolchain }}
           profile: minimal
           override: true
-          components: rust-src
       - name: Cache Rust package builds
         uses: Swatinem/rust-cache@v1
       - name: Build
@@ -120,7 +118,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install supported Rust nightly
+      - name: Install Rust ${{ env.rust_toolchain }} 
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.rust_toolchain }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,6 @@ jobs:
           toolchain: ${{ env.rust_toolchain }}
           profile: minimal
           override: true
-          components: rust-src
       - name: Cache Rust package builds
         uses: Swatinem/rust-cache@v1
       - name: Build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-    needs: format-python, format-rust
+    needs: [format-python, format-rust]
     steps:
       - uses: actions/checkout@v2
       - name: Setup python

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: '3.10'
       - name: Check Python imports
         uses: isort/isort-action@master
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,30 @@ env:
   rust_toolchain: nightly-2022-02-09
 
 jobs:
+  format-rust:
+    name: "Rust Formatting"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install supported Rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.rust_toolchain }}
+          profile: minimal
+          override: true
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v1
+      - name: Check Rust formatting
+        run: cargo fmt -- --check
+      - name: Check Clippy linting
+        run: cargo clippy --all --tests --all-features -- -A clippy::needless_option_as_deref
+
+        
   build-rust:
     name: "Rust Build"
     runs-on: ubuntu-latest
+    needs: format-rust
     steps:
       - uses: actions/checkout@v2
       - name: Install supported Rust nightly
@@ -22,10 +43,8 @@ jobs:
           toolchain: ${{ env.rust_toolchain }}
           profile: minimal
           override: true
-          components: rustfmt, rust-src
+          components: rust-src
       - uses: Swatinem/rust-cache@v1
-      - name: Check Rust formatting
-        run: cargo fmt -- --check
       - name: Build
         run: cargo build --examples --verbose
       - name: Run tests
@@ -35,6 +54,7 @@ jobs:
     name: "ROS Integration"
     runs-on: ubuntu-latest
     container: ros:noetic
+    needs: format-rust
     steps:
       - uses: actions/checkout@v2
       - name: Install curl
@@ -45,10 +65,8 @@ jobs:
           toolchain: ${{ env.rust_toolchain }}
           profile: minimal
           override: true
-          components: rustfmt, rust-src
+          components: rust-src
       - uses: Swatinem/rust-cache@v1
-      - name: Check Rust formatting
-        run: cargo fmt -- --check
       - name: Build
         shell: bash
         run: |
@@ -90,7 +108,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-    needs: format-python
+    needs: format-python, format-rust
     steps:
       - uses: actions/checkout@v2
       - name: Setup python
@@ -103,7 +121,7 @@ jobs:
           toolchain: ${{ env.rust_toolchain }}
           profile: minimal
           override: true
-          components: rustfmt, rust-src
+          components: rust-src
       - uses: Swatinem/rust-cache@v1
       - name: Build
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,6 @@ jobs:
           flake8 --inline-quotes="double" ./python/doc/
           flake8 --inline-quotes="double" ./python/
 
-
   build-python:
     name: "Python ${{ matrix.python-version }} Build"
     runs-on: ubuntu-latest
@@ -98,9 +97,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Python dependencies
-        run: |
-          python -m pip install maturin
       - name: Install supported Rust nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -110,4 +106,6 @@ jobs:
           components: rustfmt, rust-src
       - uses: Swatinem/rust-cache@v1
       - name: Build
-        run: cd python && maturin build
+        run: |
+          python -m pip install maturin
+          cd python && maturin build

--- a/erdos/src/communication/control_message_handler.rs
+++ b/erdos/src/communication/control_message_handler.rs
@@ -39,7 +39,7 @@ impl ControlMessageHandler {
         node_id: NodeId,
         tx: UnboundedSender<ControlMessage>,
     ) {
-        if let Some(_) = self.channels_to_control_senders.insert(node_id, tx) {
+        if self.channels_to_control_senders.insert(node_id, tx).is_some() {
             tracing::error!(
                 "ControlMessageHandler: overwrote channel to control sender for node {}",
                 node_id
@@ -73,7 +73,7 @@ impl ControlMessageHandler {
         node_id: NodeId,
         tx: UnboundedSender<ControlMessage>,
     ) {
-        if let Some(_) = self.channels_to_control_receivers.insert(node_id, tx) {
+        if self.channels_to_control_receivers.insert(node_id, tx).is_some() {
             tracing::error!(
                 "ControlMessageHandler: overwrote channel to control receiver for node {}",
                 node_id
@@ -107,7 +107,7 @@ impl ControlMessageHandler {
         node_id: NodeId,
         tx: UnboundedSender<ControlMessage>,
     ) {
-        if let Some(_) = self.channels_to_data_senders.insert(node_id, tx) {
+        if self.channels_to_data_senders.insert(node_id, tx).is_some() {
             tracing::error!(
                 "ControlMessageHandler: overwrote channel to data sender for node {}",
                 node_id
@@ -141,7 +141,7 @@ impl ControlMessageHandler {
         node_id: NodeId,
         tx: UnboundedSender<ControlMessage>,
     ) {
-        if let Some(_) = self.channels_to_data_receivers.insert(node_id, tx) {
+        if self.channels_to_data_receivers.insert(node_id, tx).is_some() {
             tracing::error!(
                 "ControlMessageHandler: overwrote channel to data receiver for node {}",
                 node_id

--- a/erdos/src/communication/control_message_handler.rs
+++ b/erdos/src/communication/control_message_handler.rs
@@ -39,7 +39,11 @@ impl ControlMessageHandler {
         node_id: NodeId,
         tx: UnboundedSender<ControlMessage>,
     ) {
-        if self.channels_to_control_senders.insert(node_id, tx).is_some() {
+        if self
+            .channels_to_control_senders
+            .insert(node_id, tx)
+            .is_some()
+        {
             tracing::error!(
                 "ControlMessageHandler: overwrote channel to control sender for node {}",
                 node_id
@@ -73,7 +77,11 @@ impl ControlMessageHandler {
         node_id: NodeId,
         tx: UnboundedSender<ControlMessage>,
     ) {
-        if self.channels_to_control_receivers.insert(node_id, tx).is_some() {
+        if self
+            .channels_to_control_receivers
+            .insert(node_id, tx)
+            .is_some()
+        {
             tracing::error!(
                 "ControlMessageHandler: overwrote channel to control receiver for node {}",
                 node_id
@@ -141,7 +149,11 @@ impl ControlMessageHandler {
         node_id: NodeId,
         tx: UnboundedSender<ControlMessage>,
     ) {
-        if self.channels_to_data_receivers.insert(node_id, tx).is_some() {
+        if self
+            .channels_to_data_receivers
+            .insert(node_id, tx)
+            .is_some()
+        {
             tracing::error!(
                 "ControlMessageHandler: overwrote channel to data receiver for node {}",
                 node_id

--- a/erdos/src/communication/mod.rs
+++ b/erdos/src/communication/mod.rs
@@ -96,7 +96,7 @@ pub async fn create_tcp_streams(
     node_addrs: Vec<SocketAddr>,
     node_id: NodeId,
 ) -> Vec<(NodeId, TcpStream)> {
-    let node_addr = node_addrs[node_id].clone();
+    let node_addr = node_addrs[node_id];
     // Connect to the nodes that have a lower id than the node.
     let connect_streams_fut = connect_to_nodes(node_addrs[..node_id].to_vec(), node_id);
     // Wait for connections from the nodes that have a higher id than the node.
@@ -208,7 +208,7 @@ async fn await_node_connections(
         await_futures.push(read_node_id(stream));
     }
     // Await until we've received `expected_conns` node ids.
-    Ok(future::try_join_all(await_futures).await?)
+    future::try_join_all(await_futures).await
 }
 
 /// Reads a node id from a TCP stream.

--- a/erdos/src/communication/serializable.rs
+++ b/erdos/src/communication/serializable.rs
@@ -80,7 +80,7 @@ where
     default fn decode(
         buf: &'a mut BytesMut,
     ) -> Result<DeserializedMessage<'a, D>, CommunicationError> {
-        let msg: D = bincode::deserialize(buf).map_err(|e| CommunicationError::from(e))?;
+        let msg: D = bincode::deserialize(buf).map_err(CommunicationError::from)?;
         Ok(DeserializedMessage::Owned(msg))
     }
 }

--- a/erdos/src/configuration.rs
+++ b/erdos/src/configuration.rs
@@ -60,12 +60,12 @@ impl Configuration {
 
         let data_addrs = args.value_of("data-addresses").unwrap();
         let mut data_addresses: Vec<SocketAddr> = Vec::new();
-        for addr in data_addrs.split(",") {
+        for addr in data_addrs.split(',') {
             data_addresses.push(addr.parse().expect("Unable to parse socket address"));
         }
         let control_addrs = args.value_of("control-addresses").unwrap();
         let mut control_addresses: Vec<SocketAddr> = Vec::new();
-        for addr in control_addrs.split(",") {
+        for addr in control_addrs.split(',') {
             control_addresses.push(addr.parse().expect("Unable to parse socket address"));
         }
         assert_eq!(
@@ -83,7 +83,7 @@ impl Configuration {
             "Node index is larger than number of available nodes"
         );
         let graph_filename_arg = args.value_of("graph-filename").unwrap();
-        let graph_filename = if graph_filename_arg == "" {
+        let graph_filename = if graph_filename_arg.is_empty() {
             None
         } else {
             Some(graph_filename_arg.to_string())

--- a/erdos/src/dataflow/connect.rs
+++ b/erdos/src/dataflow/connect.rs
@@ -44,7 +44,7 @@ where
         };
 
     default_graph::add_operator::<_, (), (), T, ()>(
-        config.clone(),
+        config,
         op_runner,
         None,
         None,
@@ -137,7 +137,7 @@ pub fn connect_sink<O, S, T>(
         };
 
     default_graph::add_operator::<_, T, (), (), ()>(
-        config.clone(),
+        config,
         op_runner,
         Some(read_stream),
         None,
@@ -189,7 +189,7 @@ where
         };
 
     default_graph::add_operator::<_, T, (), U, ()>(
-        config.clone(),
+        config,
         op_runner,
         Some(read_stream),
         None,
@@ -241,7 +241,7 @@ where
         };
 
     default_graph::add_operator::<_, T, (), U, ()>(
-        config.clone(),
+        config,
         op_runner,
         Some(read_stream),
         None,
@@ -302,7 +302,7 @@ where
         };
 
     default_graph::add_operator::<_, T, U, V, ()>(
-        config.clone(),
+        config,
         op_runner,
         Some(left_read_stream),
         Some(right_read_stream),
@@ -361,7 +361,7 @@ where
         };
 
     default_graph::add_operator::<_, T, U, V, ()>(
-        config.clone(),
+        config,
         op_runner,
         Some(left_read_stream),
         Some(right_read_stream),
@@ -424,7 +424,7 @@ where
         };
 
     default_graph::add_operator::<_, T, (), U, V>(
-        config.clone(),
+        config,
         op_runner,
         Some(read_stream),
         None,
@@ -485,7 +485,7 @@ where
         };
 
     default_graph::add_operator::<_, T, (), U, V>(
-        config.clone(),
+        config,
         op_runner,
         Some(read_stream),
         None,

--- a/erdos/src/dataflow/context.rs
+++ b/erdos/src/dataflow/context.rs
@@ -151,7 +151,6 @@ where
     }
 
     /// Get the past state attached to the operator.
-    #[allow(clippy::needless_match)]
     pub fn get_past_state(&mut self, time: &Timestamp) -> Option<&S::Item> {
         if *time <= self.state.last_committed_timestamp() {
             match self.state.at(time) {
@@ -285,7 +284,6 @@ where
     }
 
     /// Get the past state attached to the operator.
-    #[allow(clippy::needless_match)]
     pub fn get_past_state(&mut self, time: &Timestamp) -> Option<&S::Item> {
         if *time <= self.state.last_committed_timestamp() {
             match self.state.at(time) {
@@ -424,7 +422,6 @@ where
     }
 
     /// Get the past state attached to the operator.
-    #[allow(clippy::needless_match)]
     pub fn get_past_state(&mut self, time: &Timestamp) -> Option<&S::Item> {
         if *time <= self.state.last_committed_timestamp() {
             match self.state.at(time) {
@@ -578,7 +575,6 @@ where
     }
 
     /// Get the past state attached to the operator.
-    #[allow(clippy::needless_match)]
     pub fn get_past_state(&mut self, time: &Timestamp) -> Option<&S::Item> {
         if *time <= self.state.last_committed_timestamp() {
             match self.state.at(time) {

--- a/erdos/src/dataflow/context.rs
+++ b/erdos/src/dataflow/context.rs
@@ -104,7 +104,7 @@ where
 
     /// Get the state attached to the operator.
     pub fn get_state(&self) -> &S {
-        &self.state
+        self.state
     }
 }
 
@@ -151,6 +151,7 @@ where
     }
 
     /// Get the past state attached to the operator.
+    #[allow(clippy::needless_match)]
     pub fn get_past_state(&mut self, time: &Timestamp) -> Option<&S::Item> {
         if *time <= self.state.last_committed_timestamp() {
             match self.state.at(time) {
@@ -220,7 +221,7 @@ where
 
     /// Get the state attached to the operator.
     pub fn get_state(&self) -> &S {
-        &self.state
+        self.state
     }
 
     /// Get the write stream to send the output on.
@@ -284,6 +285,7 @@ where
     }
 
     /// Get the past state attached to the operator.
+    #[allow(clippy::needless_match)]
     pub fn get_past_state(&mut self, time: &Timestamp) -> Option<&S::Item> {
         if *time <= self.state.last_committed_timestamp() {
             match self.state.at(time) {
@@ -358,7 +360,7 @@ where
 
     /// Get the state attached to the operator.
     pub fn get_state(&self) -> &S {
-        &self.state
+        self.state
     }
 
     /// Get the write stream to send the output on.
@@ -422,6 +424,7 @@ where
     }
 
     /// Get the past state attached to the operator.
+    #[allow(clippy::needless_match)]
     pub fn get_past_state(&mut self, time: &Timestamp) -> Option<&S::Item> {
         if *time <= self.state.last_committed_timestamp() {
             match self.state.at(time) {
@@ -501,7 +504,7 @@ where
 
     /// Get the state attached to the operator.
     pub fn get_state(&self) -> &S {
-        &self.state
+        self.state
     }
 
     /// Get the left write stream to send the output on.
@@ -575,6 +578,7 @@ where
     }
 
     /// Get the past state attached to the operator.
+    #[allow(clippy::needless_match)]
     pub fn get_past_state(&mut self, time: &Timestamp) -> Option<&S::Item> {
         if *time <= self.state.last_committed_timestamp() {
             match self.state.at(time) {

--- a/erdos/src/dataflow/deadlines.rs
+++ b/erdos/src/dataflow/deadlines.rs
@@ -231,7 +231,7 @@ impl DeadlineEvent {
 /// A ConditionContext contains the count of the number of messages received on a stream along with
 /// the status of the watermark for each timestamp. This data is made available to the start and
 /// end condition functions to decide when to trigger the beginning and completion of deadlines.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ConditionContext {
     message_count: HashMap<(StreamId, Timestamp), usize>,
     watermark_status: HashMap<(StreamId, Timestamp), bool>,
@@ -295,11 +295,5 @@ impl ConditionContext {
                 .chain(other.watermark_status.clone())
                 .collect(),
         }
-    }
-}
-
-impl Default for ConditionContext {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/erdos/src/dataflow/deadlines.rs
+++ b/erdos/src/dataflow/deadlines.rs
@@ -13,8 +13,8 @@ pub type DeadlineId = crate::Uuid;
 /// evaluation of the start and end conditions (s.a. the message counts and the state of the
 /// watermarks on each stream for the given timestamp) and the current timestamp for which the
 /// condition is being executed.
-pub trait CondFn: Fn(&Vec<StreamId>, &ConditionContext, &Timestamp) -> bool + Send + Sync {}
-impl<F: Fn(&Vec<StreamId>, &ConditionContext, &Timestamp) -> bool + Send + Sync> CondFn for F {}
+pub trait CondFn: Fn(&[StreamId], &ConditionContext, &Timestamp) -> bool + Send + Sync {}
+impl<F: Fn(&[StreamId], &ConditionContext, &Timestamp) -> bool + Send + Sync> CondFn for F {}
 
 /// A trait that defines the deadline function. This function receives access to the State of the
 /// operator along with the current timestamp, and must calculate the time after which the deadline
@@ -34,7 +34,7 @@ pub trait DeadlineT<S>: Send + Sync {
 
     fn invoke_start_condition(
         &self,
-        read_stream_ids: &Vec<StreamId>,
+        read_stream_ids: &[StreamId],
         condition_context: &ConditionContext,
         timestamp: &Timestamp,
     ) -> bool;
@@ -113,7 +113,7 @@ where
 
     /// The default start condition of TimestampDeadlines.
     fn default_start_condition(
-        stream_ids: &Vec<StreamId>,
+        stream_ids: &[StreamId],
         condition_context: &ConditionContext,
         current_timestamp: &Timestamp,
     ) -> bool {
@@ -135,7 +135,7 @@ where
 
     /// The default end condition of TimestampDeadlines.
     fn default_end_condition(
-        stream_ids: &Vec<StreamId>,
+        stream_ids: &[StreamId],
         condition_context: &ConditionContext,
         current_timestamp: &Timestamp,
     ) -> bool {
@@ -149,9 +149,7 @@ where
         // If the watermark for the given timestamp has been sent on all the streams, end the
         // deadline.
         for stream_id in stream_ids {
-            if condition_context.get_watermark_status(*stream_id, current_timestamp.clone())
-                == false
-            {
+            if !condition_context.get_watermark_status(*stream_id, current_timestamp.clone()) {
                 return false;
             }
         }
@@ -173,7 +171,7 @@ where
 
     fn invoke_start_condition(
         &self,
-        read_stream_ids: &Vec<StreamId>,
+        read_stream_ids: &[StreamId],
         condition_context: &ConditionContext,
         timestamp: &Timestamp,
     ) -> bool {
@@ -297,5 +295,11 @@ impl ConditionContext {
                 .chain(other.watermark_status.clone())
                 .collect(),
         }
+    }
+}
+
+impl Default for ConditionContext {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/erdos/src/dataflow/graph/abstract_graph.rs
+++ b/erdos/src/dataflow/graph/abstract_graph.rs
@@ -93,7 +93,7 @@ impl AbstractGraph {
         let abstract_operator = AbstractOperator {
             id: operator_id,
             runner: Box::new(runner),
-            config: config,
+            config,
             read_streams,
             write_streams,
         };
@@ -168,7 +168,7 @@ impl AbstractGraph {
     /// Otherwise, returns `stream_id`.
     pub(crate) fn resolve_stream_id(&self, stream_id: &StreamId) -> Option<StreamId> {
         match self.loop_streams.get(stream_id) {
-            Some(connected_stream_id) => connected_stream_id.clone(),
+            Some(connected_stream_id) => *connected_stream_id,
             None => Some(*stream_id),
         }
     }

--- a/erdos/src/dataflow/graph/job_graph.rs
+++ b/erdos/src/dataflow/graph/job_graph.rs
@@ -76,20 +76,24 @@ impl JobGraph {
         self.streams
             .iter()
             .map(|s| {
-                let source = *self.stream_sources.get(&s.id()).expect(&format!(
-                    "Internal error: stream {} (ID: {}) must have a source",
-                    s.name(),
-                    s.id()
-                ));
+                let source = *self.stream_sources.get(&s.id()).unwrap_or_else(|| {
+                    panic!(
+                        "Internal error: stream {} (ID: {}) must have a source",
+                        s.name(),
+                        s.id()
+                    )
+                });
                 let destinations = self
                     .stream_destinations
                     .get(&s.id())
                     .cloned()
-                    .expect(&format!(
-                        "Internal error: stream {} (ID: {}) must have a destination",
-                        s.name(),
-                        s.id()
-                    ));
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "Internal error: stream {} (ID: {}) must have a destination",
+                            s.name(),
+                            s.id()
+                        )
+                    });
                 (s.box_clone(), source, destinations)
             })
             .collect()

--- a/erdos/src/dataflow/message.rs
+++ b/erdos/src/dataflow/message.rs
@@ -51,7 +51,7 @@ impl<D: Data> Message<D> {
     pub fn timestamp(&self) -> &Timestamp {
         match self {
             Self::TimestampedData(d) => &d.timestamp,
-            Self::Watermark(t) => &t,
+            Self::Watermark(t) => t,
         }
     }
 }

--- a/erdos/src/dataflow/operator.rs
+++ b/erdos/src/dataflow/operator.rs
@@ -375,3 +375,9 @@ impl OperatorConfig {
         self.name.clone().unwrap_or_else(|| format!("{}", self.id))
     }
 }
+
+impl Default for OperatorConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/erdos/src/dataflow/operators/concat.rs
+++ b/erdos/src/dataflow/operators/concat.rs
@@ -30,17 +30,12 @@ use crate::{
 ///     &right_stream,
 /// );
 /// ```
+#[derive(Default)]
 pub struct ConcatOperator {}
 
 impl ConcatOperator {
     pub fn new() -> Self {
         Self {}
-    }
-}
-
-impl Default for ConcatOperator {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/erdos/src/dataflow/operators/concat.rs
+++ b/erdos/src/dataflow/operators/concat.rs
@@ -38,6 +38,12 @@ impl ConcatOperator {
     }
 }
 
+impl Default for ConcatOperator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<D: Data> TwoInOneOut<(), D, D, D> for ConcatOperator
 where
     for<'a> D: Data + Deserialize<'a>,

--- a/erdos/src/dataflow/operators/ros/to_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/to_ros_operator.rs
@@ -111,11 +111,11 @@ where
 {
     fn on_data(&mut self, ctx: &mut SinkContext<()>, data: &T) {
         let timestamp = ctx.get_timestamp().clone();
-        self.convert_and_publish(ctx, &Message::new_message(timestamp.clone(), data.clone()));
+        self.convert_and_publish(ctx, &Message::new_message(timestamp, data.clone()));
     }
 
     fn on_watermark(&mut self, ctx: &mut SinkContext<()>) {
         let timestamp = ctx.get_timestamp().clone();
-        self.convert_and_publish(ctx, &Message::new_watermark(timestamp.clone()));
+        self.convert_and_publish(ctx, &Message::new_watermark(timestamp));
     }
 }

--- a/erdos/src/dataflow/state.rs
+++ b/erdos/src/dataflow/state.rs
@@ -58,6 +58,15 @@ where
     }
 }
 
+impl<S> Default for TimeVersionedState<S>
+where
+    S: 'static + Default + Send + Sync,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<S> State for TimeVersionedState<S>
 where
     S: 'static + Default + Send + Sync,

--- a/erdos/src/dataflow/stream/ingest_stream.rs
+++ b/erdos/src/dataflow/stream/ingest_stream.rs
@@ -86,7 +86,7 @@ where
             write_stream_option: Arc::new(Mutex::new(None)),
         };
         default_graph::add_ingest_stream(&ingest_stream);
-        default_graph::set_stream_name(&id, &format!("ingest_stream_{}", id.to_string()));
+        default_graph::set_stream_name(&id, &format!("ingest_stream_{}", id));
 
         ingest_stream
     }
@@ -123,7 +123,7 @@ where
                 default_graph::get_stream_name(&self.id()),
                 self.id(),
             );
-            return Err(SendError::Closed);
+            Err(SendError::Closed)
         }
     }
 
@@ -146,6 +146,15 @@ where
             }
             Err(msg) => panic!("Unable to set up IngestStream {}: {}", id, msg),
         }
+    }
+}
+
+impl<D> Default for IngestStream<D>
+where
+    for<'a> D: Data + Deserialize<'a>,
+{
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/erdos/src/dataflow/stream/loop_stream.rs
+++ b/erdos/src/dataflow/stream/loop_stream.rs
@@ -48,6 +48,15 @@ where
     }
 }
 
+impl<D> Default for LoopStream<D>
+where
+    for<'a> D: Data + Deserialize<'a>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<D> Stream<D> for LoopStream<D>
 where
     for<'a> D: Data + Deserialize<'a>,

--- a/erdos/src/dataflow/stream/write_stream.rs
+++ b/erdos/src/dataflow/stream/write_stream.rs
@@ -219,7 +219,6 @@ impl<'a, D: Data + Deserialize<'a>> WriteStreamT<D> for WriteStream<D> {
                     self.name(),
                     self.id()
                 );
-                ()
             }
         };
 

--- a/erdos/src/lib.rs
+++ b/erdos/src/lib.rs
@@ -128,7 +128,6 @@ use abomonation_derive::Abomonation;
 use clap::{self, App, Arg};
 use rand::{Rng, SeedableRng, StdRng};
 use serde::{Deserialize, Serialize};
-use uuid;
 
 // Private submodules
 mod configuration;
@@ -149,7 +148,7 @@ pub use dataflow::{connect::*, OperatorConfig};
 pub type OperatorId = Uuid;
 
 // Random number generator which should be the same accross threads and processes.
-thread_local!(static RNG: RefCell<StdRng>= RefCell::new(StdRng::from_seed(&[1913, 03, 26])));
+thread_local!(static RNG: RefCell<StdRng>= RefCell::new(StdRng::from_seed(&[1913, 3, 26])));
 
 /// Produces a deterministic, unique ID.
 pub fn generate_id() -> Uuid {
@@ -183,7 +182,7 @@ impl Uuid {
 impl fmt::Debug for Uuid {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> fmt::Result {
         let &Uuid(bytes) = self;
-        let id = uuid::Uuid::from_bytes(bytes.clone());
+        let id = uuid::Uuid::from_bytes(bytes);
         fmt::Display::fmt(&id, f)
     }
 }
@@ -191,7 +190,7 @@ impl fmt::Debug for Uuid {
 impl fmt::Display for Uuid {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> fmt::Result {
         let &Uuid(bytes) = self;
-        let id = uuid::Uuid::from_bytes(bytes.clone());
+        let id = uuid::Uuid::from_bytes(bytes);
         fmt::Display::fmt(&id, f)
     }
 }
@@ -200,7 +199,7 @@ impl fmt::Display for Uuid {
 pub fn reset() {
     // All global variables should be reset here.
     RNG.with(|rng| {
-        *rng.borrow_mut() = StdRng::from_seed(&[1913, 03, 26]);
+        *rng.borrow_mut() = StdRng::from_seed(&[1913, 3, 26]);
     });
     dataflow::graph::default_graph::set(dataflow::graph::AbstractGraph::new());
 }

--- a/erdos/src/node/lattice.rs
+++ b/erdos/src/node/lattice.rs
@@ -73,10 +73,7 @@ impl Eq for RunnableEvent {}
 impl PartialEq for RunnableEvent {
     // Two events are equal iff they are the same i.e. same index into the lattice.
     fn eq(&self, other: &RunnableEvent) -> bool {
-        match self.node_index.index().cmp(&other.node_index.index()) {
-            Ordering::Equal => true,
-            _ => false,
-        }
+        matches!(self.node_index.index().cmp(&other.node_index.index()), Ordering::Equal)
     }
 }
 
@@ -333,7 +330,7 @@ impl ExecutionLattice {
             // elements out of the earlier run_queue, clears the run_queue and initializes it
             // afresh with the set difference of the old run_queue and the nodes to remove.
             // Since the invocation of this code is hopefully rare, we can optimize it later.
-            if demoted_leaves.len() > 0 {
+            if !demoted_leaves.is_empty() {
                 leaves.retain(|event| !demoted_leaves.contains(&event.node_index));
                 // Reconstruct the run queue.
                 let old_run_queue: Vec<RunnableEvent> = run_queue.drain().collect();
@@ -439,8 +436,7 @@ impl ExecutionLattice {
                     || {
                         leaves
                             .iter()
-                            .filter(|r| r.node_index == nx)
-                            .next()
+                            .find(|r| r.node_index == nx)
                             .map_or_else(|| "Executing".to_string(), |r| format!("Executing {}", r))
                     },
                     |x| x.to_string(),

--- a/erdos/src/node/lattice.rs
+++ b/erdos/src/node/lattice.rs
@@ -73,7 +73,10 @@ impl Eq for RunnableEvent {}
 impl PartialEq for RunnableEvent {
     // Two events are equal iff they are the same i.e. same index into the lattice.
     fn eq(&self, other: &RunnableEvent) -> bool {
-        matches!(self.node_index.index().cmp(&other.node_index.index()), Ordering::Equal)
+        matches!(
+            self.node_index.index().cmp(&other.node_index.index()),
+            Ordering::Equal
+        )
     }
 }
 

--- a/erdos/src/node/lattice.rs
+++ b/erdos/src/node/lattice.rs
@@ -73,10 +73,7 @@ impl Eq for RunnableEvent {}
 impl PartialEq for RunnableEvent {
     // Two events are equal iff they are the same i.e. same index into the lattice.
     fn eq(&self, other: &RunnableEvent) -> bool {
-        matches!(
-            self.node_index.index().cmp(&other.node_index.index()),
-            Ordering::Equal
-        )
+        self.node_index == other.node_index
     }
 }
 

--- a/erdos/src/node/mod.rs
+++ b/erdos/src/node/mod.rs
@@ -11,6 +11,7 @@
 //! scheduling operators, and hope to provide a versatile solution.
 
 // Private submodules
+#[allow(clippy::module_inception)]
 mod node;
 
 // Crate-wide visible submodules

--- a/erdos/src/node/operator_event.rs
+++ b/erdos/src/node/operator_event.rs
@@ -94,7 +94,7 @@ impl Eq for OperatorEvent {}
 
 impl PartialEq for OperatorEvent {
     fn eq(&self, other: &OperatorEvent) -> bool {
-        matches!(self.cmp(other), Ordering::Equal)
+        self.cmp(other).is_eq()
     }
 }
 

--- a/erdos/src/node/operator_event.rs
+++ b/erdos/src/node/operator_event.rs
@@ -94,10 +94,7 @@ impl Eq for OperatorEvent {}
 
 impl PartialEq for OperatorEvent {
     fn eq(&self, other: &OperatorEvent) -> bool {
-        match self.cmp(other) {
-            Ordering::Equal => true,
-            _ => false,
-        }
+        matches!(self.cmp(other), Ordering::Equal)
     }
 }
 

--- a/erdos/src/node/operator_executors/one_in_one_out_executor.rs
+++ b/erdos/src/node/operator_executors/one_in_one_out_executor.rs
@@ -104,10 +104,12 @@ where
         if !self.write_stream.is_closed() {
             self.write_stream
                 .send(Message::new_watermark(Timestamp::Top))
-                .expect(&format!(
-                    "[ParallelOneInOneOut] Error sending Top watermark for operator {}",
-                    self.config.get_name()
-                ));
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "[ParallelOneInOneOut] Error sending Top watermark for operator {}",
+                        self.config.get_name()
+                    )
+                });
         }
     }
 
@@ -230,7 +232,7 @@ where
         if deadline_event.write_stream_ids.contains(&write_stream_id) {
             // Invoke the end condition function on the statistics from the WriteStream.
             return (deadline_event.end_condition)(
-                &vec![write_stream_id],
+                &[write_stream_id],
                 &self.write_stream.get_condition_context(),
                 &deadline_event.timestamp,
             );
@@ -322,10 +324,12 @@ where
         if !self.write_stream.is_closed() {
             self.write_stream
                 .send(Message::new_watermark(Timestamp::Top))
-                .expect(&format!(
-                    "[OneInOneOut] Error sending Top watermark for operator {}",
-                    self.config.get_name()
-                ));
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "[OneInOneOut] Error sending Top watermark for operator {}",
+                        self.config.get_name()
+                    )
+                });
         }
     }
 
@@ -459,7 +463,7 @@ where
         if deadline_event.write_stream_ids.contains(&write_stream_id) {
             // Invoke the end condition function on the statistics from the WriteStream.
             return (deadline_event.end_condition)(
-                &vec![write_stream_id],
+                &[write_stream_id],
                 &self.write_stream.get_condition_context(),
                 &deadline_event.timestamp,
             );

--- a/erdos/src/node/operator_executors/one_in_two_out_executor.rs
+++ b/erdos/src/node/operator_executors/one_in_two_out_executor.rs
@@ -114,20 +114,24 @@ where
         if !self.left_write_stream.is_closed() {
             self.left_write_stream
                 .send(Message::new_watermark(Timestamp::Top))
-                .expect(&format!(
-                    "[ParallelOneInTwoOut] Error sending Top watermark on left stream \
-                    for operator {}",
-                    self.config.get_name()
-                ));
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "[ParallelOneInTwoOut] Error sending Top watermark on left stream \
+                        for operator {}",
+                        self.config.get_name()
+                    )
+                });
         }
         if !self.right_write_stream.is_closed() {
             self.right_write_stream
                 .send(Message::new_watermark(Timestamp::Top))
-                .expect(&format!(
-                    "[ParallelOneInTwoOut] Error sending Top watermark on right stream\
-                    for operator {}",
-                    self.config.get_name()
-                ));
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "[ParallelOneInTwoOut] Error sending Top watermark on right stream\
+                        for operator {}",
+                        self.config.get_name()
+                    )
+                });
         }
     }
 
@@ -273,7 +277,7 @@ where
         {
             // Invoke the end condition function on the statistics from the WriteStream.
             return (deadline_event.end_condition)(
-                &vec![left_write_stream_id, right_write_stream_id],
+                &[left_write_stream_id, right_write_stream_id],
                 &(self
                     .left_write_stream
                     .get_condition_context()
@@ -379,20 +383,24 @@ where
         if !self.left_write_stream.is_closed() {
             self.left_write_stream
                 .send(Message::new_watermark(Timestamp::Top))
-                .expect(&format!(
-                    "[ParallelOneInTwoOut] Error sending Top watermark on left stream \
-                    for operator {}",
-                    self.config.get_name()
-                ));
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "[ParallelOneInTwoOut] Error sending Top watermark on left stream \
+                        for operator {}",
+                        self.config.get_name()
+                    )
+                });
         }
         if !self.right_write_stream.is_closed() {
             self.right_write_stream
                 .send(Message::new_watermark(Timestamp::Top))
-                .expect(&format!(
-                    "[ParallelOneInTwoOut] Error sending Top watermark on right stream\
-                    for operator {}",
-                    self.config.get_name()
-                ));
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "[ParallelOneInTwoOut] Error sending Top watermark on right stream\
+                        for operator {}",
+                        self.config.get_name()
+                    )
+                });
         }
     }
 
@@ -549,7 +557,7 @@ where
         {
             // Invoke the end condition function on the statistics from the WriteStream.
             return (deadline_event.end_condition)(
-                &vec![left_write_stream_id, right_write_stream_id],
+                &[left_write_stream_id, right_write_stream_id],
                 &(self
                     .left_write_stream
                     .get_condition_context()

--- a/erdos/src/node/operator_executors/two_in_one_out_executor.rs
+++ b/erdos/src/node/operator_executors/two_in_one_out_executor.rs
@@ -121,10 +121,12 @@ where
         if !self.write_stream.is_closed() {
             self.write_stream
                 .send(Message::new_watermark(Timestamp::Top))
-                .expect(&format!(
-                    "[ParallelTwoInOneOut] Error sending Top watermark for operator {}",
-                    self.config.get_name(),
-                ));
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "[ParallelTwoInOneOut] Error sending Top watermark for operator {}",
+                        self.config.get_name(),
+                    )
+                });
         }
     }
 
@@ -271,7 +273,7 @@ where
         if deadline_event.write_stream_ids.contains(&write_stream_id) {
             // Invoke the end condition function on the statistics from the WriteStream.
             return (deadline_event.end_condition)(
-                &vec![write_stream_id],
+                &[write_stream_id],
                 &self.write_stream.get_condition_context(),
                 &deadline_event.timestamp,
             );
@@ -381,10 +383,12 @@ where
         if !self.write_stream.is_closed() {
             self.write_stream
                 .send(Message::new_watermark(Timestamp::Top))
-                .expect(&format!(
-                    "[TwoInOneOut] Error sending Top watermark for operator {}",
-                    self.config.get_name(),
-                ));
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "[TwoInOneOut] Error sending Top watermark for operator {}",
+                        self.config.get_name(),
+                    )
+                });
         }
     }
 
@@ -546,7 +550,7 @@ where
         if deadline_event.write_stream_ids.contains(&write_stream_id) {
             // Invoke the end condition function on the statistics from the WriteStream.
             return (deadline_event.end_condition)(
-                &vec![write_stream_id],
+                &[write_stream_id],
                 &self.write_stream.get_condition_context(),
                 &deadline_event.timestamp,
             );

--- a/erdos/src/scheduler/channel_manager.rs
+++ b/erdos/src/scheduler/channel_manager.rs
@@ -153,6 +153,7 @@ impl ChannelManager {
     /// for operators with streams containing dataflow channels to other nodes, and transport
     /// channels from TCP receivers to operators that are connected to streams originating on
     /// other nodes.
+    #[allow(clippy::needless_collect)]
     pub async fn new(
         job_graph: &JobGraph,
         node_id: NodeId,
@@ -220,7 +221,7 @@ impl ChannelManager {
                 let contains_destination = destinations.iter().any(|destination| {
                     let destination_node_id = match destination {
                         Job::Operator(operator_id) => {
-                            operators.get(&operator_id).unwrap().config.node_id
+                            operators.get(operator_id).unwrap().config.node_id
                         }
                         // TODO: change this when ERDOS programs are submitted to a cluster.
                         Job::Driver => 0,

--- a/erdos/src/scheduler/endpoints_manager.rs
+++ b/erdos/src/scheduler/endpoints_manager.rs
@@ -42,15 +42,10 @@ impl ChannelsToReceivers {
 }
 
 /// Wrapper used to store mappings between node ids and `mpsc::UnboundedSender` to sender threads.
+#[derive(Default)]
 pub struct ChannelsToSenders {
     /// The ith sender corresponds to a TCP connection to the ith node.
     senders: HashMap<NodeId, UnboundedSender<InterProcessMessage>>,
-}
-
-impl Default for ChannelsToSenders {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl ChannelsToSenders {

--- a/erdos/src/scheduler/endpoints_manager.rs
+++ b/erdos/src/scheduler/endpoints_manager.rs
@@ -35,7 +35,7 @@ impl ChannelsToReceivers {
     /// It sends a `PusherT` to message on all receiving threads.
     pub fn send(&mut self, stream_id: StreamId, pusher: Box<dyn PusherT>) {
         for sender in self.senders.iter_mut() {
-            let msg = (stream_id.clone(), pusher.clone());
+            let msg = (stream_id, pusher.clone());
             sender.send(msg).unwrap();
         }
     }
@@ -45,6 +45,12 @@ impl ChannelsToReceivers {
 pub struct ChannelsToSenders {
     /// The ith sender corresponds to a TCP connection to the ith node.
     senders: HashMap<NodeId, UnboundedSender<InterProcessMessage>>,
+}
+
+impl Default for ChannelsToSenders {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ChannelsToSenders {
@@ -68,6 +74,6 @@ impl ChannelsToSenders {
         &self,
         node_id: NodeId,
     ) -> Option<tokio::sync::mpsc::UnboundedSender<InterProcessMessage>> {
-        self.senders.get(&node_id).map(|c| c.clone())
+        self.senders.get(&node_id).cloned()
     }
 }

--- a/python/src/build.rs
+++ b/python/src/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+  pyo3_build_config::add_extension_module_link_args();
+}

--- a/python/src/build.rs
+++ b/python/src/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-  pyo3_build_config::add_extension_module_link_args();
-}

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -238,6 +238,7 @@ fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
 
     #[pyfn(m)]
     #[pyo3(name = "connect_two_in_one_out")]
+    #[allow(clippy::too_many_arguments)]
     fn connect_two_in_one_out_py(
         py: Python,
         py_type: PyObject,

--- a/python/src/py_message.rs
+++ b/python/src/py_message.rs
@@ -16,7 +16,8 @@ pub(crate) struct PyMessage {
 #[pymethods]
 impl PyMessage {
     #[new]
-    fn new<'a>(timestamp: Option<PyTimestamp>, data: Option<&'a PyBytes>) -> PyResult<Self> {
+    #[allow(clippy::needless_option_as_deref)]
+    fn new(timestamp: Option<PyTimestamp>, data: Option<&PyBytes>) -> PyResult<Self> {
         if timestamp.is_none() && data.is_some() {
             return Err(exceptions::PyValueError::new_err(
                 "Passing a non-None value to data when timestamp=None is not allowed",
@@ -44,17 +45,11 @@ impl PyMessage {
     }
 
     fn is_timestamped_data(&self) -> bool {
-        match &self.msg {
-            Message::TimestampedData(_) => true,
-            _ => false,
-        }
+        matches!(&self.msg, Message::TimestampedData(_))
     }
 
     fn is_watermark(&self) -> bool {
-        match &self.msg {
-            Message::Watermark(_) => true,
-            _ => false,
-        }
+        matches!(&self.msg, Message::Watermark(_))
     }
 
     fn is_top_watermark(&self) -> bool {

--- a/python/src/py_operators/mod.rs
+++ b/python/src/py_operators/mod.rs
@@ -24,6 +24,8 @@ fn construct_operator(
     py_operator_config: Arc<PyObject>,
     config: OperatorConfig,
 ) -> Arc<PyObject> {
+    // TODO (Sukrit): The function should return a Result object instead of echoing errors to
+    // standard output.
     Python::with_gil(|py| -> Arc<PyObject> {
         let locals = PyDict::new(py);
         if let Some(e) = locals

--- a/python/src/py_operators/mod.rs
+++ b/python/src/py_operators/mod.rs
@@ -53,10 +53,7 @@ fn construct_operator(
         {
             e.print(py)
         }
-        if let Some(e) = locals
-            .set_item("op_name", config.get_name())
-            .err()
-        {
+        if let Some(e) = locals.set_item("op_name", config.get_name()).err() {
             e.print(py)
         }
 

--- a/python/src/py_operators/mod.rs
+++ b/python/src/py_operators/mod.rs
@@ -26,30 +26,39 @@ fn construct_operator(
 ) -> Arc<PyObject> {
     Python::with_gil(|py| -> Arc<PyObject> {
         let locals = PyDict::new(py);
-        locals
+        if let Some(e) = locals
             .set_item("Operator", py_operator_type.clone_ref(py))
             .err()
-            .map(|e| e.print(py));
-        locals
-            .set_item("op_id", format!("{}", config.id))
-            .err()
-            .map(|e| e.print(py));
-        locals
+        {
+            e.print(py)
+        }
+        if let Some(e) = locals.set_item("op_id", format!("{}", config.id)).err() {
+            e.print(py)
+        }
+        if let Some(e) = locals
             .set_item("args", py_operator_args.clone_ref(py))
             .err()
-            .map(|e| e.print(py));
-        locals
+        {
+            e.print(py)
+        }
+        if let Some(e) = locals
             .set_item("kwargs", py_operator_kwargs.clone_ref(py))
             .err()
-            .map(|e| e.print(py));
-        locals
+        {
+            e.print(py)
+        }
+        if let Some(e) = locals
             .set_item("config", py_operator_config.clone_ref(py))
             .err()
-            .map(|e| e.print(py));
-        locals
-            .set_item("op_name", format!("{}", config.get_name()))
+        {
+            e.print(py)
+        }
+        if let Some(e) = locals
+            .set_item("op_name", config.get_name())
             .err()
-            .map(|e| e.print(py));
+        {
+            e.print(py)
+        }
 
         // Initialize the operator.
         let init_result = py.run(
@@ -67,7 +76,7 @@ operator._trace_event_logger = erdos.utils.setup_trace_logging(
 operator.__init__(*args, **kwargs)
             "#,
             None,
-            Some(&locals),
+            Some(locals),
         );
         if let Err(e) = init_result {
             e.print(py);
@@ -75,7 +84,7 @@ operator.__init__(*args, **kwargs)
 
         // Retrieve the constructed operator.
         Arc::new(
-            py.eval("operator", None, Some(&locals))
+            py.eval("operator", None, Some(locals))
                 .unwrap()
                 .to_object(py),
         )

--- a/python/src/py_operators/py_one_in_one_out.rs
+++ b/python/src/py_operators/py_one_in_one_out.rs
@@ -67,44 +67,56 @@ impl OneInOneOut<(), Vec<u8>, Vec<u8>> for PyOneInOneOut {
 
             // Create the Python version of the ReadStream.
             let read_stream_id = read_stream.id();
-            let read_stream_name = String::from(read_stream.name().clone());
+            let read_stream_name = read_stream.name();
             let read_stream_arc = Arc::new(read_stream);
             let py_read_stream = PyReadStream::from(&read_stream_arc);
 
             // Create the Python version of the WriteStream.
             let write_stream_clone = write_stream.clone();
             let write_stream_id = write_stream.id();
-            let write_stream_name = String::from(write_stream.name().clone());
+            let write_stream_name = write_stream.name();
             let py_write_stream = PyWriteStream::from(write_stream_clone);
 
             // Create the locals to run the constructor for the ReadStream and WriteStream.
             let (py_read_stream_obj, py_write_stream_obj) =
                 Python::with_gil(|py| -> (PyObject, PyObject) {
                     let locals = PyDict::new(py);
-                    locals
+                    if let Some(e) = locals
                         .set_item("py_read_stream", &Py::new(py, py_read_stream).unwrap())
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item("read_stream_id", format!("{}", read_stream_id))
                         .err()
-                        .map(|e| e.print(py));
-                    locals
-                        .set_item("read_stream_name", format!("{}", read_stream_name))
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
+                        .set_item("read_stream_name", read_stream_name.to_string())
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item("py_write_stream", &Py::new(py, py_write_stream).unwrap())
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item("write_stream_id", format!("{}", write_stream_id))
                         .err()
-                        .map(|e| e.print(py));
-                    locals
-                        .set_item("write_stream_name", format!("{}", write_stream_name))
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
+                        .set_item("write_stream_name", write_stream_name.to_string())
                         .err()
-                        .map(|e| e.print(py));
+                    {
+                        e.print(py)
+                    }
                     let stream_construction_result = py.run(
                         r#"
 import uuid, erdos
@@ -116,7 +128,7 @@ read_stream = erdos.ReadStream(_py_read_stream=py_read_stream)
 write_stream = erdos.WriteStream(_py_write_stream=py_write_stream)
             "#,
                         None,
-                        Some(&locals),
+                        Some(locals),
                     );
                     if let Err(e) = stream_construction_result {
                         e.print(py);
@@ -124,11 +136,11 @@ write_stream = erdos.WriteStream(_py_write_stream=py_write_stream)
 
                     // Retrieve the constructed stream.
                     let py_read_stream_obj = py
-                        .eval("read_stream", None, Some(&locals))
+                        .eval("read_stream", None, Some(locals))
                         .unwrap()
                         .to_object(py);
                     let py_write_stream_obj = py
-                        .eval("write_stream", None, Some(&locals))
+                        .eval("write_stream", None, Some(locals))
                         .unwrap()
                         .to_object(py);
 

--- a/python/src/py_operators/py_one_in_two_out.rs
+++ b/python/src/py_operators/py_one_in_two_out.rs
@@ -72,77 +72,92 @@ impl OneInTwoOut<(), Vec<u8>, Vec<u8>, Vec<u8>> for PyOneInTwoOut {
 
             // Create the Python version of the ReadStream.
             let read_stream_id = read_stream.id();
-            let read_stream_name = String::from(read_stream.name().clone());
+            let read_stream_name = read_stream.name();
             let read_stream_arc = Arc::new(read_stream);
             let py_read_stream = PyReadStream::from(&read_stream_arc);
 
             // Create the Python version of the left WriteStream.
             let left_write_stream_clone = left_write_stream.clone();
             let left_write_stream_id = left_write_stream.id();
-            let left_write_stream_name = String::from(left_write_stream.name().clone());
+            let left_write_stream_name = left_write_stream.name();
             let py_left_write_stream = PyWriteStream::from(left_write_stream_clone);
 
             // Create the Python version of the right WriteStream.
             let right_write_stream_clone = right_write_stream.clone();
             let right_write_stream_id = right_write_stream.id();
-            let right_write_stream_name = String::from(right_write_stream.name().clone());
+            let right_write_stream_name = right_write_stream.name();
             let py_right_write_stream = PyWriteStream::from(right_write_stream_clone);
 
             // Create the locals to run the constructor for the ReadStream and WriteStream.
             let (py_read_stream_obj, py_left_write_stream_obj, py_right_write_stream_obj) =
                 Python::with_gil(|py| -> (PyObject, PyObject, PyObject) {
                     let locals = PyDict::new(py);
-                    locals
+                    if let Some(e) = locals
                         .set_item("py_read_stream", &Py::new(py, py_read_stream).unwrap())
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item("read_stream_id", format!("{}", read_stream_id))
                         .err()
-                        .map(|e| e.print(py));
-                    locals
-                        .set_item("read_stream_name", format!("{}", read_stream_name))
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
+                        .set_item("read_stream_name", read_stream_name.to_string())
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item(
                             "py_left_write_stream",
                             &Py::new(py, py_left_write_stream).unwrap(),
                         )
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item("left_write_stream_id", format!("{}", left_write_stream_id))
                         .err()
-                        .map(|e| e.print(py));
-                    locals
-                        .set_item(
-                            "left_write_stream_name",
-                            format!("{}", left_write_stream_name),
-                        )
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
+                        .set_item("left_write_stream_name", left_write_stream_name.to_string())
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item(
                             "py_right_write_stream",
                             &Py::new(py, py_right_write_stream).unwrap(),
                         )
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item(
                             "right_write_stream_id",
                             format!("{}", right_write_stream_id),
                         )
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item(
                             "right_write_stream_name",
-                            format!("{}", right_write_stream_name),
+                            right_write_stream_name.to_string(),
                         )
                         .err()
-                        .map(|e| e.print(py));
+                    {
+                        e.print(py)
+                    }
                     let stream_construction_result = py.run(
                         r#"
 import uuid, erdos
@@ -157,7 +172,7 @@ left_write_stream = erdos.WriteStream(_py_write_stream=py_left_write_stream)
 right_write_stream = erdos.WriteStream(_py_write_stream=py_right_write_stream)
             "#,
                         None,
-                        Some(&locals),
+                        Some(locals),
                     );
                     if let Err(e) = stream_construction_result {
                         e.print(py);
@@ -165,15 +180,15 @@ right_write_stream = erdos.WriteStream(_py_write_stream=py_right_write_stream)
 
                     // Retrieve the constructed streams.
                     let py_read_stream_obj = py
-                        .eval("read_stream", None, Some(&locals))
+                        .eval("read_stream", None, Some(locals))
                         .unwrap()
                         .to_object(py);
                     let py_left_write_stream_obj = py
-                        .eval("left_write_stream", None, Some(&locals))
+                        .eval("left_write_stream", None, Some(locals))
                         .unwrap()
                         .to_object(py);
                     let py_right_write_stream_obj = py
-                        .eval("right_write_stream", None, Some(&locals))
+                        .eval("right_write_stream", None, Some(locals))
                         .unwrap()
                         .to_object(py);
 

--- a/python/src/py_operators/py_two_in_one_out.rs
+++ b/python/src/py_operators/py_two_in_one_out.rs
@@ -66,7 +66,7 @@ impl TwoInOneOut<(), Vec<u8>, Vec<u8>, Vec<u8>> for PyTwoInOneOut {
             let left_read_stream_ptr: *mut ReadStream<Vec<u8>> = left_read_stream;
             let left_read_stream: ReadStream<Vec<u8>> = left_read_stream_ptr.read();
             let left_read_stream_id = left_read_stream.id();
-            let left_read_stream_name = String::from(left_read_stream.name().clone());
+            let left_read_stream_name = left_read_stream.name();
             let left_read_stream_arc = Arc::new(left_read_stream);
             let py_left_read_stream = PyReadStream::from(&left_read_stream_arc);
 
@@ -75,68 +75,80 @@ impl TwoInOneOut<(), Vec<u8>, Vec<u8>, Vec<u8>> for PyTwoInOneOut {
             let right_read_stream_ptr: *mut ReadStream<Vec<u8>> = right_read_stream;
             let right_read_stream: ReadStream<Vec<u8>> = right_read_stream_ptr.read();
             let right_read_stream_id = right_read_stream.id();
-            let right_read_stream_name = String::from(right_read_stream.name().clone());
+            let right_read_stream_name = right_read_stream.name();
             let right_read_stream_arc = Arc::new(right_read_stream);
             let py_right_read_stream = PyReadStream::from(&right_read_stream_arc);
 
             // Create the Python version of the WriteStream.
             let write_stream_clone = write_stream.clone();
             let write_stream_id = write_stream.id();
-            let write_stream_name = String::from(write_stream.name().clone());
+            let write_stream_name = write_stream.name();
             let py_write_stream = PyWriteStream::from(write_stream_clone);
 
             // Create the locals to run the constructor for the ReadStream and WriteStream.
             let (py_left_read_stream_obj, py_right_read_stream_obj, py_write_stream_obj) =
                 Python::with_gil(|py| -> (PyObject, PyObject, PyObject) {
                     let locals = PyDict::new(py);
-                    locals
+                    if let Some(e) = locals
                         .set_item(
                             "py_left_read_stream",
                             &Py::new(py, py_left_read_stream).unwrap(),
                         )
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item("left_read_stream_id", format!("{}", left_read_stream_id))
                         .err()
-                        .map(|e| e.print(py));
-                    locals
-                        .set_item(
-                            "left_read_stream_name",
-                            format!("{}", left_read_stream_name),
-                        )
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
+                        .set_item("left_read_stream_name", left_read_stream_name.to_string())
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item(
                             "py_right_read_stream",
                             &Py::new(py, py_right_read_stream).unwrap(),
                         )
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item("right_read_stream_id", format!("{}", right_read_stream_id))
                         .err()
-                        .map(|e| e.print(py));
-                    locals
-                        .set_item(
-                            "right_read_stream_name",
-                            format!("{}", right_read_stream_name),
-                        )
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
+                        .set_item("right_read_stream_name", right_read_stream_name.to_string())
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item("py_write_stream", &Py::new(py, py_write_stream).unwrap())
                         .err()
-                        .map(|e| e.print(py));
-                    locals
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
                         .set_item("write_stream_id", format!("{}", write_stream_id))
                         .err()
-                        .map(|e| e.print(py));
-                    locals
-                        .set_item("write_stream_name", format!("{}", write_stream_name))
+                    {
+                        e.print(py)
+                    }
+                    if let Some(e) = locals
+                        .set_item("write_stream_name", write_stream_name.to_string())
                         .err()
-                        .map(|e| e.print(py));
+                    {
+                        e.print(py)
+                    }
                     let stream_construction_result = py.run(
                         r#"
 import uuid, erdos
@@ -151,7 +163,7 @@ right_read_stream = erdos.ReadStream(_py_read_stream=py_right_read_stream)
 write_stream = erdos.WriteStream(_py_write_stream=py_write_stream)
             "#,
                         None,
-                        Some(&locals),
+                        Some(locals),
                     );
                     if let Err(e) = stream_construction_result {
                         e.print(py);
@@ -159,15 +171,15 @@ write_stream = erdos.WriteStream(_py_write_stream=py_write_stream)
 
                     // Retrieve the constructed stream.
                     let py_left_read_stream_obj = py
-                        .eval("left_read_stream", None, Some(&locals))
+                        .eval("left_read_stream", None, Some(locals))
                         .unwrap()
                         .to_object(py);
                     let py_right_read_stream_obj = py
-                        .eval("right_read_stream", None, Some(&locals))
+                        .eval("right_read_stream", None, Some(locals))
                         .unwrap()
                         .to_object(py);
                     let py_write_stream_obj = py
-                        .eval("write_stream", None, Some(&locals))
+                        .eval("write_stream", None, Some(locals))
                         .unwrap()
                         .to_object(py);
 

--- a/python/src/py_stream/py_extract_stream.rs
+++ b/python/src/py_stream/py_extract_stream.rs
@@ -24,7 +24,7 @@ impl PyExtractStream {
         self.extract_stream.is_closed()
     }
 
-    fn read<'p>(&mut self, py: Python<'p>) -> PyResult<PyMessage> {
+    fn read(&mut self, py: Python) -> PyResult<PyMessage> {
         let result = py.allow_threads(|| self.extract_stream.read());
         match result {
             Ok(msg) => Ok(PyMessage::from(msg)),
@@ -36,7 +36,7 @@ impl PyExtractStream {
         }
     }
 
-    fn try_read<'p>(&mut self) -> PyResult<Option<PyMessage>> {
+    fn try_read(&mut self) -> PyResult<Option<PyMessage>> {
         match self.extract_stream.try_read() {
             Ok(msg) => Ok(Some(PyMessage::from(msg))),
             Err(TryReadError::Empty) => Ok(None),

--- a/python/src/py_timestamp.rs
+++ b/python/src/py_timestamp.rs
@@ -81,6 +81,6 @@ impl From<Timestamp> for PyTimestamp {
 
 impl From<PyTimestamp> for Timestamp {
     fn from(timestamp: PyTimestamp) -> Self {
-        timestamp.timestamp.clone()
+        timestamp.timestamp
     }
 }


### PR DESCRIPTION
- Enables Clippy linting on the Rust code, and fixed code to conform to the warnings raised. There seems to be a bug in the Clippy linting that does not respect an `#[allow(needless_option_as_deref)]` on the `new` method of the `PyMessage` class, so it was added as a global allow for now. 
- Separates Formatting checks for Rust and Python into separate jobs, and makes the builds depend on the formatting checks to succeed first.
- Package builds are now cached at the formatting stage, which allows the Rust/ROS/Python builds to use the cache instead of rebuilding the dependencies in parallel.  