### PR TITLE
[Bug] Fix deadlock in watermark callbacks

### DIFF
--- a/erdos/src/node/operator_executors/one_in_two_out_executor.rs
+++ b/erdos/src/node/operator_executors/one_in_two_out_executor.rs
@@ -501,7 +501,7 @@ where
                     mutable_operator.on_watermark(&mut OneInTwoOutContext::new(
                         time.clone(),
                         config,
-                        &mut state.lock().unwrap(),
+                        &mut mutable_state,
                         left_write_stream,
                         right_write_stream,
                     ));


### PR DESCRIPTION
Fix an issue when `flow_watermarks=False` does not execute watermark callbacks.