### PR TITLE
[LINQ] Add timestamp join

### DIFF
--- a/erdos/src/dataflow/connect.rs
+++ b/erdos/src/dataflow/connect.rs
@@ -59,6 +59,7 @@ where
 /// interacts with external systems.
 pub fn connect_parallel_sink<O, S, T, U>(
     operator_fn: impl Fn() -> O + Clone + Send + Sync + 'static,
+    // Add state as an explicit argument to support future features such as state sharing.
     state_fn: impl Fn() -> S + Clone + Send + Sync + 'static,
     mut config: OperatorConfig,
     read_stream: &dyn Stream<T>,
@@ -105,6 +106,7 @@ pub fn connect_parallel_sink<O, S, T, U>(
 /// with external systems.
 pub fn connect_sink<O, S, T>(
     operator_fn: impl Fn() -> O + Clone + Send + Sync + 'static,
+    // Add state as an explicit argument to support future features such as state sharing.
     state_fn: impl Fn() -> S + Clone + Send + Sync + 'static,
     mut config: OperatorConfig,
     read_stream: &dyn Stream<T>,
@@ -150,6 +152,7 @@ pub fn connect_sink<O, S, T>(
 /// write stream.
 pub fn connect_parallel_one_in_one_out<O, S, T, U, V>(
     operator_fn: impl Fn() -> O + Clone + Send + Sync + 'static,
+    // Add state as an explicit argument to support future features such as state sharing.
     state_fn: impl Fn() -> S + Clone + Send + Sync + 'static,
     mut config: OperatorConfig,
     read_stream: &dyn Stream<T>,
@@ -203,6 +206,7 @@ where
 /// Adds a [`OneInOneOut`] operator that has one input read stream and one output write stream.
 pub fn connect_one_in_one_out<O, S, T, U>(
     operator_fn: impl Fn() -> O + Clone + Send + Sync + 'static,
+    // Add state as an explicit argument to support future features such as state sharing.
     state_fn: impl Fn() -> S + Clone + Send + Sync + 'static,
     mut config: OperatorConfig,
     read_stream: &dyn Stream<T>,
@@ -256,6 +260,7 @@ where
 /// write stream.
 pub fn connect_parallel_two_in_one_out<O, S, T, U, V, W>(
     operator_fn: impl Fn() -> O + Clone + Send + Sync + 'static,
+    // Add state as an explicit argument to support future features such as state sharing.
     state_fn: impl Fn() -> S + Clone + Send + Sync + 'static,
     mut config: OperatorConfig,
     left_read_stream: &dyn Stream<T>,
@@ -316,6 +321,7 @@ where
 /// Adds a [`TwoInOneOut`] operator that has two input read streams and one output write stream.
 pub fn connect_two_in_one_out<O, S, T, U, V>(
     operator_fn: impl Fn() -> O + Clone + Send + Sync + 'static,
+    // Add state as an explicit argument to support future features such as state sharing.
     state_fn: impl Fn() -> S + Clone + Send + Sync + 'static,
     mut config: OperatorConfig,
     left_read_stream: &dyn Stream<T>,
@@ -376,6 +382,7 @@ where
 /// write streams.
 pub fn connect_parallel_one_in_two_out<O, S, T, U, V, W>(
     operator_fn: impl Fn() -> O + Clone + Send + Sync + 'static,
+    // Add state as an explicit argument to support future features such as state sharing.
     state_fn: impl Fn() -> S + Clone + Send + Sync + 'static,
     mut config: OperatorConfig,
     read_stream: &dyn Stream<T>,
@@ -438,6 +445,7 @@ where
 /// Adds a [`OneInTwoOut`] operator that has one input read stream and two output write streams.
 pub fn connect_one_in_two_out<O, S, T, U, V>(
     operator_fn: impl Fn() -> O + Clone + Send + Sync + 'static,
+    // Add state as an explicit argument to support future features such as state sharing.
     state_fn: impl Fn() -> S + Clone + Send + Sync + 'static,
     mut config: OperatorConfig,
     read_stream: &dyn Stream<T>,

--- a/erdos/src/dataflow/context.rs
+++ b/erdos/src/dataflow/context.rs
@@ -430,7 +430,10 @@ where
         }
     }
 
-    /// Gets a mutable version of the state.
+    /// [Experimental] Returns a mutable version of the state.
+    ///
+    /// Used to garbage-collect time-versioned state in
+    /// [`TimestampJoin`](crate::dataflow::operators::TimestampJoin)
     pub(crate) fn get_state_mut(&mut self) -> &mut S {
         self.state
     }

--- a/erdos/src/dataflow/context.rs
+++ b/erdos/src/dataflow/context.rs
@@ -146,8 +146,7 @@ where
 
     /// Get the current state attached to the operator.
     pub fn get_current_state(&mut self) -> Option<&mut S::Item> {
-        let timestamp = self.get_timestamp().clone();
-        self.state.at(&timestamp)
+        self.state.at(&self.timestamp)
     }
 
     /// Get the past state attached to the operator.
@@ -279,8 +278,7 @@ where
 
     /// Get the current state attached to the operator.
     pub fn get_current_state(&mut self) -> Option<&mut S::Item> {
-        let timestamp = self.get_timestamp().clone();
-        self.state.at(&timestamp)
+        self.state.at(&self.timestamp)
     }
 
     /// Get the past state attached to the operator.
@@ -417,8 +415,7 @@ where
 
     /// Get the current state attached to the operator.
     pub fn get_current_state(&mut self) -> Option<&mut S::Item> {
-        let timestamp = self.get_timestamp().clone();
-        self.state.at(&timestamp)
+        self.state.at(&self.timestamp)
     }
 
     /// Get the past state attached to the operator.
@@ -431,6 +428,11 @@ where
         } else {
             None
         }
+    }
+
+    /// Gets a mutable version of the state.
+    pub(crate) fn get_state_mut(&mut self) -> &mut S {
+        self.state
     }
 
     /// Get the timestamp of the last committed state.
@@ -570,8 +572,7 @@ where
 
     /// Get the current state attached to the operator.
     pub fn get_current_state(&mut self) -> Option<&mut S::Item> {
-        let timestamp = self.get_timestamp().clone();
-        self.state.at(&timestamp)
+        self.state.at(&self.timestamp)
     }
 
     /// Get the past state attached to the operator.

--- a/erdos/src/dataflow/context.rs
+++ b/erdos/src/dataflow/context.rs
@@ -433,7 +433,7 @@ where
     /// [Experimental] Returns a mutable version of the state.
     ///
     /// Used to garbage-collect time-versioned state in
-    /// [`TimestampJoinOperator`](crate::dataflow::operators::TimestampJoinOperator)
+    /// [`TimestampJoinOperator`](crate::dataflow::operators::TimestampJoinOperator).
     pub(crate) fn get_state_mut(&mut self) -> &mut S {
         self.state
     }

--- a/erdos/src/dataflow/context.rs
+++ b/erdos/src/dataflow/context.rs
@@ -433,7 +433,7 @@ where
     /// [Experimental] Returns a mutable version of the state.
     ///
     /// Used to garbage-collect time-versioned state in
-    /// [`TimestampJoin`](crate::dataflow::operators::TimestampJoin)
+    /// [`TimestampJoinOperator`](crate::dataflow::operators::TimestampJoinOperator)
     pub(crate) fn get_state_mut(&mut self) -> &mut S {
         self.state
     }

--- a/erdos/src/dataflow/operators/join.rs
+++ b/erdos/src/dataflow/operators/join.rs
@@ -11,10 +11,10 @@ use crate::dataflow::{
 
 /// Joins messages with matching timestamps from two different streams.
 ///
-/// The following table provides an example of how the [`TimestampJoin`] processes data from two
+/// The following table provides an example of how the [`TimestampJoinOperator`] processes data from two
 /// streams:
 ///
-/// | Timestamp | Left input | Right input | [`TimestampJoin`] output                   |
+/// | Timestamp | Left input | Right input | [`TimestampJoinOperator`] output                   |
 /// |-----------|------------|-------------|--------------------------------------------|
 /// | 1         | a <br> b   | 1 <br> 2    | (a, 1) <br> (a, 2) <br> (b, 1) <br> (b, 2) |
 /// | 2         | c          |             |                                            |
@@ -22,13 +22,13 @@ use crate::dataflow::{
 /// | 4         | d          | 4           | (d, 4)                                     |
 ///
 /// # Example
-/// The following example shows how to use a [`TimestampJoin`] to join two streams.
+/// The following example shows how to use a [`TimestampJoinOperator`] to join two streams.
 ///
 /// ```
 /// # use erdos::dataflow::{
 /// #     stream::IngestStream,
 /// #     operator::OperatorConfig,
-/// #     operators::TimestampJoin,
+/// #     operators::TimestampJoinOperator,
 /// #     state::TimeVersionedState
 /// # };
 /// #
@@ -37,23 +37,23 @@ use crate::dataflow::{
 /// #
 /// // Joins two streams of types String and usize
 /// let joined_stream = erdos::connect_two_in_one_out(
-///     TimestampJoin::new,
+///     TimestampJoinOperator::new,
 ///     TimeVersionedState::new,
-///     OperatorConfig::new().name("TimestampJoin"),
+///     OperatorConfig::new().name("TimestampJoinOperator"),
 ///     &left_stream,
 ///     &right_stream,
 /// );
 /// ```
 #[derive(Default)]
-pub struct TimestampJoin {}
+pub struct TimestampJoinOperator {}
 
-impl TimestampJoin {
+impl TimestampJoinOperator {
     pub fn new() -> Self {
         Self {}
     }
 }
 
-impl<T, U> TwoInOneOut<TimeVersionedState<(Vec<T>, Vec<U>)>, T, U, (T, U)> for TimestampJoin
+impl<T, U> TwoInOneOut<TimeVersionedState<(Vec<T>, Vec<U>)>, T, U, (T, U)> for TimestampJoinOperator
 where
     T: Data + for<'a> Deserialize<'a>,
     U: Data + for<'a> Deserialize<'a>,
@@ -120,7 +120,7 @@ where
     T: Data + for<'a> Deserialize<'a>,
     U: Data + for<'a> Deserialize<'a>,
 {
-    /// Joins messages with matching timestamps from two different streams using a [`TimestampJoin`].
+    /// Joins messages with matching timestamps from two different streams using a [`TimestampJoinOperator`].
     ///
     /// # Example
     ///
@@ -135,7 +135,7 @@ where
     fn timestamp_join(&self, other: &dyn Stream<U>) -> OperatorStream<(T, U)> {
         let name = format!("TimestampJoinOp_{}_{}", self.name(), other.name());
         crate::connect_two_in_one_out(
-            TimestampJoin::new,
+            TimestampJoinOperator::new,
             TimeVersionedState::new,
             OperatorConfig::new().name(&name),
             self,

--- a/erdos/src/dataflow/operators/join.rs
+++ b/erdos/src/dataflow/operators/join.rs
@@ -1,198 +1,85 @@
-use std::{
-    cmp::Reverse,
-    collections::{BinaryHeap, HashMap},
-    marker::PhantomData,
-    sync::{Arc, RwLock},
-};
+use std::{cmp::Reverse, collections::HashMap};
 
 use serde::Deserialize;
 
 use crate::dataflow::{
-    message::Message, stream::WriteStreamT, Data, Operator, OperatorConfig, ReadStream, Timestamp,
-    WriteStream,
+    context::TwoInOneOutContext,
+    message::Message,
+    operator::{OperatorConfig, TwoInOneOut},
+    state::TimeVersionedState,
+    stream::{OperatorStream, Stream, WriteStreamT},
+    Data, Timestamp,
 };
 
-/// A structure that stores the state associated with a stream for the JoinOperator, and provides
-/// the associated functions for mutation of the data.
-/// Uses a ConcurrentHashMap to store the messages and a min-heap to ensure easy retrieval of the
-/// timestamps for cleaning.
-#[derive(Clone)]
-struct StreamState<D: Data> {
-    msgs: Arc<RwLock<HashMap<Timestamp, Vec<D>>>>,
-    // A min-heap tracking the keys of the hashmap.
-    timestamps: Arc<RwLock<BinaryHeap<Reverse<Timestamp>>>>,
+/// Joins messages with equivalent timestamps from two different streams.
+/// TODO: more documentation
+pub struct TimestampJoin<T: Data, U: Data> {
+    /// Lists of received data, grouped by timestamp.
+    items: HashMap<Timestamp, (Vec<T>, Vec<U>)>,
 }
 
-impl<D: Data> StreamState<D> {
-    fn new() -> Self {
+impl<T: Data, U: Data> TimestampJoin<T, U> {
+    pub fn new() -> Self {
         Self {
-            msgs: Arc::new(RwLock::new(HashMap::new())),
-            timestamps: Arc::new(RwLock::new(BinaryHeap::new())),
+            items: HashMap::new(),
         }
-    }
-
-    /// Adds a message to the ConcurrentHashMap.
-    fn add_msg(&mut self, timestamp: &Timestamp, msg: D) {
-        // Insert a new vector if the key does not exist, and add the key to the timestamps.
-        let mut msgs = self.msgs.write().unwrap();
-        match msgs.get_mut(timestamp) {
-            Some(msg_vec) => msg_vec.push(msg),
-            None => {
-                msgs.insert(timestamp.clone(), vec![msg]);
-                self.timestamps
-                    .write()
-                    .unwrap()
-                    .push(Reverse(timestamp.clone()));
-            }
-        };
-    }
-
-    /// Cleans the state corresponding to a given Timestamp (upto and including).
-    fn clean_state(&self, timestamp: &Timestamp) {
-        let timestamps = &mut self.timestamps.write().unwrap();
-        while timestamps.peek().map_or(false, |t| t.0 <= *timestamp) {
-            let t = timestamps.pop().unwrap().0;
-            self.msgs
-                .write()
-                .unwrap()
-                .remove(&t)
-                .expect("StreamState: expected Timestamp to be present");
-        }
-    }
-
-    /// Retrieve the state.
-    fn get_state(&self, timestamp: &Timestamp) -> Option<Vec<D>> {
-        match self.msgs.read().unwrap().get(timestamp) {
-            Some(value) => Some(value.clone()),
-            None => None,
-        }
-        //(*((*(self.msgs.read().unwrap())).get(timestamp).unwrap())).clone()
     }
 }
 
-/// An operator that joins two incoming streams of type D1 and D2 into a stream of type D3 using
-/// the function provided.
-///
-/// # Example
-/// The below example shows how to use a JoinOperator to sum two streams of incoming u32 messages,
-/// and return them as u64 messages.
-///
-/// ```
-/// # use erdos::dataflow::{stream::IngestStream, operators::JoinOperator, OperatorConfig};
-/// # use erdos::*;
-/// #
-/// # let mut left_u32_stream = IngestStream::new(0);
-/// # let mut right_u32_stream = IngestStream::new(0);
-/// #
-/// // Add the joining function as an argument to the operator via the OperatorConfig.
-/// let join_config = OperatorConfig::new()
-///     .name("JoinOperator")
-///     .arg(|left_data: Vec<u32>, right_data: Vec<u32>| -> u64 {
-///         (left_data.iter().sum::<u32>() + right_data.iter().sum::<u32>()) as u64
-///     });
-/// let output_stream = connect_1_write!(
-///     JoinOperator<u32, u32, u64>, join_config,left_u32_stream, right_u32_stream);
-/// ```
-pub struct JoinOperator<D1: Data, D2: Data, D3: Data> {
-    phantom_data: PhantomData<(D1, D2, D3)>,
-}
+impl<T, U> TwoInOneOut<(), T, U, (T, U)> for TimestampJoin<T, U>
+where
+    T: Data + for<'a> Deserialize<'a>,
+    U: Data + for<'a> Deserialize<'a>,
+{
+    fn on_left_data(&mut self, ctx: &mut TwoInOneOutContext<(), (T, U)>, data: &T) {
+        let (left_items, right_items) = self.items.entry(ctx.get_timestamp().clone()).or_default();
+        left_items.push(data.clone());
 
-impl<'a, D1: Data, D2: Data, D3: Data + Deserialize<'a>> JoinOperator<D1, D2, D3> {
-    /// Returns a new instance of the JoinOperator.
-    ///
-    /// # Arguments
-    /// * `config` - An instance of OperatorConfig that provides the closure used to join items of
-    /// type Vec<D1> and Vec<D2> to a value of type D3.
-    /// * `input_stream_left` - Represents the incoming stream of messages of type D1.
-    /// * `input_stream_right` - Represents the incoming stream of messages of type D2.
-    /// * `output_stream` - Represents an outgoing stream of messages of type D3.
-    pub fn new<F: 'static + Clone + Fn(Vec<D1>, Vec<D2>) -> D3>(
-        config: OperatorConfig<F>,
-        input_stream_left: ReadStream<D1>,
-        input_stream_right: ReadStream<D2>,
-        output_stream: WriteStream<D3>,
-    ) -> Self {
-        let name = match config.name {
-            Some(s) => s,
-            None => format!("JoinOperator {}", config.id),
-        };
-
-        // Package the state with the left stream and add a callback to the new stream.
-        let stateful_stream_left = input_stream_left.add_state(StreamState::<D1>::new());
-        stateful_stream_left.add_callback(Self::on_left_data_callback);
-
-        // Package the state with the right stream and add a callback to the new stream.
-        let stateful_stream_right = input_stream_right.add_state(StreamState::<D2>::new());
-        stateful_stream_right.add_callback(Self::on_right_data_callback);
-
-        let cb = config
-            .arg
-            .unwrap_or_else(|| panic!("{}: no join function provided", name));
-        stateful_stream_left
-            .add_read_stream(&stateful_stream_right)
-            .borrow_mut()
-            .add_write_stream(&output_stream)
-            .borrow_mut()
-            .add_watermark_callback(
-                move |t: &Timestamp,
-                      left_state: &StreamState<D1>,
-                      right_state: &StreamState<D2>,
-                      write_stream: &mut WriteStream<D3>| {
-                    Self::on_watermark_callback(t, left_state, right_state, write_stream, &cb)
-                },
-            );
-
-        Self {
-            phantom_data: PhantomData,
+        for right_item in right_items.iter().cloned() {
+            let msg = Message::new_message(ctx.get_timestamp().clone(), (data.clone(), right_item));
+            ctx.get_write_stream().send(msg).unwrap();
         }
     }
 
-    /// The function to be called when a message is received on the left input stream.
-    /// This callback adds the data received in the message to the state associated with the
-    /// stream.
-    fn on_left_data_callback(t: &Timestamp, msg: &D1, state: &mut StreamState<D1>) {
-        state.add_msg(t, msg.clone());
+    fn on_right_data(&mut self, ctx: &mut TwoInOneOutContext<(), (T, U)>, data: &U) {
+        let (left_items, right_items) = self.items.entry(ctx.get_timestamp().clone()).or_default();
+        right_items.push(data.clone());
+
+        for left_item in left_items.iter().cloned() {
+            let msg = Message::new_message(ctx.get_timestamp().clone(), (left_item, data.clone()));
+            ctx.get_write_stream().send(msg).unwrap();
+        }
     }
 
-    /// The function to be called when a message is received on the right input stream.
-    /// This callback adds the data received in the message to the state associated with the
-    /// stream.
-    fn on_right_data_callback(t: &Timestamp, msg: &D2, state: &mut StreamState<D2>) {
-        state.add_msg(t, msg.clone());
-    }
-
-    /// The function to be called when a watermark is received on both the left and the right
-    /// streams.
-    /// This callback uses the saved state from the two streams and joins them using the provided
-    /// closure.
-    fn on_watermark_callback<F: 'static + Clone + Fn(Vec<D1>, Vec<D2>) -> D3>(
-        t: &Timestamp,
-        left_state: &StreamState<D1>,
-        right_state: &StreamState<D2>,
-        write_stream: &mut WriteStream<D3>,
-        join_function: &F,
-    ) {
-        // Retrieve the state and run the given callback on it.
-        let left_state_t: Vec<D1> = left_state.get_state(t).unwrap();
-        let right_state_t: Vec<D2> = right_state.get_state(t).unwrap();
-        let result_t: D3 = join_function(left_state_t, right_state_t);
-
-        // Send the result on the write stream.
-        write_stream
-            .send(Message::new_message(t.clone(), result_t))
-            .expect("JoinOperator: error sending on write stream");
-
-        // Garbage collect all the data upto and including this timestamp.
-        left_state.clean_state(t);
-        right_state.clean_state(t);
-    }
-
-    pub fn connect(
-        _left_read_stream: &ReadStream<D1>,
-        _right_read_stream: &ReadStream<D2>,
-    ) -> WriteStream<D3> {
-        WriteStream::new()
+    fn on_watermark(&mut self, ctx: &mut TwoInOneOutContext<(), (T, U)>) {
+        // Garbage-collect stale items.
+        self.items.retain(|k, _| k > ctx.get_timestamp());
     }
 }
 
-impl<'a, D1: Data, D2: Data, D3: Data + Deserialize<'a>> Operator for JoinOperator<D1, D2, D3> {}
+/// TODO: document
+pub trait Join<T, U>
+where
+    T: Data + for<'a> Deserialize<'a>,
+    U: Data + for<'a> Deserialize<'a>,
+{
+    fn timestamp_join(&self, other: &dyn Stream<U>) -> OperatorStream<(T, U)>;
+}
+
+impl<S, T, U> Join<T, U> for S
+where
+    S: Stream<T>,
+    T: Data + for<'a> Deserialize<'a>,
+    U: Data + for<'a> Deserialize<'a>,
+{
+    fn timestamp_join(&self, other: &dyn Stream<U>) -> OperatorStream<(T, U)> {
+        let name = format!("TimestampJoinOp_{}_{}", self.name(), other.name());
+        crate::connect_two_in_one_out(
+            TimestampJoin::new,
+            || {},
+            OperatorConfig::new().name(&name),
+            self,
+            other,
+        )
+    }
+}

--- a/erdos/src/dataflow/operators/join.rs
+++ b/erdos/src/dataflow/operators/join.rs
@@ -11,10 +11,10 @@ use crate::dataflow::{
 
 /// Joins messages with matching timestamps from two different streams.
 ///
-/// The following table provides an example of how the [`TimestampJoinOperator`] processes data from two
-/// streams:
+/// The following table provides an example of how the [`TimestampJoinOperator`] processes data
+/// from two streams:
 ///
-/// | Timestamp | Left input | Right input | [`TimestampJoinOperator`] output                   |
+/// | Timestamp | Left input | Right input | [`TimestampJoinOperator`] output           |
 /// |-----------|------------|-------------|--------------------------------------------|
 /// | 1         | a <br> b   | 1 <br> 2    | (a, 1) <br> (a, 2) <br> (b, 1) <br> (b, 2) |
 /// | 2         | c          |             |                                            |
@@ -120,7 +120,8 @@ where
     T: Data + for<'a> Deserialize<'a>,
     U: Data + for<'a> Deserialize<'a>,
 {
-    /// Joins messages with matching timestamps from two different streams using a [`TimestampJoinOperator`].
+    /// Joins messages with matching timestamps from two different streams using a
+    /// [`TimestampJoinOperator`].
     ///
     /// # Example
     ///

--- a/erdos/src/dataflow/operators/join.rs
+++ b/erdos/src/dataflow/operators/join.rs
@@ -44,6 +44,7 @@ use crate::dataflow::{
 ///     &right_stream,
 /// );
 /// ```
+#[derive(Default)]
 pub struct TimestampJoin {}
 
 impl TimestampJoin {

--- a/erdos/src/dataflow/operators/mod.rs
+++ b/erdos/src/dataflow/operators/mod.rs
@@ -8,6 +8,7 @@ pub mod ros;
 // mod join_operator;
 mod concat;
 mod filter;
+mod join;
 mod map;
 mod split;
 

--- a/erdos/src/dataflow/operators/mod.rs
+++ b/erdos/src/dataflow/operators/mod.rs
@@ -16,5 +16,6 @@ mod split;
 // pub use crate::dataflow::operators::join_operator::JoinOperator;
 pub use concat::{Concat, ConcatOperator};
 pub use filter::{Filter, FilterOperator};
+pub use join::{Join, TimestampJoin};
 pub use map::{FlatMapOperator, Map};
 pub use split::{Split, SplitOperator};

--- a/erdos/src/dataflow/operators/mod.rs
+++ b/erdos/src/dataflow/operators/mod.rs
@@ -16,6 +16,6 @@ mod split;
 // pub use crate::dataflow::operators::join_operator::JoinOperator;
 pub use concat::{Concat, ConcatOperator};
 pub use filter::{Filter, FilterOperator};
-pub use join::{Join, TimestampJoin};
+pub use join::{Join, TimestampJoinOperator};
 pub use map::{FlatMapOperator, Map};
 pub use split::{Split, SplitOperator};

--- a/erdos/src/dataflow/state.rs
+++ b/erdos/src/dataflow/state.rs
@@ -57,7 +57,9 @@ where
         }
     }
 
-    /// Evicts all committed state until and including the provided timestamp.
+    /// [Experimental] Evicts all committed state until and including the provided timestamp.
+    ///
+    /// Used to bound state size in [`TimestampJoin`](crate::dataflow::operators::TimestampJoin).
     pub(crate) fn evict_until(&mut self, timestamp: &Timestamp) {
         let timestamp = std::cmp::min(timestamp, &self.last_committed_timestamp);
         self.state.retain(|k, _| k > timestamp);

--- a/erdos/src/dataflow/state.rs
+++ b/erdos/src/dataflow/state.rs
@@ -59,7 +59,7 @@ where
 
     /// [Experimental] Evicts all committed state until and including the provided timestamp.
     ///
-    /// Used to bound state size in [`TimestampJoin`](crate::dataflow::operators::TimestampJoin).
+    /// Used to bound state size in [`TimestampJoinOperator`](crate::dataflow::operators::TimestampJoinOperator).
     pub(crate) fn evict_until(&mut self, timestamp: &Timestamp) {
         let timestamp = std::cmp::min(timestamp, &self.last_committed_timestamp);
         self.state.retain(|k, _| k > timestamp);

--- a/erdos/src/dataflow/state.rs
+++ b/erdos/src/dataflow/state.rs
@@ -59,7 +59,8 @@ where
 
     /// [Experimental] Evicts all committed state until and including the provided timestamp.
     ///
-    /// Used to bound state size in [`TimestampJoinOperator`](crate::dataflow::operators::TimestampJoinOperator).
+    /// Used to bound state size in
+    /// [`TimestampJoinOperator`](crate::dataflow::operators::TimestampJoinOperator).
     pub(crate) fn evict_until(&mut self, timestamp: &Timestamp) {
         let timestamp = std::cmp::min(timestamp, &self.last_committed_timestamp);
         self.state.retain(|k, _| k > timestamp);

--- a/erdos/src/dataflow/state.rs
+++ b/erdos/src/dataflow/state.rs
@@ -56,6 +56,12 @@ where
             last_committed_timestamp: Timestamp::Bottom,
         }
     }
+
+    /// Evicts all committed state until and including the provided timestamp.
+    pub(crate) fn evict_until(&mut self, timestamp: &Timestamp) {
+        let timestamp = std::cmp::min(timestamp, &self.last_committed_timestamp);
+        self.state.retain(|k, _| k > timestamp);
+    }
 }
 
 impl<S> State for TimeVersionedState<S>


### PR DESCRIPTION
Introduces the `TimestampJoin`, which joins messages with matching timestamps from two different streams by performing a cartesian product. I've tested the operator locally, and it seems to work.

A few things I wasn't sure about that can hopefully be addressed in review:
1. Consistent naming: `TimestampJoin` seems more ergonomic, but this should be named `TimestampJoinOperator` to stay consistent with the other operators.
2. Example: I wasn't sure how to best add the timestamp join to the existing LINQ and full pipeline examples. These examples may also need to be revamped. 