### PR TITLE
[Bug] Fix import error for PyNodeHandle

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -36,6 +36,7 @@ fn internal(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyWriteStream>()?;
     m.add_class::<PyIngestStream>()?;
     m.add_class::<PyExtractStream>()?;
+    m.add_class::<PyNodeHandle>()?;
 
     #[pyfn(m)]
     #[pyo3(name = "connect_source")]


### PR DESCRIPTION
Fixes an error when importing ERDOS in python:
```
In [1]: import erdos                                                                                                                                                                                       
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-a99ca392442f> in <module>
----> 1 import erdos

~/workspace/erdos/python/erdos/__init__.py in <module>
    369 # TODO (Sukrit) : Should this be called a GraphHandle?
    370 # What is the significance of the "Node" here?
--> 371 class NodeHandle:
    372     """A handle to the dataflow graph returned by the :py:func:`run_async`
    373     function.

~/workspace/erdos/python/erdos/__init__.py in NodeHandle()
    382     def __init__(
    383         self,
--> 384         py_node_handle: _internal.PyNodeHandle,
    385         processes: List[mp.Process],
    386     ) -> None:

AttributeError: module 'erdos.internal' has no attribute 'PyNodeHandle'
```