### PR TITLE
[Python] Expose ERDOS' LINQ API in Python

### DIFF
--- a/python/erdos/streams.py
+++ b/python/erdos/streams.py
@@ -148,7 +148,7 @@ class Stream(ABC):
                 self.
 
         Returns:
-            A :py:class:`OperatorStream` that carries the joined results from the two
+            An :py:class:`OperatorStream` that carries the joined results from the two
             streams.
         """
 
@@ -170,7 +170,7 @@ class Stream(ABC):
                 stream(s) that needs to be merged with self.
 
         Returns
-            A :py:class:`OperatorStream` that carries the merged results from the
+            An :py:class:`OperatorStream` that carries the merged results from the
             streams.
         """
         if isinstance(other, Stream):

--- a/python/erdos/streams.py
+++ b/python/erdos/streams.py
@@ -139,6 +139,27 @@ class Stream(ABC):
         left_stream, right_stream = self._internal_stream._split(split_fn)
         return (OperatorStream(left_stream), OperatorStream(right_stream))
 
+    def timestamp_join(self, other: "Stream") -> "OperatorStream":
+        """Joins the data with matching timestamps from the two different streams.
+
+        Args:
+            other (:py:class:`Stream`): The other stream that needs to be joined with
+                self.
+
+        Returns:
+            A :py:class:`OperatorStream` that carries the joined results from the two
+            streams.
+        """
+
+        def join_fn(serialized_data_left: bytes, serialized_data_right: bytes) -> bytes:
+            left_data = pickle.loads(serialized_data_left)
+            right_data = pickle.loads(serialized_data_right)
+            return pickle.dumps((left_data, right_data))
+
+        return OperatorStream(
+            self._internal_stream._timestamp_join(other._internal_stream, join_fn)
+        )
+
 
 class ReadStream:
     """A :py:class:`ReadStream` allows an operator to read and do work on

--- a/python/erdos/streams.py
+++ b/python/erdos/streams.py
@@ -91,6 +91,9 @@ class Stream(ABC):
             function.
         """
 
+        # TODO (Sukrit): This method generates all the elements together and then sends
+        # the messages out to downstream operators. Instead, the method should `yield`
+        # individual elements so that they can be eagerly sent out.
         def flat_map_fn(serialized_data: bytes) -> Sequence[bytes]:
             mapped_values = function(pickle.loads(serialized_data))
             result = []

--- a/python/erdos/streams.py
+++ b/python/erdos/streams.py
@@ -160,6 +160,20 @@ class Stream(ABC):
             self._internal_stream._timestamp_join(other._internal_stream, join_fn)
         )
 
+    def concat(self, other: "Stream") -> "OperatorStream":
+        """Merges the data messages from the two streams into a single stream and
+        forwards a watermark when a minimum watermark on both the streams is achieved.
+
+        Args:
+            other (:py:class:`Stream`): The other stream that needs to be merged with
+                self.
+
+        Returns
+            A :py:class:`OperatorStream` that carries the merged results from the two
+            streams.
+        """
+        return OperatorStream(self._internal_stream._concat(other._internal_stream))
+
 
 class ReadStream:
     """A :py:class:`ReadStream` allows an operator to read and do work on

--- a/python/erdos/streams.py
+++ b/python/erdos/streams.py
@@ -198,7 +198,6 @@ class Stream(ABC):
                     else:
                         merged_streams.append(left_stream)
                 streams_to_be_merged = merged_streams
-            print(streams_to_be_merged[0].id)
             return streams_to_be_merged[0]
 
 

--- a/python/erdos/streams.py
+++ b/python/erdos/streams.py
@@ -77,6 +77,29 @@ class Stream(ABC):
 
         return OperatorStream(self._internal_stream._map(map_fn))
 
+    def flat_map(self, function: Callable[[Any], Sequence[Any]]) -> "OperatorStream":
+        """Applies the given function to each received value on the stream, and outputs
+        the sequence of received outputs as individual messages.
+
+        Args:
+            function (Callable[[Any], Sequence[Any]]): The function to be applied to
+                each message received on the input stream.
+
+        Returns:
+            An :py:class:`OperatorStream` that carries the results of the applied
+            function.
+        """
+
+        def flat_map_fn(serialized_data: bytes) -> bytes:
+            mapped_values = function(pickle.loads(serialized_data))
+            print(f"Got the values: {mapped_values}")
+            result = []
+            for element in mapped_values:
+                result.append(pickle.dumps(element))
+            return result
+
+        return OperatorStream(self._internal_stream._flat_map(flat_map_fn))
+
 
 class ReadStream:
     """A :py:class:`ReadStream` allows an operator to read and do work on

