### PR TITLE
Bump PyO3 version and fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt -- --check
       - name: Check Clippy linting
-        run: cargo clippy --all --tests --all-features -- -A clippy::needless_option_as_deref
+        run: cargo clippy --all --tests --all-features
         
   build-rust:
     name: "Rust Build"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 erdos = { path = "../erdos" }
-pyo3 = { version = "0.15.1", features = ["extension-module"] }
+pyo3 = { version = "0.16.0", features = ["extension-module"] }
 tracing = "0.1.29"
 
 [lib]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 erdos = { path = "../erdos" }
-pyo3 = { version = "0.16.0", features = ["extension-module"] }
+pyo3 = { version = "0.16.2", features = ["extension-module"] }
 tracing = "0.1.29"
 
 [lib]

--- a/python/src/py_message.rs
+++ b/python/src/py_message.rs
@@ -16,7 +16,6 @@ pub(crate) struct PyMessage {
 #[pymethods]
 impl PyMessage {
     #[new]
-    #[allow(clippy::needless_option_as_deref)]
     fn new(timestamp: Option<PyTimestamp>, data: Option<&PyBytes>) -> PyResult<Self> {
         if timestamp.is_none() && data.is_some() {
             return Err(exceptions::PyValueError::new_err(

--- a/python/src/py_timestamp.rs
+++ b/python/src/py_timestamp.rs
@@ -1,5 +1,5 @@
 use erdos::dataflow::Timestamp;
-use pyo3::{basic::CompareOp, exceptions, prelude::*, PyObjectProtocol};
+use pyo3::{basic::CompareOp, exceptions, prelude::*};
 
 /// A Python version of ERDOS' Timestamp.
 ///
@@ -45,10 +45,7 @@ impl PyTimestamp {
             _ => None,
         }
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for PyTimestamp {
     fn __str__(&self) -> PyResult<String> {
         match &self.timestamp {
             Timestamp::Top => Ok(String::from("Timestamp::Top")),


### PR DESCRIPTION
- Bumps pyo3 to 0.16.0 and moves dunder methods from `pyproto` implementation to `pymethods` (documented [here](https://pyo3.rs/master/class/protocols.html)).
- Remove `clippy::unneeded_option_deref` from CI build arguments.