### PR TITLE
[CI] Fail on warnings when building Rust docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,6 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTDOCFLAGS: -D warnings
   rust_toolchain: nightly-2022-02-09
 
 jobs:
@@ -19,9 +20,9 @@ jobs:
           toolchain: ${{ env.rust_toolchain }}
           profile: minimal
           override: true
-          components: rustfmt, rust-src
+          components: rust-docs
       - name: Build Documentation
-        run: cargo doc --all --no-deps
+        run: cargo doc --workspace --no-deps --all-features
 
   pythondoc:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,6 +21,7 @@ jobs:
           profile: minimal
           override: true
           components: rust-docs
+      - uses: Swatinem/rust-cache@v1
       - name: Build Documentation
         run: cargo doc --workspace --no-deps --all-features
 

--- a/erdos/src/dataflow/operators/ros/from_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/from_ros_operator.rs
@@ -10,14 +10,19 @@ use std::sync::{Arc, Mutex};
 /// Subscribes to a ROS topic and outputs incoming messages to an ERDOS stream using the
 /// provided message conversion function.
 ///
-/// Conversion function should convert a ROS type which implements the [`rosrust::Message`]
-/// trait and return a ERDOS [`Message`] containing data of a Rust data type. See [`rosrust_msg`]
-/// for a variety of supported standard ROS messages.
+/// The conversion function transforms a ROS message implementing the [`rosrust::Message`] trait
+/// into an ERDOS [`Message`].
+///
+/// See [`rosrust_msg`](https://lib.rs/crates/rosrust_msg),
+/// the [ROS `std_msgs` package](http://wiki.ros.org/std_msgs),
+/// and the [ROS `common_msgs` package](http://wiki.ros.org/common_msgs)
+/// for a variety of supported and commonly-used ROS messages.
 ///
 /// # Example
 /// The following example shows how to use a [`FromRosOperator`] with a conversion function
-/// which takes a [`rosrust_msg::sensor_msgs::Image`] and returns an ERDOS message containing
-/// [`Vec<u8>`] a vector of bytes.
+/// which takes a
+/// [`rosrust_msg::sensor_msgs::Image`](http://docs.ros.org/en/api/sensor_msgs/html/msg/Image.html)
+/// and returns an ERDOS message containing [`Vec<u8>`] a vector of bytes.
 ///
 /// ```
 /// # use erdos::{

--- a/erdos/src/dataflow/operators/ros/to_ros_operator.rs
+++ b/erdos/src/dataflow/operators/ros/to_ros_operator.rs
@@ -5,12 +5,18 @@ use std::sync::Arc;
 /// Takes an input ERDOS stream and publishes to a ROS topic using the provided message conversion
 /// function.
 ///
-/// Conversion function should convert a Rust data type and return a ROS type which implements
-/// the [`rosrust::Message`] trait.
+/// The conversion function transforms a [`Message`] into a ROS message which implements the
+/// [`rosrust::Message`] trait.
+///
+/// See [`rosrust_msg`](https://lib.rs/crates/rosrust_msg),
+/// the [ROS `std_msgs` package](http://wiki.ros.org/std_msgs),
+/// and the [ROS `common_msgs` package](http://wiki.ros.org/common_msgs)
+/// for a variety of supported and commonly-used ROS messages.
 ///
 /// # Example
 /// The following example shows how to use a [`ToRosOperator`] with a conversion function which
-/// takes a Rust [`i32`] and converts it to a ROS message with [`rosrust_msg::std_msgs::Int32`]
+/// takes a Rust [`i32`] and converts it to a ROS message with
+/// [`rosrust_msg::std_msgs::Int32`](http://docs.ros.org/en/api/std_msgs/html/msg/Int32.html)
 /// data.
 ///
 /// Assume that `source_stream` is an ERDOS stream sending the correct messages.

--- a/erdos/src/dataflow/stream/extract_stream.rs
+++ b/erdos/src/dataflow/stream/extract_stream.rs
@@ -28,7 +28,7 @@ use super::{
 ///
 /// # Example
 /// The below example shows how to use an [`IngestStream`](crate::dataflow::stream::IngestStream)
-/// to send data to a [`MapOperator`](crate::dataflow::operators::MapOperator),
+/// to send data to a [`FlatMapOperator`](crate::dataflow::operators::FlatMapOperator),
 /// and retrieve the processed values through an [`ExtractStream`].
 /// ```no_run
 /// # use erdos::dataflow::{

--- a/erdos/src/dataflow/stream/ingest_stream.rs
+++ b/erdos/src/dataflow/stream/ingest_stream.rs
@@ -23,7 +23,7 @@ use super::{errors::SendError, Stream, StreamId, WriteStream, WriteStreamT};
 ///
 /// # Example
 /// The below example shows how to use an [`IngestStream`] to send data to a
-/// [`MapOperator`](crate::dataflow::operators::MapOperator),
+/// [`FlatMapOperator`](crate::dataflow::operators::FlatMapOperator),
 /// and retrieve the processed values through an
 /// [`ExtractStream`](crate::dataflow::stream::ExtractStream).
 /// ```no_run

--- a/erdos/src/lib.rs
+++ b/erdos/src/lib.rs
@@ -58,7 +58,7 @@
 //!
 //! ### Implementing Operators
 //! For an example, see the implementation of the
-//! [`MapOperator`](crate::dataflow::operators::MapOperator).
+//! [`FlatMapOperator`](crate::dataflow::operators::FlatMapOperator).
 //!
 //! Operators are structures which implement an
 //! [operator trait](crate::dataflow::operator) reflecting their


### PR DESCRIPTION
- The rustdoc check fails if building the documentation produces any warnings.
- Enables all features when building the documentation.
- Fixes errors in the documentation, add iterates on ROS operator documentation.
- Adds caching to the rustdoc workflow, reducing run times in CI from ~2.5 minutes to ~30 seconds.