--- a/python/erdos/streams.py
+++ b/python/erdos/streams.py
@@ -122,8 +122,8 @@ class Stream(ABC):
         self, function: Callable[[Any], bool]
     ) -> Tuple["OperatorStream", "OperatorStream"]:
         """Applies the given function to each received value on the stream, and outputs
-        the value to either the left or the right stream depending on the returned
-        boolean value from the function.
+        the value to either the left or the right stream depending on if the returned
+        boolean value is `True` or `False` respectively.
 
         Args:
             function (Callable[[Any], bool]): The function to be applied to each

--- a/python/examples/linq.py
+++ b/python/examples/linq.py
@@ -37,7 +37,7 @@ class SinkOp(Sink):
 
 def main():
     source_stream = erdos.connect_source(SendOp, OperatorConfig())
-    map_stream = source_stream.map(lambda a: a * 2)
+    map_stream = source_stream.map(lambda x: x * 2)
     flat_map_stream = map_stream.flat_map(lambda a: list(range(a)))
     left_stream, right_stream = flat_map_stream.split(lambda a: a % 2 == 0)
     merged_stream = left_stream.concat(right_stream)

--- a/python/examples/linq_api.py
+++ b/python/examples/linq_api.py
@@ -35,7 +35,8 @@ class SinkOp(Sink):
 def main():
     source_stream = erdos.connect_source(SendOp, OperatorConfig())
     map_stream = source_stream.map(lambda a: a * 2)
-    erdos.connect_sink(SinkOp, OperatorConfig(), map_stream)
+    flat_map_stream = map_stream.flat_map(lambda a: list(range(a)))
+    erdos.connect_sink(SinkOp, OperatorConfig(), flat_map_stream)
     erdos.run()
 
 

--- a/python/examples/linq_api.py
+++ b/python/examples/linq_api.py
@@ -1,0 +1,43 @@
+import time
+from typing import Any
+
+import erdos
+from erdos.context import OneInOneOutContext
+from erdos.operator import OperatorConfig, Sink, Source
+from erdos.streams import WriteStream
+
+
+class SendOp(Source):
+    """A :py:class:`SendOp` is a :py:class:`Source` operator that generates a sequence
+    of inputs for the dataflow graph."""
+
+    def __init__(self):
+        print("Initializing SendOp")
+
+    def run(self, write_stream: WriteStream):
+        count = 0
+        while True:
+            msg = erdos.Message(erdos.Timestamp(coordinates=[count]), count)
+            print(f"SendOp sending {msg}")
+            write_stream.send(msg)
+            count += 1
+            time.sleep(1)
+
+
+class SinkOp(Sink):
+    """A :py:class:`SinkOp` is a :py:class:`Sink` operator that prints the received
+    output to the standard output."""
+
+    def on_data(self, context: OneInOneOutContext, data: Any):
+        print(f"SinkOp: Received data: {data} for timestamp: {context.timestamp}")
+
+
+def main():
+    source_stream = erdos.connect_source(SendOp, OperatorConfig())
+    map_stream = source_stream.map(lambda a: a * 2)
+    erdos.connect_sink(SinkOp, OperatorConfig(), map_stream)
+    erdos.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/linq_api.py
+++ b/python/examples/linq_api.py
@@ -40,8 +40,8 @@ def main():
     map_stream = source_stream.map(lambda a: a * 2)
     flat_map_stream = map_stream.flat_map(lambda a: list(range(a)))
     left_stream, right_stream = flat_map_stream.split(lambda a: a % 2 == 0)
-    joined_stream = left_stream.timestamp_join(right_stream)
-    erdos.connect_sink(SinkOp, OperatorConfig(name="JoinedOutput"), joined_stream)
+    merged_stream = left_stream.concat(right_stream)
+    erdos.connect_sink(SinkOp, OperatorConfig(name="MergedOutput"), merged_stream)
     erdos.run()
 
 

--- a/python/examples/linq_api.py
+++ b/python/examples/linq_api.py
@@ -40,8 +40,8 @@ def main():
     map_stream = source_stream.map(lambda a: a * 2)
     flat_map_stream = map_stream.flat_map(lambda a: list(range(a)))
     left_stream, right_stream = flat_map_stream.split(lambda a: a % 2 == 0)
-    erdos.connect_sink(SinkOp, OperatorConfig(name="LeftOutput"), left_stream)
-    erdos.connect_sink(SinkOp, OperatorConfig(name="RightOutput"), right_stream)
+    joined_stream = left_stream.timestamp_join(right_stream)
+    erdos.connect_sink(SinkOp, OperatorConfig(name="JoinedOutput"), joined_stream)
     erdos.run()
 
 

--- a/python/examples/linq_api.py
+++ b/python/examples/linq_api.py
@@ -36,7 +36,8 @@ def main():
     source_stream = erdos.connect_source(SendOp, OperatorConfig())
     map_stream = source_stream.map(lambda a: a * 2)
     flat_map_stream = map_stream.flat_map(lambda a: list(range(a)))
-    erdos.connect_sink(SinkOp, OperatorConfig(), flat_map_stream)
+    filtered_flat_map_stream = flat_map_stream.filter(lambda a: a % 2 == 0)
+    erdos.connect_sink(SinkOp, OperatorConfig(), filtered_flat_map_stream)
     erdos.run()
 
 

--- a/python/src/py_stream/mod.rs
+++ b/python/src/py_stream/mod.rs
@@ -53,6 +53,20 @@ impl PyStream {
         };
         PyOperatorStream::new(py, self.map(map_fn))
     }
+
+    fn _flat_map(&self, py: Python<'_>, function: PyObject) -> PyResult<Py<PyOperatorStream>> {
+        let flat_map_fn = move |data: &Vec<u8>| -> Vec<Vec<u8>> {
+            Python::with_gil(|py| {
+                let serialized_data = PyBytes::new(py, &data[..]);
+                function
+                    .call1(py, (serialized_data,))
+                    .unwrap()
+                    .extract(py)
+                    .unwrap()
+            })
+        };
+        PyOperatorStream::new(py, self.flat_map(flat_map_fn))
+    }
 }
 
 impl Stream<Vec<u8>> for PyStream {

--- a/python/src/py_stream/mod.rs
+++ b/python/src/py_stream/mod.rs
@@ -1,5 +1,5 @@
 use erdos::dataflow::{
-    operators::{Filter, Join, Map, Split},
+    operators::{Concat, Filter, Join, Map, Split},
     stream::{Stream, StreamId},
 };
 use pyo3::{prelude::*, types::PyBytes};
@@ -122,6 +122,10 @@ impl PyStream {
             })
         };
         PyOperatorStream::new(py, self.timestamp_join(other).map(map_fn))
+    }
+
+    fn _concat(&self, py: Python<'_>, other: &PyStream) -> PyResult<Py<PyOperatorStream>> {
+        PyOperatorStream::new(py, self.concat(other))
     }
 }
 


### PR DESCRIPTION
- Provides the `map`, `flat_map`, `filter`, `split`, `timestamp_join` and `concat` methods from Rust in Python.
- Enables developers to provide multiple streams to `concat` to ease the implementation of multi-in operators.

Potential TODOs:
- Syntactic sugar over the `split` method to enable developers to specify the type of outputs expected and automatically route them to different streams.
- Our Rust `timestamp_join` does not allow developers to specify a `join_function` similar to `apply` in Flink, which could prevent the addition of an extra `map` when doing `timestamp_join`s in Python.